### PR TITLE
fix: gear sharing hardening pre-race-day (G1-G8)

### DIFF
--- a/routes/import_routes.py
+++ b/routes/import_routes.py
@@ -201,6 +201,9 @@ def confirm_pro_entries(tournament_id):
     updated  = 0
     errors   = []
     gear_parse_warnings = 0
+    # Competitors whose gear_sharing was just written and need to be mirrored
+    # to their partners after the main commit (gear audit fix G5 — 2026-04-07).
+    gear_synced_competitors: list = []
     now      = datetime.utcnow()
 
     existing_names = [c.name for c in ProCompetitor.query.filter_by(tournament_id=tournament_id).all()]
@@ -285,6 +288,8 @@ def confirm_pro_entries(tournament_id):
                 )
                 for gear_key, partner_name in parsed_gear.items():
                     competitor.set_gear_sharing(gear_key, partner_name)
+                if parsed_gear:
+                    gear_synced_competitors.append(competitor)
                 if warnings:
                     gear_parse_warnings += 1
 
@@ -337,6 +342,38 @@ def confirm_pro_entries(tournament_id):
     if gear_post['parsed']:
         db.session.commit()
         post_parsed_msg = f' Auto-parsed gear-sharing details for {gear_post["parsed"]} competitor(s).'
+
+    # Mirror gear-sharing entries onto each partner's row so the gear manager
+    # shows both sides without requiring a manual "Complete one-sided pairs"
+    # click (gear audit fix G5 — 2026-04-07).  Build the lookup once after the
+    # main commit so newly imported competitors are present in the tournament.
+    try:
+        from services.gear_sharing import (
+            normalize_person_name as _norm,
+        )
+        from services.gear_sharing import (
+            sync_all_gear_for_competitor,
+        )
+        all_pro_now = ProCompetitor.query.filter_by(
+            tournament_id=tournament_id, status='active'
+        ).all()
+        pro_lookup = {_norm(c.name): c for c in all_pro_now}
+        # Combine per-entry parses + post-import parses (lookup current rows by id).
+        gear_synced_ids = {c.id for c in gear_synced_competitors if getattr(c, 'id', None)}
+        synced_set = [c for c in all_pro_now if c.id in gear_synced_ids]
+        # Add any competitor whose gear_sharing was populated by parse_all_gear_details.
+        if gear_post['parsed']:
+            for c in all_pro_now:
+                if c.id not in gear_synced_ids and c.get_gear_sharing():
+                    synced_set.append(c)
+        for c in synced_set:
+            sync_all_gear_for_competitor(c, pro_lookup, old_gear={})
+        if synced_set:
+            db.session.commit()
+            flash('Gear sharing imported and mirrored for all matched partners.', 'info')
+    except Exception as exc:
+        db.session.rollback()
+        flash(f'Gear sharing mirror skipped: {exc}', 'warning')
 
     # Clean up temp file and session key
     try:

--- a/routes/registration.py
+++ b/routes/registration.py
@@ -2,6 +2,7 @@
 Registration routes for uploading and managing competitor entries.
 """
 import json
+import logging
 
 from flask import (
     Blueprint,
@@ -24,8 +25,59 @@ from services.gear_sharing import build_name_index, normalize_person_name, resol
 from services.upload_security import malware_scan, save_upload, validate_excel_upload
 
 registration_bp = Blueprint('registration', __name__)
+logger = logging.getLogger(__name__)
 
 ALLOWED_EXTENSIONS = {'xlsx', 'xls'}
+
+
+def _mirror_college_gear_set(comp, event_key: str, partner_name: str) -> None:
+    """Mirror a college gear-sharing set onto the partner's row.
+
+    Looks up the partner CollegeCompetitor by normalized name within the same
+    tournament.  If found, writes comp.name onto partner.gear_sharing[event_key].
+    Missing partners are logged at DEBUG and silently skipped — the one-sided
+    state is still detectable at heat-gen time (gear audit fix G4 — 2026-04-07).
+    Caller is responsible for db.session.commit().
+    """
+    partner_norm = normalize_person_name(partner_name)
+    if not partner_norm:
+        return
+    partner = CollegeCompetitor.query.filter_by(
+        tournament_id=comp.tournament_id, status='active'
+    ).all()
+    partner_comp = next((p for p in partner if normalize_person_name(p.name) == partner_norm), None)
+    if not partner_comp or partner_comp.id == comp.id:
+        logger.debug('college gear mirror: partner %r not on roster for tournament %s',
+                     partner_name, comp.tournament_id)
+        return
+    partner_gear = partner_comp.get_gear_sharing()
+    partner_gear[event_key] = comp.name
+    partner_comp.gear_sharing = json.dumps(partner_gear)
+
+
+def _mirror_college_gear_remove(comp, event_key: str, partner_name: str) -> None:
+    """Mirror a college gear-sharing remove onto the partner's row.
+
+    Removes comp.name from partner.gear_sharing[event_key] if present.
+    Missing partners are logged at DEBUG and silently skipped (gear audit
+    fix G4 — 2026-04-07).  Caller is responsible for db.session.commit().
+    """
+    partner_norm = normalize_person_name(partner_name)
+    if not partner_norm:
+        return
+    candidates = CollegeCompetitor.query.filter_by(
+        tournament_id=comp.tournament_id, status='active'
+    ).all()
+    partner_comp = next((p for p in candidates if normalize_person_name(p.name) == partner_norm), None)
+    if not partner_comp or partner_comp.id == comp.id:
+        logger.debug('college gear mirror remove: partner %r not on roster for tournament %s',
+                     partner_name, comp.tournament_id)
+        return
+    partner_gear = partner_comp.get_gear_sharing()
+    existing = str(partner_gear.get(event_key, '') or '').strip()
+    if normalize_person_name(existing) == normalize_person_name(comp.name):
+        del partner_gear[event_key]
+        partner_comp.gear_sharing = json.dumps(partner_gear)
 
 
 def allowed_file(filename):
@@ -441,6 +493,15 @@ def new_pro_competitor(tournament_id):
         # Non-blocking — any failure is logged and registration continues normally.
         from services.strathmark_sync import enroll_pro_competitor
         enroll_pro_competitor(competitor)
+
+        # Persist free-text gear sharing details from the form so the auto-parser
+        # has something to work with.  Resolution of partner names is deferred to
+        # the competitor detail page (G1 audit fix 2026-04-07).
+        gear_details_raw = (request.form.get('gear_sharing_details') or '').strip()
+        if gear_details_raw:
+            competitor.gear_sharing_details = gear_details_raw
+            db.session.commit()
+            flash('Gear sharing details saved — open competitor profile to resolve partners.', 'info')
 
         # Auto-parse gear-sharing details into structured map (non-blocking).
         try:
@@ -1104,6 +1165,9 @@ def college_gear_update(tournament_id):
     if partner_name:
         gear[event_key] = partner_name
         comp.gear_sharing = json.dumps(gear)
+        # Mirror onto partner's row so college gear sharing is bidirectional
+        # (gear audit fix G4 — 2026-04-07).
+        _mirror_college_gear_set(comp, event_key, partner_name)
         db.session.commit()
         invalidate_tournament_caches(tournament_id)
         log_action('college_gear_updated', 'college_competitor', competitor_id, {
@@ -1140,6 +1204,9 @@ def college_gear_update_ajax(tournament_id):
     gear = comp.get_gear_sharing()
     gear[event_key] = partner_name
     comp.gear_sharing = json.dumps(gear)
+    # Mirror onto partner's row so college gear sharing is bidirectional
+    # (gear audit fix G4 — 2026-04-07).
+    _mirror_college_gear_set(comp, event_key, partner_name)
     db.session.commit()
     invalidate_tournament_caches(tournament_id)
     log_action('college_gear_updated', 'college_competitor', competitor_id, {
@@ -1167,8 +1234,13 @@ def college_gear_remove(tournament_id):
     event_key = (request.form.get('event_key') or '').strip()
     gear = comp.get_gear_sharing()
     if event_key in gear:
+        old_partner = str(gear.get(event_key, '') or '').strip()
         del gear[event_key]
         comp.gear_sharing = json.dumps(gear)
+        # Mirror remove onto the partner's row so college gear sharing stays
+        # bidirectional (gear audit fix G4 — 2026-04-07).
+        if old_partner:
+            _mirror_college_gear_remove(comp, event_key, old_partner)
         db.session.commit()
         invalidate_tournament_caches(tournament_id)
         log_action('college_gear_removed', 'college_competitor', competitor_id, {'event_key': event_key})

--- a/routes/scheduling/heats.py
+++ b/routes/scheduling/heats.py
@@ -109,7 +109,7 @@ def generate_heats(tournament_id, event_id):
                                         event_id=event_id))
 
     # Import heat generation service
-    from services.heat_generator import generate_event_heats
+    from services.heat_generator import generate_event_heats, get_last_gear_violations
 
     try:
         num_heats = generate_event_heats(event)
@@ -118,6 +118,14 @@ def generate_heats(tournament_id, event_id):
             flash(f'{event.display_name} uses signups only (no heats).', 'success')
         else:
             flash(text.FLASH['heats_generated'].format(num_heats=num_heats, event_name=event.display_name), 'success')
+        # Surface any forced gear-sharing fallback placements (gear audit G2/G3).
+        violations = get_last_gear_violations(event.id)
+        if violations:
+            flash(
+                f'WARNING: {len(violations)} gear-sharing conflict(s) could not be avoided '
+                f'during heat generation. Review the gear manager before running the show.',
+                'warning'
+            )
     except Exception as e:
         db.session.rollback()
         flash(text.FLASH['heats_error'].format(error=str(e)), 'error')

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -470,6 +470,8 @@ def _score_ordering(ordered: list, heats_per_flight: int,
             event_blocks_seen[block_key] = True
 
     # Gear adjacency penalty across the full ordering.
+    # Raised from -30 per gear audit 2026-04-07 — must outweigh spacing bonus
+    # so back-to-back gear-share heats are an exception, not normal output.
     if gear_conflict_pairs:
         for pos in range(1, len(ordered)):
             prev_comps = ordered[pos - 1]['competitors']
@@ -479,7 +481,7 @@ def _score_ordering(ordered: list, heats_per_flight: int,
                 if partner_ids:
                     overlap = partner_ids & prev_comps
                     if overlap:
-                        total -= 30 * len(overlap)
+                        total -= 200 * len(overlap)
 
     return total
 
@@ -578,14 +580,16 @@ def _calculate_heat_score(competitors: set, competitor_last_heat: dict,
 
     # Gear adjacency penalty: penalize placing a heat immediately after one that
     # contains a gear-sharing partner.  This gives equipment time to be moved
-    # between stands.  Soft penalty (-30 per conflict) — does not hard-block.
+    # between stands.  Penalty (-200 per conflict) — does not hard-block, but
+    # is large enough to outweigh spacing bonuses.  Raised from -30 per gear
+    # audit 2026-04-07 — must outweigh spacing bonus.
     if gear_conflict_pairs and previous_heat_comps:
         for comp_id in competitors:
             partner_ids = gear_conflict_pairs.get(comp_id)
             if partner_ids:
                 overlap = partner_ids & previous_heat_comps
                 if overlap:
-                    score -= 30 * len(overlap)
+                    score -= 200 * len(overlap)
 
     return score
 

--- a/services/gear_sharing.py
+++ b/services/gear_sharing.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 import difflib
 import json
+import logging
 import re
 from typing import Iterable
+
+logger = logging.getLogger(__name__)
 
 _CATEGORY_KEYS = {'category:crosscut', 'category:chainsaw', 'category:springboard'}
 
@@ -114,6 +117,12 @@ def resolve_partner_name(raw_name: str, name_index: dict[str, str], cutoff: floa
 
     direct = name_index.get(normalize_person_name(candidate))
     if direct:
+        # Auditable log line so a judge reviewing import logs can spot a wrong
+        # match before race day (gear audit fix G8 — 2026-04-07).
+        logger.info(
+            "Gear partner resolved: %r -> %r (method: exact, score: 1.00)",
+            candidate, direct,
+        )
         return direct
 
     keys = list(name_index.keys())
@@ -126,7 +135,13 @@ def resolve_partner_name(raw_name: str, name_index: dict[str, str], cutoff: floa
 
     close = difflib.get_close_matches(wanted, keys, n=1, cutoff=cutoff)
     if close:
-        return name_index[close[0]]
+        score = difflib.SequenceMatcher(None, wanted, close[0]).ratio()
+        resolved = name_index[close[0]]
+        logger.info(
+            "Gear partner resolved: %r -> %r (method: fuzzy, score: %.2f)",
+            candidate, resolved, score,
+        )
+        return resolved
 
     # Last-name-only fallback: "Smith" → matches "John Smith" when unambiguous.
     candidate_tokens = candidate.strip().split()
@@ -135,7 +150,12 @@ def resolve_partner_name(raw_name: str, name_index: dict[str, str], cutoff: floa
         if len(last_norm) >= 3:
             last_matches = [k for k in keys if k.endswith(last_norm)]
             if len(last_matches) == 1:
-                return name_index[last_matches[0]]
+                resolved = name_index[last_matches[0]]
+                logger.info(
+                    "Gear partner resolved: %r -> %r (method: last_name_only, score: 1.00)",
+                    candidate, resolved,
+                )
+                return resolved
 
     # Initials fallback: "J. Smith" or "J Smith" → matches "John Smith" when unambiguous.
     if len(candidate_tokens) == 2:
@@ -147,7 +167,12 @@ def resolve_partner_name(raw_name: str, name_index: dict[str, str], cutoff: floa
                 if k.startswith(first_initial) and k.endswith(last_norm)
             ]
             if len(initial_matches) == 1:
-                return name_index[initial_matches[0]]
+                resolved = name_index[initial_matches[0]]
+                logger.info(
+                    "Gear partner resolved: %r -> %r (method: initial_last, score: 1.00)",
+                    candidate, resolved,
+                )
+                return resolved
 
     return candidate
 
@@ -748,6 +773,8 @@ def build_gear_conflict_pairs(tournament) -> dict[int, set[int]]:
         Dict mapping each pro competitor ID to the set of all competitor IDs
         they share gear with.
     """
+    import config
+    from models import Event
     from models.competitor import ProCompetitor
 
     pro_comps = ProCompetitor.query.filter_by(
@@ -777,6 +804,55 @@ def build_gear_conflict_pairs(tournament) -> dict[int, set[int]]:
             if partner_comp and partner_comp.id != comp.id:
                 conflicts.setdefault(comp.id, set()).add(partner_comp.id)
                 conflicts.setdefault(partner_comp.id, set()).add(comp.id)
+
+    # Cascade pass — ensures pairs that share gear in any cascade family
+    # (e.g. the chopping family: springboard / underhand / standing block)
+    # are paired in the conflict dict regardless of which event they declared
+    # the share on.  The dict is event-blind, so the existing pass already
+    # mirrors most cases; this pass uses the canonical config.GEAR_FAMILIES
+    # taxonomy as the source of truth and catches any pair that the literal
+    # name-match loop above missed (e.g. a comp with one declaration only
+    # whose declared key resolves to a cascade-family event id)
+    # — gear audit fix G6 — 2026-04-07.
+    cascade_stand_types: set[str] = set()
+    for fam in config.GEAR_FAMILIES.values():
+        if fam.get('cascade'):
+            cascade_stand_types.update(fam.get('stand_types', set()))
+
+    if cascade_stand_types:
+        try:
+            tournament_events = Event.query.filter_by(tournament_id=tournament.id).all()
+        except Exception:
+            tournament_events = []
+        cascade_event_ids: set[str] = {
+            str(ev.id) for ev in tournament_events
+            if str(getattr(ev, 'stand_type', '') or '').strip().lower() in cascade_stand_types
+        }
+
+        for comp in pro_comps:
+            gear = comp.get_gear_sharing()
+            if not isinstance(gear, dict):
+                continue
+            declares_cascade = False
+            for key in gear.keys():
+                key_str = str(key or '').strip()
+                if key_str in cascade_event_ids:
+                    declares_cascade = True
+                    break
+                # Category keys for cascade families also count.
+                if key_str in {'category:crosscut', 'category:springboard'}:
+                    declares_cascade = True
+                    break
+            if not declares_cascade:
+                continue
+            for raw_partner in gear.values():
+                pt = str(raw_partner or '').strip()
+                if not pt or pt.startswith('group:'):
+                    continue
+                partner_comp = pro_by_norm.get(normalize_person_name(pt))
+                if partner_comp and partner_comp.id != comp.id:
+                    conflicts.setdefault(comp.id, set()).add(partner_comp.id)
+                    conflicts.setdefault(partner_comp.id, set()).add(comp.id)
 
     return conflicts
 

--- a/services/heat_generator.py
+++ b/services/heat_generator.py
@@ -16,6 +16,17 @@ from services.gear_sharing import competitors_share_gear_for_event
 logger = logging.getLogger(__name__)
 # LIST_ONLY_EVENT_NAMES and _rank_category_for_event imported from config above.
 
+# Per-event gear-sharing violation log populated by the snake-draft fallbacks.
+# Routes call get_last_gear_violations(event.id) after generate_event_heats() to
+# surface a warning flash to the judge (gear audit fix G2/G3 — 2026-04-07).
+_last_gear_violations: dict[int, list[dict]] = {}
+
+
+def get_last_gear_violations(event_id: int) -> list[dict]:
+    """Return the gear-sharing violations recorded by the most recent
+    generate_event_heats(event) call for this event_id, or an empty list."""
+    return list(_last_gear_violations.get(event_id, []))
+
 
 def _sort_by_ability(competitors: list, event: Event) -> list:
     """
@@ -100,13 +111,22 @@ def generate_event_heats(event: Event) -> int:
     # Clear existing heats
     _delete_event_heats(event.id)
 
+    # Per-event gear-sharing fallback violations recorded by the snake-draft
+    # helpers.  Entries are dicts with keys: comp_id, comp_name, heat_index.
+    # Cleared on every generate_event_heats() call (gear audit fix G2/G3).
+    gear_violations: list[dict] = []
+    _last_gear_violations.pop(event.id, None)
+
     # Apply special constraints
     if event.stand_type == 'springboard':
-        heats = _generate_springboard_heats(competitors, num_heats, max_per_heat, stand_config, event=event)
+        heats = _generate_springboard_heats(competitors, num_heats, max_per_heat, stand_config, event=event,
+                                            gear_violations=gear_violations)
     elif event.stand_type in ['saw_hand']:
-        heats = _generate_saw_heats(competitors, num_heats, max_per_heat, stand_config, event=event)
+        heats = _generate_saw_heats(competitors, num_heats, max_per_heat, stand_config, event=event,
+                                    gear_violations=gear_violations)
     else:
-        heats = _generate_standard_heats(competitors, num_heats, max_per_heat, event=event)
+        heats = _generate_standard_heats(competitors, num_heats, max_per_heat, event=event,
+                                         gear_violations=gear_violations)
 
     # Use actual heat count returned by the generator (saw events recalculate internally).
     actual_heat_count = len(heats)
@@ -166,6 +186,31 @@ def generate_event_heats(event: Event) -> int:
     comp_type = event.event_type  # 'pro' or 'college'
     for heat in created_heats:
         heat.sync_assignments(comp_type)
+
+    # Promote any fallback gear-sharing violations recorded by the snake-draft
+    # helpers into the module-level lookup so the route layer can surface a
+    # WARNING flash to the judge (gear audit fix G2/G3 — 2026-04-07).  Each
+    # violation's heat_index is mapped to the freshly created Heat row's id.
+    if gear_violations:
+        resolved: list[dict] = []
+        for v in gear_violations:
+            idx = v.get('heat_index')
+            heat_id = None
+            heat_number = None
+            if isinstance(idx, int) and 0 <= idx < len(created_heats):
+                heat_id = created_heats[idx].id
+                heat_number = created_heats[idx].heat_number
+            resolved.append({
+                'comp_id': v.get('comp_id'),
+                'comp_name': v.get('comp_name', ''),
+                'heat_id': heat_id,
+                'heat_number': heat_number,
+            })
+            logger.warning(
+                'GEAR CONFLICT FORCED: %s placed in heat %s — manual review required',
+                v.get('comp_name', ''), heat_id,
+            )
+        _last_gear_violations[event.id] = resolved
 
     # Flush but do NOT commit — the calling route owns the transaction boundary and
     # will commit (or roll back) after all scheduling actions are complete.  This
@@ -239,7 +284,8 @@ def _get_event_competitors(event: Event) -> list:
     return competitors
 
 
-def _generate_standard_heats(competitors: list, num_heats: int, max_per_heat: int, event: Event = None) -> list:
+def _generate_standard_heats(competitors: list, num_heats: int, max_per_heat: int, event: Event = None,
+                              gear_violations: list | None = None) -> list:
     """
     Generate heats using snake draft distribution.
 
@@ -271,9 +317,19 @@ def _generate_standard_heats(competitors: list, num_heats: int, max_per_heat: in
             heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
 
         # Fallback: place despite conflict if every heat conflicts/full.
+        # Record any gear-sharing conflict introduced here so the caller can
+        # surface a warning to the judge (gear audit fix G2 — 2026-04-07).
         if not placed:
             for _ in range(num_heats):
                 if (len(heats[heat_idx]) + len(unit)) <= max_per_heat:
+                    if gear_violations is not None:
+                        for comp in unit:
+                            if _has_gear_sharing_conflict(comp, heats[heat_idx], event):
+                                gear_violations.append({
+                                    'comp_id': comp.get('id'),
+                                    'comp_name': comp.get('name', ''),
+                                    'heat_index': heat_idx,
+                                })
                     heats[heat_idx].extend(unit)
                     placed = True
                     break
@@ -377,7 +433,8 @@ def _get_partner_name_for_event(competitor, event: Event) -> str:
 
 
 def _generate_springboard_heats(competitors: list, num_heats: int,
-                                 max_per_heat: int, stand_config: dict, event: Event = None) -> list:
+                                 max_per_heat: int, stand_config: dict, event: Event = None,
+                                 gear_violations: list | None = None) -> list:
     """
     Generate springboard heats with left-handed cutter grouping.
 
@@ -438,20 +495,47 @@ def _generate_springboard_heats(competitors: list, num_heats: int,
     heat_idx = 0
     direction = 1
     for comp in remaining:
-        attempts = 0
-        while attempts < num_heats and len(heats[heat_idx]) >= max_per_heat:
+        # First pass: find a heat with capacity AND no gear-sharing conflict.
+        # Springboards are the highest-stakes shared-equipment event, so this
+        # check matches the standard heat generator (gear audit fix G3).
+        placed = False
+        for _ in range(num_heats):
+            if (
+                len(heats[heat_idx]) < max_per_heat and
+                not _has_gear_sharing_conflict(comp, heats[heat_idx], event)
+            ):
+                heats[heat_idx].append(comp)
+                placed = True
+                break
             heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-            attempts += 1
-        if attempts >= num_heats:
+
+        # Fallback: place despite conflict if every heat conflicts/full.
+        # Record any gear-sharing conflict introduced here so the caller can
+        # surface a warning to the judge (gear audit fix G3 — 2026-04-07).
+        if not placed:
+            for _ in range(num_heats):
+                if len(heats[heat_idx]) < max_per_heat:
+                    if gear_violations is not None and _has_gear_sharing_conflict(comp, heats[heat_idx], event):
+                        gear_violations.append({
+                            'comp_id': comp.get('id'),
+                            'comp_name': comp.get('name', ''),
+                            'heat_index': heat_idx,
+                        })
+                    heats[heat_idx].append(comp)
+                    placed = True
+                    break
+                heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
+
+        if not placed:
             break
-        heats[heat_idx].append(comp)
         heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
 
     return heats
 
 
 def _generate_saw_heats(competitors: list, num_heats: int,
-                        max_per_heat: int, stand_config: dict, event: Event = None) -> list:
+                        max_per_heat: int, stand_config: dict, event: Event = None,
+                        gear_violations: list | None = None) -> list:
     """
     Generate saw heats respecting stand group constraints.
 
@@ -461,7 +545,8 @@ def _generate_saw_heats(competitors: list, num_heats: int,
     actual_max = min(max_per_heat, 4)  # Saw groups are 4 each
     num_heats = math.ceil(len(competitors) / actual_max)
 
-    return _generate_standard_heats(competitors, num_heats, actual_max, event=event)
+    return _generate_standard_heats(competitors, num_heats, actual_max, event=event,
+                                    gear_violations=gear_violations)
 
 
 def _advance_snake_index(heat_idx: int, direction: int, num_heats: int):

--- a/templates/pro/new_competitor.html
+++ b/templates/pro/new_competitor.html
@@ -107,6 +107,17 @@
                             </div>
                         </div>
 
+                        <!-- Gear sharing free-text — paired with the G1 route fix
+                             so registrars can capture sharing notes at signup
+                             time.  Partner names are resolved on the competitor
+                             profile page after registration.  Gear audit G1. -->
+                        <div class="mb-3">
+                            <label for="gear_sharing_details" class="form-label">Gear Sharing Details</label>
+                            <textarea class="form-control" id="gear_sharing_details" name="gear_sharing_details" rows="2"
+                                      placeholder="e.g. sharing springboard with John Smith"></textarea>
+                            <small class="text-muted">Free-text notes about equipment sharing partners. Resolved on the competitor profile page after registration.</small>
+                        </div>
+
                         <hr>
 
                         <div class="d-grid gap-2">

--- a/tests/test_flight_builder_25_pros.py
+++ b/tests/test_flight_builder_25_pros.py
@@ -403,19 +403,38 @@ class TestFlightBuilderEventVariety:
             tournament_id=tournament.id
         ).order_by(Flight.flight_number).all()
 
+        # Gear-share pressure (raised to -200 per gear audit 2026-04-07) is now
+        # strong enough that the optimizer occasionally clusters one flight to
+        # avoid splitting a gear pair across adjacent heats.  Allow at most one
+        # such monolithic flight per build; the rest must still show variety.
+        monolithic = 0
+        multi_heat_flights = 0
         for flight in flights:
             heats = Heat.query.filter_by(flight_id=flight.id).all()
             if len(heats) <= 1:
                 continue  # Single-heat flights are trivially fine.
 
+            multi_heat_flights += 1
             event_ids = set(h.event_id for h in heats)
-            assert len(event_ids) > 1, (
-                f"Flight {flight.flight_number} has {len(heats)} heats "
-                f"but only {len(event_ids)} distinct event(s)"
-            )
+            if len(event_ids) <= 1:
+                monolithic += 1
+
+        # Allow up to ~20% of multi-heat flights to be monolithic under gear
+        # pressure, but never more than 2 per build.
+        allowed = max(1, multi_heat_flights // 5)
+        assert monolithic <= min(allowed, 2), (
+            f"{monolithic} of {multi_heat_flights} multi-heat flights are monolithic; "
+            f"allowed up to {min(allowed, 2)} under gear pressure"
+        )
 
     def test_no_single_event_dominates_flight(self, db_session):
-        """No single event should take up more than half the heats in a flight."""
+        """No single event should take up more than half the heats in a flight.
+
+        Gear-share pressure (raised to -200 per gear audit 2026-04-07) is now
+        strong enough that one flight per build may end up dominated by a
+        single event when gear pairs would otherwise straddle adjacent heats.
+        Allow at most one such flight; the rest must respect the threshold.
+        """
         from collections import Counter
 
         from models.heat import Flight, Heat
@@ -428,6 +447,7 @@ class TestFlightBuilderEventVariety:
             tournament_id=tournament.id
         ).order_by(Flight.flight_number).all()
 
+        violations: list[str] = []
         for flight in flights:
             heats = Heat.query.filter_by(flight_id=flight.id).all()
             if len(heats) <= 2:
@@ -437,10 +457,17 @@ class TestFlightBuilderEventVariety:
             most_common_count = event_counts.most_common(1)[0][1]
             # Allow up to 60% of heats from one event (tolerance for small flights).
             threshold = max(2, int(len(heats) * 0.6) + 1)
-            assert most_common_count <= threshold, (
-                f"Flight {flight.flight_number}: one event has {most_common_count} "
-                f"of {len(heats)} heats (threshold={threshold})"
-            )
+            if most_common_count > threshold:
+                violations.append(
+                    f"Flight {flight.flight_number}: one event has {most_common_count} "
+                    f"of {len(heats)} heats (threshold={threshold})"
+                )
+
+        # Allow at most one gear-pressure-induced dominated flight per build.
+        assert len(violations) <= 1, (
+            f"{len(violations)} flights exceed dominance threshold under gear pressure: "
+            + '; '.join(violations)
+        )
 
     def test_calculate_heat_score_springboard_opener_bonus(self):
         """Springboard at flight start (position 0) should get a large bonus."""

--- a/tests/test_routes_post.py
+++ b/tests/test_routes_post.py
@@ -371,3 +371,83 @@ class TestUndoHeatResults:
             follow_redirects=True,
         )
         _ok(resp)
+
+
+# ---------------------------------------------------------------------------
+# Gear sharing regression tests (gear audit fixes G1 + G4 — 2026-04-07)
+# These guard against the silent-drop bug where new_pro_competitor and
+# college_gear_update wrote nothing for the gear-sharing fields and no test
+# caught it because the route still returned 302.
+# ---------------------------------------------------------------------------
+
+class TestGearSharingFormPersistence:
+    """G1 — new_pro_competitor must persist gear_sharing_details from the form."""
+
+    def test_new_pro_competitor_saves_gear_details(self, auth_client, tid, db_session):
+        from models.competitor import ProCompetitor
+        resp = auth_client.post(f'/registration/{tid}/pro/new', data={
+            'name': 'G1 Regression Pro',
+            'gender': 'M',
+            'address': '1 Test Way',
+            'phone': '5550001111',
+            'email': 'g1-regression@example.com',
+            'gear_sharing_details': 'sharing springboard with Test Partner',
+        }, follow_redirects=True)
+        _ok(resp)
+        comp = ProCompetitor.query.filter_by(
+            tournament_id=tid, name='G1 Regression Pro'
+        ).first()
+        assert comp is not None, 'competitor was not created'
+        assert comp.gear_sharing_details == 'sharing springboard with Test Partner', (
+            'gear_sharing_details was silently dropped from the new pro form '
+            '(gear audit G1)'
+        )
+
+
+class TestCollegeGearMirror:
+    """G4 — college_gear_update must mirror onto the partner's row."""
+
+    def _make_team(self, session, tid, code='UM-A', school='UM Test'):
+        from models.team import Team
+        t = Team(tournament_id=tid, team_code=code, school_name=school,
+                 school_abbreviation='UM', total_points=0, status='active')
+        session.add(t)
+        session.flush()
+        return t
+
+    def _make_college(self, session, tid, team_id, name, gender='M'):
+        from models.competitor import CollegeCompetitor
+        c = CollegeCompetitor(
+            tournament_id=tid, team_id=team_id, name=name, gender=gender,
+            events_entered=json.dumps([]), status='active',
+            individual_points=0, gear_sharing='{}',
+        )
+        session.add(c)
+        session.flush()
+        return c
+
+    def test_college_gear_update_mirrors_to_partner(self, auth_client, tid, db_session):
+        from models.competitor import CollegeCompetitor
+        team = self._make_team(db_session, tid)
+        comp_a = self._make_college(db_session, tid, team.id, 'G4 Comp A')
+        comp_b = self._make_college(db_session, tid, team.id, 'G4 Comp B')
+        db_session.commit()
+
+        resp = auth_client.post(
+            f'/registration/{tid}/college/gear-sharing/update',
+            data={
+                'competitor_id': str(comp_a.id),
+                'event_key': 'springboard',
+                'partner_name': 'G4 Comp B',
+            },
+            follow_redirects=True,
+        )
+        _ok(resp)
+
+        # Re-fetch to bypass any session caching.
+        a = CollegeCompetitor.query.get(comp_a.id)
+        b = CollegeCompetitor.query.get(comp_b.id)
+        assert a.get_gear_sharing().get('springboard') == 'G4 Comp B'
+        assert b.get_gear_sharing().get('springboard') == 'G4 Comp A', (
+            'college gear update did not mirror onto partner row (gear audit G4)'
+        )


### PR DESCRIPTION
## Summary

Eight audit-driven fixes (G1–G8) for the gear sharing system plus one
completeness gap caught by /cso, all tied to data integrity before the
2026 Missoula Pro Am race day on Saturday April 11.

The original audit ran on this branch's base (PR #7) and identified 9
gaps. G9 was structural model debt and is deferred. The other 8 are
fixed. /cso surfaced the missing form field for G1 and that fix is in
this same PR.

## Files changed (9)

- `routes/registration.py` — G1 + G4
- `routes/import_routes.py` — G5
- `routes/scheduling/heats.py` — G2/G3 surfacing
- `services/heat_generator.py` — G2/G3
- `services/gear_sharing.py` — G6 + G8
- `services/flight_builder.py` — G7
- `templates/pro/new_competitor.html` — G1 form field
- `tests/test_routes_post.py` — G1 + G4 regression tests
- `tests/test_flight_builder_25_pros.py` — variety assertions relaxed for new gear pressure regime

## Test plan

- [x] Full pytest suite — 2114 passed, 4 skipped, 1 xpassed
- [x] Ruff lint — clean
- [x] /cso security audit — 1 finding (missing form field), fixed in this PR, no security findings
- [ ] /qa walkthrough on local Flask instance (NOT prod) — 7-step checklist from original brief
- [ ] Manual gear manager smoke check on race-day staging instance after merge

## Risk

LOW for the code changes themselves. MEDIUM for race-day timing — this
ships two days before the show. The full test suite green and /cso
clean partially mitigate, and G9 was deferred specifically to avoid
last-minute model surgery.

## Coordination

This PR was developed concurrently with PR #7 in two separate Claude
Code sessions coordinated via instance/coordination.md (gitignored).
PR #7 merged first; this branch was rebased onto fresh main (PR #7's
squash commit 1042ee8) before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)