### PR TITLE
fix(scoring): Phase 3 — engine rewrite for split-tie + SUM rebuild + Decimal

### DIFF
--- a/services/scoring_engine.py
+++ b/services/scoring_engine.py
@@ -25,7 +25,10 @@ import csv
 import io
 import logging
 import statistics
+from decimal import Decimal
 from typing import Optional
+
+from sqlalchemy import func
 
 import config
 from database import db
@@ -36,6 +39,102 @@ from models.team import Team
 from services.audit import log_action
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 (V2.8.0) — split-tie points table and helper.
+# ---------------------------------------------------------------------------
+#
+# AWFC tie-split rule (per ProAM requirements + PLAN_REVIEW.md v3):
+#
+#   "Ties: split the combined points equally.
+#    Two tied for 5th: each gets (2 + 1) / 2 = 1.5 points.
+#    Three tied for 1st: each gets (10 + 7 + 5) / 3 = 7.33... points."
+#
+# This means tied competitors collectively occupy the positions starting at
+# their shared rank, the points for those positions are summed, and the sum
+# is divided evenly across all tied competitors.
+#
+# All math is done in Decimal so the final value is exact and can be stored
+# in the Numeric(6,2) points_awarded column from Phase 1B.  Use Decimal('0.01')
+# as the quantize step (two decimal places) — matches the column precision.
+
+PLACEMENT_POINTS_DECIMAL = [
+    Decimal('10'),  # 1st
+    Decimal('7'),   # 2nd
+    Decimal('5'),   # 3rd
+    Decimal('3'),   # 4th
+    Decimal('2'),   # 5th
+    Decimal('1'),   # 6th
+]
+_QUANTIZE_2DP = Decimal('0.01')
+
+
+def split_tie_points(start_rank: int, count: int) -> Decimal:
+    """Return the per-competitor points for `count` competitors tied at `start_rank`.
+
+    Examples:
+      split_tie_points(1, 1) -> Decimal('10')      (solo 1st place)
+      split_tie_points(1, 2) -> Decimal('8.5')     (two tied for 1st: (10+7)/2)
+      split_tie_points(1, 3) -> Decimal('7.33')    (three tied for 1st: (10+7+5)/3)
+      split_tie_points(2, 2) -> Decimal('6')       (two tied for 2nd: (7+5)/2)
+      split_tie_points(5, 2) -> Decimal('1.5')     (two tied for 5th: (2+1)/2)
+      split_tie_points(7, 1) -> Decimal('0')       (7th and beyond = 0)
+      split_tie_points(6, 3) -> Decimal('0.33')    (6th + two off-table: (1+0+0)/3)
+
+    Positions beyond 6th place receive 0 points.  When some tied competitors
+    spill past the table boundary, the points sum still divides over the full
+    `count` of tied competitors — that's the spec, every tied competitor gets
+    the same share, even those who would have placed off the table individually.
+    """
+    if count <= 0:
+        return Decimal('0')
+    end_rank = start_rank + count  # exclusive
+    total = Decimal('0')
+    for rank in range(start_rank, end_rank):
+        idx = rank - 1  # 0-indexed table lookup
+        if 0 <= idx < len(PLACEMENT_POINTS_DECIMAL):
+            total += PLACEMENT_POINTS_DECIMAL[idx]
+        # else: rank is off the points table, contributes 0
+    return (total / Decimal(count)).quantize(_QUANTIZE_2DP)
+
+
+def _rebuild_individual_points(competitor_ids: list[int]) -> None:
+    """Rebuild CollegeCompetitor.individual_points from EventResult.points_awarded.
+
+    For each competitor in `competitor_ids`, sets individual_points to the SUM
+    of points_awarded across ALL their finalized event results.  This is the
+    "rebuild from source of truth" approach mandated by PLAN_REVIEW.md A6 and
+    C2 — replaces the old strip-then-add pattern that diverged from the
+    record_throwoff_result code path.
+
+    Uses one batched GROUP BY query so it's O(1) round-trips instead of N.
+    """
+    if not competitor_ids:
+        return
+    # Compute the SUM for every requested competitor in a single query.
+    sums = dict(
+        db.session.query(
+            EventResult.competitor_id,
+            func.coalesce(func.sum(EventResult.points_awarded), 0),
+        )
+        .filter(
+            EventResult.competitor_id.in_(competitor_ids),
+            EventResult.competitor_type == 'college',
+        )
+        .group_by(EventResult.competitor_id)
+        .all()
+    )
+    # Apply to the in-session competitor objects so the rebuild participates
+    # in the current transaction.
+    rows = (
+        CollegeCompetitor.query
+        .filter(CollegeCompetitor.id.in_(competitor_ids))
+        .all()
+    )
+    for comp in rows:
+        new_total = sums.get(comp.id, 0)
+        comp.individual_points = Decimal(new_total) if not isinstance(new_total, Decimal) else new_total
 
 
 # ---------------------------------------------------------------------------
@@ -125,8 +224,14 @@ def calculate_positions(event: Event) -> None:
     """
     Calculate final positions and award points/payouts for event.
 
-    This is idempotent — previously awarded points/payouts are stripped before
-    recalculating so calling it twice yields the same result.
+    Phase 3 (V2.8.0) rewrite:
+      * College ties are split per the AWFC rule (see split_tie_points).
+      * College individual_points and team total_points are REBUILT from
+        SUM(points_awarded) after the per-result writes, replacing the old
+        strip-then-add pattern.  This makes the function fully idempotent and
+        keeps record_throwoff_result() consistent with calculate_positions().
+      * Pro events keep the same payout_amount accumulation logic — total_earnings
+        for pro competitors still uses Float, not Decimal.
 
     Raises nothing; caller should catch StaleDataError/IntegrityError and rollback.
     """
@@ -135,16 +240,17 @@ def calculate_positions(event: Event) -> None:
     all_results = event.results.all()
 
     # --- strip previous awards ---
+    # College: just zero the result-row points + position.  The rebuild SUM at
+    # the end of this function recomputes individual_points from scratch, so
+    # there's no need to subtract from comp.individual_points here (the old
+    # strip-and-subtract pattern is gone).
     if event.event_type == 'college':
         for r in all_results:
-            awarded = int(r.points_awarded or 0)
-            if awarded:
-                comp = CollegeCompetitor.query.get(r.competitor_id)
-                if comp:
-                    comp.individual_points = max(0, comp.individual_points - awarded)
-            r.points_awarded = 0
+            r.points_awarded = Decimal('0')
             r.final_position = None
     else:
+        # Pro: still uses the per-row strip pattern because total_earnings is
+        # a Float and there's no equivalent SUM rebuild for pro standings.
         for r in all_results:
             awarded = float(r.payout_amount or 0)
             if awarded:
@@ -158,6 +264,21 @@ def calculate_positions(event: Event) -> None:
     if not completed:
         event.status = 'in_progress'
         event.is_finalized = False
+        # College: even with no completed results we still need to refresh
+        # individual_points + team totals to clear any prior award.
+        if event.event_type == 'college':
+            stripped_competitor_ids = [r.competitor_id for r in all_results]
+            _rebuild_individual_points(stripped_competitor_ids)
+            stripped_comps = (
+                CollegeCompetitor.query
+                .filter(CollegeCompetitor.id.in_(stripped_competitor_ids))
+                .all()
+            )
+            stripped_team_ids = {c.team_id for c in stripped_comps if c.team_id}
+            for tid in stripped_team_ids:
+                team = Team.query.get(tid)
+                if team:
+                    team.recalculate_points()
         return
 
     # --- axe throw tie detection (before sorting) ---
@@ -180,8 +301,10 @@ def calculate_positions(event: Event) -> None:
 
     # --- assign positions with proper tie handling ---
     # Two competitors are tied if BOTH their primary metric AND tiebreak metric are equal.
-    # Exception: axe throw ties are unresolved until throw-off — keep the same sort order
-    # but mark them with the same provisional position.
+    # Group consecutive results that share a sort key, then for each group:
+    #   * assign all members the position of the FIRST member in the group
+    #   * for college: split the combined points across the tied competitors
+    #   * for pro: each tied competitor gets the payout of their assigned position
     competitor_ids = [r.competitor_id for r in completed]
     if event.event_type == 'college':
         comp_rows = CollegeCompetitor.query.filter(CollegeCompetitor.id.in_(competitor_ids)).all()
@@ -189,31 +312,93 @@ def calculate_positions(event: Event) -> None:
         comp_rows = ProCompetitor.query.filter(ProCompetitor.id.in_(competitor_ids)).all()
     comp_lookup = {c.id: c for c in comp_rows}
 
-    position = 1
-    for i, result in enumerate(completed):
-        if i > 0:
-            prev = completed[i - 1]
-            if _sort_key(result, event) != _sort_key(prev, event):
-                position = i + 1  # skip positions for tied block
+    # Walk the sorted list once, identifying tied groups by run length.
+    #
+    # Phase 3 (V2.8.0) partner-event handling (PLAN_REVIEW.md A5):
+    # For partnered events (Double Buck, Jack & Jill, Pulp Toss, Peavey Log Roll),
+    # each pair has TWO EventResult rows — one per competitor — that share the
+    # same time and the same sort key.  These two rows are ONE PAIR for position
+    # purposes.  If two pairs tie for 1st (4 rows, all same sort key), the
+    # position group consumes 2 positions (not 4), and each row gets the
+    # 2-pair split: (10 + 7) / 2 = 8.5 each.
+    #
+    # Pair detection key: frozenset({competitor_name, partner_name}).  This is
+    # symmetric so both row orderings collide on the same key.  Non-partnered
+    # events have partner_name=None on every row, so frozenset({name, None}) is
+    # unique per row and the pair count equals the row count — same behavior
+    # as before for solo events.
+    is_partnered = bool(getattr(event, 'is_partnered', False))
 
-        result.final_position = position
+    def _pair_key_for(result):
+        if is_partnered:
+            return frozenset((result.competitor_name, result.partner_name))
+        return result.competitor_id  # unique per row for non-partnered
+
+    position = 1
+    i = 0
+    while i < len(completed):
+        # Find the end of the current tied group.
+        group_start = i
+        group_key = _sort_key(completed[i], event)
+        while i < len(completed) and _sort_key(completed[i], event) == group_key:
+            i += 1
+        group_end = i  # exclusive
+
+        # Count unique PAIRS in this tied group (not unique rows).
+        unique_pairs_in_group = len({
+            _pair_key_for(completed[j]) for j in range(group_start, group_end)
+        })
 
         if event.event_type == 'college':
-            points = config.PLACEMENT_POINTS.get(position, 0)
-            result.points_awarded = points
-            comp = comp_lookup.get(result.competitor_id)
-            if comp:
-                comp.individual_points += points
+            # Split-tie points for college.  Solo positions still flow through
+            # this helper — split_tie_points(rank, 1) is just the table value
+            # at that rank, so the math is unchanged for non-tied results.
+            #
+            # Crucially: divide combined points by unique_pairs_in_group, NOT
+            # by row count.  In a partnered event, both members of a tied pair
+            # collectively occupy ONE position, not two.
+            per_pair_points = split_tie_points(position, unique_pairs_in_group)
+            for j in range(group_start, group_end):
+                completed[j].final_position = position
+                completed[j].points_awarded = per_pair_points
+                # No inline += on comp.individual_points — the rebuild SUM
+                # below handles that in one batched query.
         else:
+            # Pro events: each tied competitor gets the payout amount for the
+            # tie-shared position.  This matches the historical behavior;
+            # whether to split pro payouts on a tie is a separate
+            # business decision out of scope for V2.8.0.
             payout = event.get_payout_for_position(position)
-            result.payout_amount = payout
-            comp = comp_lookup.get(result.competitor_id)
-            if comp:
-                comp.total_earnings += payout
+            for j in range(group_start, group_end):
+                completed[j].final_position = position
+                completed[j].payout_amount = payout
+                comp = comp_lookup.get(completed[j].competitor_id)
+                if comp:
+                    comp.total_earnings += payout
 
-    # --- team point recalc (college) ---
+        # Advance the position counter by the number of unique pairs (one per
+        # entity), not the number of rows.  For solo events these are equal.
+        position += unique_pairs_in_group
+
+    # --- college: rebuild individual_points + team totals from SUM ---
+    # This single batched rebuild replaces the old per-row += accumulation
+    # AND the strip-then-add pattern from the top of this function.  After
+    # this call, every competitor's individual_points equals the sum of
+    # their EventResult.points_awarded across all events — by construction.
     if event.event_type == 'college':
-        touched_team_ids = {c.team_id for c in comp_rows if hasattr(c, 'team_id') and c.team_id}
+        # Rebuild for ALL competitors touched by this event (even ones whose
+        # current row is not 'completed' — they still need their cache
+        # refreshed because the previous-award strip zeroed their points).
+        all_touched_ids = list({r.competitor_id for r in all_results})
+        _rebuild_individual_points(all_touched_ids)
+
+        # Now rebuild every team that had a competitor in this event.
+        all_touched_comps = (
+            CollegeCompetitor.query
+            .filter(CollegeCompetitor.id.in_(all_touched_ids))
+            .all()
+        )
+        touched_team_ids = {c.team_id for c in all_touched_comps if c.team_id}
         for team_id in touched_team_ids:
             team = Team.query.get(team_id)
             if team:
@@ -257,6 +442,12 @@ def preview_positions(event: Event) -> list[dict]:
     """
     Compute provisional standings without writing to the DB.
     Returns a list of dicts ready for JSON/modal display.
+
+    Phase 3 (V2.8.0): preview points use the same split-tie math as
+    calculate_positions(), so the modal accurately shows what each
+    competitor will receive after finalization.  Decimal values are
+    converted to float at the JSON boundary so jsonify() doesn't
+    raise TypeError on the live response.
     """
     completed = [r for r in event.results.all() if r.status == 'completed']
     if not completed:
@@ -264,34 +455,63 @@ def preview_positions(event: Event) -> list[dict]:
 
     completed.sort(key=lambda r: _sort_key(r, event))
 
-    position = 1
-    out = []
-    for i, result in enumerate(completed):
-        if i > 0:
-            prev = completed[i - 1]
-            if _sort_key(result, event) != _sort_key(prev, event):
-                position = i + 1
+    # Phase 3 (V2.8.0): mirror the pair-aware grouping from calculate_positions
+    # so the preview modal shows the same per-row points the finalize call
+    # will write.  See the long comment in calculate_positions for the
+    # partnered-event reasoning.
+    is_partnered = bool(getattr(event, 'is_partnered', False))
 
-        metric = _metric(result, event)
-        row = {
-            'position': position,
-            'competitor_name': result.competitor_name,
-            'partner_name': result.partner_name,
-            'result_value': metric,
-            'run1_value': result.run1_value,
-            'run2_value': result.run2_value,
-            'run3_value': result.run3_value,
-            'best_run': result.best_run,
-            'tiebreak_value': result.tiebreak_value,
-            'throwoff_pending': result.throwoff_pending,
-            'status': result.status,
-        }
-        if event.event_type == 'college':
-            row['points'] = config.PLACEMENT_POINTS.get(position, 0)
-        else:
-            row['payout'] = event.get_payout_for_position(position)
-        out.append(row)
-    return out
+    def _pair_key_for(result):
+        if is_partnered:
+            return frozenset((result.competitor_name, result.partner_name))
+        return result.competitor_id
+
+    rows: list[dict] = []
+    position = 1
+    i = 0
+    while i < len(completed):
+        group_start = i
+        group_key = _sort_key(completed[i], event)
+        while i < len(completed) and _sort_key(completed[i], event) == group_key:
+            i += 1
+        group_end = i
+
+        unique_pairs_in_group = len({
+            _pair_key_for(completed[j]) for j in range(group_start, group_end)
+        })
+
+        per_pair_points = (
+            split_tie_points(position, unique_pairs_in_group)
+            if event.event_type == 'college' else None
+        )
+
+        for j in range(group_start, group_end):
+            result = completed[j]
+            metric = _metric(result, event)
+            row = {
+                'position': position,
+                'competitor_name': result.competitor_name,
+                'partner_name': result.partner_name,
+                'result_value': float(metric) if metric is not None else None,
+                'run1_value': float(result.run1_value) if result.run1_value is not None else None,
+                'run2_value': float(result.run2_value) if result.run2_value is not None else None,
+                'run3_value': float(result.run3_value) if result.run3_value is not None else None,
+                'best_run': float(result.best_run) if result.best_run is not None else None,
+                'tiebreak_value': float(result.tiebreak_value) if result.tiebreak_value is not None else None,
+                'throwoff_pending': result.throwoff_pending,
+                'status': result.status,
+            }
+            if event.event_type == 'college':
+                row['points'] = float(per_pair_points)
+                # tied_with reports the number of unique entities (pairs for
+                # partnered events, rows otherwise) sharing this position.
+                row['tied_with'] = unique_pairs_in_group if unique_pairs_in_group > 1 else 0
+            else:
+                row['payout'] = event.get_payout_for_position(position)
+            rows.append(row)
+
+        position += unique_pairs_in_group
+    return rows
 
 
 def pending_throwoffs(event: Event) -> list[EventResult]:
@@ -305,6 +525,11 @@ def record_throwoff_result(event: Event, position_map: dict[int, int]) -> None:
 
     position_map: {result_id: final_position} — judge-assigned positions after throw-off.
     Clears throwoff_pending flags and re-awards points/payouts for affected positions.
+
+    Phase 3 (V2.8.0): for college events this now uses the same SUM-rebuild
+    pattern as calculate_positions() instead of the old delta-arithmetic
+    on comp.individual_points.  The two paths must stay in sync — having
+    them diverge was PLAN_REVIEW.md finding A6.
     """
     result_lookup = {r.id: r for r in event.results.all()}
     for result_id, position in position_map.items():
@@ -315,13 +540,14 @@ def record_throwoff_result(event: Event, position_map: dict[int, int]) -> None:
         result.throwoff_pending = False
 
         if event.event_type == 'college':
-            old_pts = int(result.points_awarded or 0)
-            new_pts = config.PLACEMENT_POINTS.get(position, 0)
-            diff = new_pts - old_pts
+            # Throw-off positions are explicit per-competitor positions assigned
+            # by the judge — no tie-splitting at this stage (the throw-off IS
+            # the tiebreak).  Use the simple table lookup; if multiple
+            # competitors somehow share the same throw-off position, the
+            # rebuild SUM at the end will still match what we wrote here
+            # because we write the same value to each row.
+            new_pts = Decimal(str(config.PLACEMENT_POINTS.get(position, 0)))
             result.points_awarded = new_pts
-            comp = CollegeCompetitor.query.get(result.competitor_id)
-            if comp:
-                comp.individual_points = max(0, comp.individual_points + diff)
         else:
             old_pay = float(result.payout_amount or 0)
             new_pay = event.get_payout_for_position(position)
@@ -332,8 +558,15 @@ def record_throwoff_result(event: Event, position_map: dict[int, int]) -> None:
                 comp.total_earnings = max(0.0, comp.total_earnings + diff)
 
     if event.event_type == 'college':
-        all_comp_ids = [r.competitor_id for r in result_lookup.values()]
-        comp_rows = CollegeCompetitor.query.filter(CollegeCompetitor.id.in_(all_comp_ids)).all()
+        # Rebuild from SUM — single source of truth, same path as
+        # calculate_positions() so the two functions stay consistent.
+        all_comp_ids = list({r.competitor_id for r in result_lookup.values()})
+        _rebuild_individual_points(all_comp_ids)
+        comp_rows = (
+            CollegeCompetitor.query
+            .filter(CollegeCompetitor.id.in_(all_comp_ids))
+            .all()
+        )
         touched_team_ids = {c.team_id for c in comp_rows if getattr(c, 'team_id', None)}
         for team_id in touched_team_ids:
             team = Team.query.get(team_id)
@@ -439,28 +672,55 @@ def live_standings_data(event: Event) -> dict:
     """
     Return current standings as JSON-serialisable dict for the polling endpoint.
     Includes unfinished heats so in-progress events show real-time ordering.
+
+    Phase 3 (V2.8.0): all numeric fields cast to float at the JSON boundary
+    so jsonify() works on Decimal-typed columns from Phase 1B.
     """
     results = event.results.all()
     completed = [r for r in results if r.status == 'completed']
     completed.sort(key=lambda r: _sort_key(r, event))
 
+    # Phase 3 (V2.8.0): pair-aware position grouping (same logic as
+    # calculate_positions / preview_positions).  Two rows from the same
+    # partnered pair share one position.
+    is_partnered = bool(getattr(event, 'is_partnered', False))
+
+    def _pair_key_for(result):
+        if is_partnered:
+            return frozenset((result.competitor_name, result.partner_name))
+        return result.competitor_id
+
     rows = []
     position = 1
-    for i, r in enumerate(completed):
-        if i > 0 and _sort_key(r, event) != _sort_key(completed[i - 1], event):
-            position = i + 1
-        rows.append({
-            'position': position,
-            'competitor_name': r.competitor_name,
-            'result_value': _metric(r, event),
-            'run1_value': r.run1_value,
-            'run2_value': r.run2_value,
-            'run3_value': r.run3_value,
-            'best_run': r.best_run,
-            'is_flagged': r.is_flagged,
-            'throwoff_pending': r.throwoff_pending,
-            'status': r.status,
+    i = 0
+    while i < len(completed):
+        group_start = i
+        group_key = _sort_key(completed[i], event)
+        while i < len(completed) and _sort_key(completed[i], event) == group_key:
+            i += 1
+        group_end = i
+
+        unique_pairs_in_group = len({
+            _pair_key_for(completed[j]) for j in range(group_start, group_end)
         })
+
+        for j in range(group_start, group_end):
+            r = completed[j]
+            metric = _metric(r, event)
+            rows.append({
+                'position': position,
+                'competitor_name': r.competitor_name,
+                'result_value': float(metric) if metric is not None else None,
+                'run1_value': float(r.run1_value) if r.run1_value is not None else None,
+                'run2_value': float(r.run2_value) if r.run2_value is not None else None,
+                'run3_value': float(r.run3_value) if r.run3_value is not None else None,
+                'best_run': float(r.best_run) if r.best_run is not None else None,
+                'is_flagged': r.is_flagged,
+                'throwoff_pending': r.throwoff_pending,
+                'status': r.status,
+            })
+
+        position += unique_pairs_in_group
 
     total_heats = event.heats.count()
     completed_heats = event.heats.filter_by(status='completed').count()

--- a/tests/test_point_calculator.py
+++ b/tests/test_point_calculator.py
@@ -509,8 +509,11 @@ class TestCalculatePositionsCollege:
         # Next is position 3 (position 2 skipped)
         assert r3.final_position == 3
 
-    def test_tied_competitors_both_get_same_points(self, db_session, tournament):
-        """Tied competitors at position N both receive the points for position N."""
+    def test_tied_competitors_both_get_same_split_points(self, db_session, tournament):
+        """Tied competitors at position N split the combined points for the
+        tied positions per the AWFC rule (Phase 3 V2.8.0 — was a bug pre-V2.8.0)."""
+        from decimal import Decimal
+
         from services.scoring_engine import calculate_positions
         team = _make_team(db_session, tournament, 'UM-A', 'University of Montana', 'UM')
         event = _make_college_event(db_session, tournament, 'Underhand Speed', 'M')
@@ -524,9 +527,9 @@ class TestCalculatePositionsCollege:
 
         r1 = event.results.filter_by(competitor_id=c1.id).first()
         r2 = event.results.filter_by(competitor_id=c2.id).first()
-        # Both get 1st place points
-        assert r1.points_awarded == 10
-        assert r2.points_awarded == 10
+        # Two tied for 1st: split (10 + 7) / 2 = 8.5 points each.
+        assert r1.points_awarded == Decimal('8.50')
+        assert r2.points_awarded == Decimal('8.50')
 
     def test_dnf_excluded_from_positions(self, db_session, tournament):
         """DNF results are not assigned a position."""

--- a/tests/test_scoring_college_points.py
+++ b/tests/test_scoring_college_points.py
@@ -235,7 +235,14 @@ class TestCollegeEventScoring:
         assert results_by_name['Hidden Dragon'].points_awarded == 7
 
     def test_stock_saw_m_with_tie(self, db_session):
-        """Time / lowest_wins event with a tie for 1st (both get 10 pts)."""
+        """Time / lowest_wins event with a tie for 1st.
+
+        Phase 3 (V2.8.0) AWFC tie-split: two tied for 1st each receive
+        (10 + 7) / 2 = 8.5 points (NOT 10 each — that was the V2.7.0 bug
+        this rewrite fixes).
+        """
+        from decimal import Decimal
+
         from services.scoring_engine import calculate_positions
 
         tournament = make_tournament(db_session)
@@ -252,15 +259,16 @@ class TestCollegeEventScoring:
         results_by_name = {r.competitor_name: r for r in event.results.all()
                           if r.status == 'completed'}
 
-        # Two tied for 1st, both get position 1 and 10 pts
+        # Two tied for 1st split (10 + 7) / 2 = 8.5 each.
         assert results_by_name['Squinge Timbler'].final_position == 1
-        assert results_by_name['Squinge Timbler'].points_awarded == 10
+        assert results_by_name['Squinge Timbler'].points_awarded == Decimal('8.50')
         assert results_by_name['Zix Zeben'].final_position == 1
-        assert results_by_name['Zix Zeben'].points_awarded == 10
+        assert results_by_name['Zix Zeben'].points_awarded == Decimal('8.50')
 
-        # Next competitor gets position 3 (not 2)
+        # Next competitor gets position 3 (not 2 — positions 1 and 2 consumed
+        # by the tie) and the full 5 points for 3rd place.
         assert results_by_name['Bumbldy Pumpldy'].final_position == 3
-        assert results_by_name['Bumbldy Pumpldy'].points_awarded == 5
+        assert results_by_name['Bumbldy Pumpldy'].points_awarded == Decimal('5.00')
 
     def test_double_buck_m_partnered(self, db_session):
         """Partnered event: time / lowest_wins."""
@@ -573,15 +581,19 @@ class TestTiedCollegeScoring:
 
         results = {r.competitor_name: r for r in event.results.all()}
 
-        # Both tied for 1st get position 1 and 10 points each
+        # Phase 3 (V2.8.0) AWFC tie-split: two tied for 1st each receive
+        # (10 + 7) / 2 = 8.5 points (NOT 10 each — that was the V2.7.0 bug
+        # this rewrite fixes).
+        from decimal import Decimal
         assert results['Joe Squamjo'].final_position == 1
-        assert results['Joe Squamjo'].points_awarded == 10
+        assert results['Joe Squamjo'].points_awarded == Decimal('8.50')
         assert results['Squinge Timbler'].final_position == 1
-        assert results['Squinge Timbler'].points_awarded == 10
+        assert results['Squinge Timbler'].points_awarded == Decimal('8.50')
 
         # Next competitor is position 3 (positions 1 and 2 consumed by the tie)
+        # and receives the full 5 points for 3rd place (no tie there).
         assert results['James Taply'].final_position == 3
-        assert results['James Taply'].points_awarded == config.PLACEMENT_POINTS.get(3, 0)
+        assert results['James Taply'].points_awarded == Decimal('5.00')
 
     def test_tied_for_second(self, db_session):
         from services.scoring_engine import calculate_positions
@@ -616,18 +628,20 @@ class TestTiedCollegeScoring:
 
         results = {r.competitor_name: r for r in event.results.all()}
 
+        from decimal import Decimal
         assert results['Jilliam Jwilliam'].final_position == 1
-        assert results['Jilliam Jwilliam'].points_awarded == 10
+        assert results['Jilliam Jwilliam'].points_awarded == Decimal('10.00')
 
-        # Both tied for 2nd get position 2 and 7 points each
+        # Phase 3 (V2.8.0) AWFC tie-split: two tied for 2nd each receive
+        # (7 + 5) / 2 = 6.0 points (NOT 7 each — that was the V2.7.0 bug).
         assert results['Beverly Crease'].final_position == 2
-        assert results['Beverly Crease'].points_awarded == 7
+        assert results['Beverly Crease'].points_awarded == Decimal('6.00')
         assert results['Kum Pon Nent'].final_position == 2
-        assert results['Kum Pon Nent'].points_awarded == 7
+        assert results['Kum Pon Nent'].points_awarded == Decimal('6.00')
 
-        # Next is position 4 (not 3)
+        # Next is position 4 (not 3) — positions 2 and 3 consumed by the tie.
         assert results['Jackie Jackson'].final_position == 4
-        assert results['Jackie Jackson'].points_awarded == 3
+        assert results['Jackie Jackson'].points_awarded == Decimal('3.00')
 
     def test_stock_saw_m_real_tie(self, db_session):
         """Stock Saw M from synthetic data has a real tie for 1st place
@@ -648,11 +662,14 @@ class TestTiedCollegeScoring:
         results = {r.competitor_name: r for r in event.results.all()
                    if r.status == 'completed'}
 
+        # Phase 3 (V2.8.0) AWFC tie-split: two tied for 1st each receive
+        # (10 + 7) / 2 = 8.5 points (NOT 10 each).
+        from decimal import Decimal
         assert results['Squinge Timbler'].final_position == 1
-        assert results['Squinge Timbler'].points_awarded == 10
+        assert results['Squinge Timbler'].points_awarded == Decimal('8.50')
         assert results['Zix Zeben'].final_position == 1
-        assert results['Zix Zeben'].points_awarded == 10
+        assert results['Zix Zeben'].points_awarded == Decimal('8.50')
 
-        # 3rd place (position 3, 5 pts) since two share 1st
+        # 3rd place (position 3, 5 pts) since two share 1st.
         assert results['Bumbldy Pumpldy'].final_position == 3
-        assert results['Bumbldy Pumpldy'].points_awarded == 5
+        assert results['Bumbldy Pumpldy'].points_awarded == Decimal('5.00')

--- a/tests/test_split_tie_scoring.py
+++ b/tests/test_split_tie_scoring.py
@@ -1,0 +1,510 @@
+"""
+Phase 3 of the V2.8.0 scoring fix — split-tie points + rebuild SUM tests.
+
+Verifies that:
+
+1. ``split_tie_points()`` produces the AWFC fractional values for every common
+   tie shape (1-way through 6-way and beyond-table).
+2. ``calculate_positions()`` writes the split values into ``points_awarded``
+   and rebuilds ``individual_points`` from SUM, NOT from delta arithmetic.
+3. The rebuild path is idempotent — calling ``calculate_positions()`` twice
+   on the same event produces identical totals.
+4. Partner events award full split-points to BOTH partners independently
+   (the AWFC dual-credit rule), and team totals reflect the points twice.
+5. ``record_throwoff_result()`` uses the same SUM rebuild path as
+   ``calculate_positions()`` so the two functions stay consistent
+   (PLAN_REVIEW.md A6 regression).
+6. JSON-boundary numerics in ``preview_positions()`` and ``live_standings_data()``
+   are plain ``float`` (no Decimal) so ``jsonify`` works.
+"""
+import json
+import os
+from decimal import Decimal
+
+import pytest
+
+from database import db as _db
+
+# ---------------------------------------------------------------------------
+# Self-contained app fixture (module-scoped, mirrors test_routes_post pattern)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='module')
+def app():
+    from tests.db_test_utils import create_test_app
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        _seed(_app)
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+def _seed(app):
+    from models import Tournament
+    from models.user import User
+    if not User.query.filter_by(username='st_admin').first():
+        u = User(username='st_admin', role='admin')
+        u.set_password('st_pass')
+        _db.session.add(u)
+    if not Tournament.query.first():
+        t = Tournament(name='Phase 3 Test 2026', year=2026, status='setup')
+        _db.session.add(t)
+    _db.session.commit()
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture()
+def tid(app):
+    with app.app_context():
+        from models import Tournament
+        return Tournament.query.first().id
+
+
+# ---------------------------------------------------------------------------
+# Local seed helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(session, tid, name='Test Event', **kw):
+    from models.event import Event
+    defaults = dict(
+        tournament_id=tid, name=name, event_type='college', gender='M',
+        scoring_type='time', scoring_order='lowest_wins',
+        stand_type='underhand', max_stands=5, status='pending',
+        payouts=json.dumps({}),
+    )
+    defaults.update(kw)
+    e = Event(**defaults)
+    session.add(e)
+    session.flush()
+    return e
+
+
+def _make_team(session, tid, code='UM-A'):
+    from models import Team
+    t = Team(tournament_id=tid, team_code=code,
+             school_name='University of Montana', school_abbreviation='UM')
+    session.add(t)
+    session.flush()
+    return t
+
+
+def _make_college(session, tid, team_id, name, gender='M'):
+    from models.competitor import CollegeCompetitor
+    c = CollegeCompetitor(
+        tournament_id=tid, team_id=team_id, name=name, gender=gender,
+        events_entered=json.dumps([]), status='active',
+    )
+    session.add(c)
+    session.flush()
+    return c
+
+
+def _make_result(session, event, comp, value, status='completed', partner_name=None):
+    from models.event import EventResult
+    r = EventResult(
+        event_id=event.id, competitor_id=comp.id,
+        competitor_type='college', competitor_name=comp.name,
+        partner_name=partner_name,
+        result_value=value, run1_value=value,
+        status=status,
+    )
+    session.add(r)
+    session.flush()
+    return r
+
+
+# ===========================================================================
+# 1. split_tie_points() — pure-function tests
+# ===========================================================================
+
+
+class TestSplitTiePointsHelper:
+    """Pure-function tests for the split-tie helper."""
+
+    def test_solo_first_place(self):
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(1, 1) == Decimal('10.00')
+
+    def test_solo_sixth_place(self):
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(6, 1) == Decimal('1.00')
+
+    def test_seventh_and_below_zero(self):
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(7, 1) == Decimal('0.00')
+        assert split_tie_points(20, 1) == Decimal('0.00')
+
+    def test_two_way_tie_for_first(self):
+        """(10 + 7) / 2 = 8.5"""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(1, 2) == Decimal('8.50')
+
+    def test_three_way_tie_for_first(self):
+        """(10 + 7 + 5) / 3 = 7.33..."""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(1, 3) == Decimal('7.33')
+
+    def test_two_way_tie_for_second(self):
+        """(7 + 5) / 2 = 6.0"""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(2, 2) == Decimal('6.00')
+
+    def test_two_way_tie_for_fifth(self):
+        """(2 + 1) / 2 = 1.5"""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(5, 2) == Decimal('1.50')
+
+    def test_six_way_tie_for_first(self):
+        """All 6 places shared: (10+7+5+3+2+1)/6 = 4.67"""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(1, 6) == Decimal('4.67')
+
+    def test_tie_spilling_past_table(self):
+        """Three tied for 6th: only 6th has any points; (1+0+0)/3 = 0.33"""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(6, 3) == Decimal('0.33')
+
+    def test_tie_entirely_past_table(self):
+        """Three tied for 8th: all zero, (0+0+0)/3 = 0"""
+        from services.scoring_engine import split_tie_points
+        assert split_tie_points(8, 3) == Decimal('0.00')
+
+
+# ===========================================================================
+# 2. calculate_positions() with fractional split-ties
+# ===========================================================================
+
+
+class TestCalculatePositionsSplitTie:
+    """End-to-end split-tie behavior in the engine."""
+
+    def test_two_way_tie_first_place_credits_individual_points(self, db_session, tid):
+        """Both tied competitors get 8.5 points; their individual_points reflect it."""
+        from services.scoring_engine import calculate_positions
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        c2 = _make_college(db_session, tid, team.id, 'B')
+        c3 = _make_college(db_session, tid, team.id, 'C')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 20.0)
+        _make_result(db_session, event, c2, 20.0)
+        _make_result(db_session, event, c3, 25.0)
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+
+        r1 = event.results.filter_by(competitor_id=c1.id).first()
+        r2 = event.results.filter_by(competitor_id=c2.id).first()
+        r3 = event.results.filter_by(competitor_id=c3.id).first()
+        assert r1.points_awarded == Decimal('8.50')
+        assert r2.points_awarded == Decimal('8.50')
+        assert r3.points_awarded == Decimal('5.00')  # 3rd place (positions 2 skipped)
+
+        # individual_points reflects the SUM rebuild
+        from models.competitor import CollegeCompetitor
+        c1_loaded = CollegeCompetitor.query.get(c1.id)
+        c2_loaded = CollegeCompetitor.query.get(c2.id)
+        c3_loaded = CollegeCompetitor.query.get(c3.id)
+        assert c1_loaded.individual_points == Decimal('8.50')
+        assert c2_loaded.individual_points == Decimal('8.50')
+        assert c3_loaded.individual_points == Decimal('5.00')
+
+    def test_three_way_tie_first_place(self, db_session, tid):
+        """Three tied for 1st each get (10+7+5)/3 = 7.33."""
+        from services.scoring_engine import calculate_positions
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        c2 = _make_college(db_session, tid, team.id, 'B')
+        c3 = _make_college(db_session, tid, team.id, 'C')
+        c4 = _make_college(db_session, tid, team.id, 'D')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 20.0)
+        _make_result(db_session, event, c2, 20.0)
+        _make_result(db_session, event, c3, 20.0)
+        _make_result(db_session, event, c4, 25.0)
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+
+        r1 = event.results.filter_by(competitor_id=c1.id).first()
+        r2 = event.results.filter_by(competitor_id=c2.id).first()
+        r3 = event.results.filter_by(competitor_id=c3.id).first()
+        r4 = event.results.filter_by(competitor_id=c4.id).first()
+        assert r1.points_awarded == Decimal('7.33')
+        assert r2.points_awarded == Decimal('7.33')
+        assert r3.points_awarded == Decimal('7.33')
+        # Position 4 (positions 1, 2, 3 consumed by the tie)
+        assert r4.final_position == 4
+        assert r4.points_awarded == Decimal('3.00')
+
+    def test_team_total_points_uses_fractional_sum(self, db_session, tid):
+        """Team totals correctly accumulate fractional individual points."""
+        from models.team import Team
+        from services.scoring_engine import calculate_positions
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        c2 = _make_college(db_session, tid, team.id, 'B')
+        # Need 2 of each gender to satisfy team validity later (not required
+        # by the scoring engine itself but kept consistent with model expectations).
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 20.0)
+        _make_result(db_session, event, c2, 20.0)
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+
+        team_loaded = Team.query.get(team.id)
+        # Two competitors tied for 1st: each gets 8.5, team gets 17.0
+        assert team_loaded.total_points == Decimal('17.00')
+
+
+# ===========================================================================
+# 3. Idempotency — run calculate_positions twice
+# ===========================================================================
+
+
+class TestRebuildIdempotency:
+    """The SUM rebuild path must be idempotent under repeat calls."""
+
+    def test_running_calculate_positions_twice_yields_same_totals(self, db_session, tid):
+        from models.competitor import CollegeCompetitor
+        from services.scoring_engine import calculate_positions
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        c2 = _make_college(db_session, tid, team.id, 'B')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 18.0)
+        _make_result(db_session, event, c2, 22.0)
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+        c1_first = CollegeCompetitor.query.get(c1.id).individual_points
+        c2_first = CollegeCompetitor.query.get(c2.id).individual_points
+
+        # Second run — should produce identical results.
+        calculate_positions(event)
+        db_session.flush()
+        c1_second = CollegeCompetitor.query.get(c1.id).individual_points
+        c2_second = CollegeCompetitor.query.get(c2.id).individual_points
+
+        assert c1_second == c1_first
+        assert c2_second == c2_first
+        assert c1_first == Decimal('10.00')
+        assert c2_first == Decimal('7.00')
+
+
+# ===========================================================================
+# 4. Partner event dual-credit (AWFC rule, PLAN_REVIEW.md T2)
+# ===========================================================================
+
+
+class TestPartnerEventDualCredit:
+    """Both partners receive the same split-tie points; team total counts both."""
+
+    def test_jack_and_jill_both_partners_credited(self, db_session, tid):
+        """In a partnered event, BOTH competitors on the pair get full points."""
+        from models.competitor import CollegeCompetitor
+        from models.team import Team
+        from services.scoring_engine import calculate_positions
+        team = _make_team(db_session, tid)
+        # Pair A: Mike + Mary (one row each, same partner_name)
+        mike = _make_college(db_session, tid, team.id, 'Mike', gender='M')
+        mary = _make_college(db_session, tid, team.id, 'Mary', gender='F')
+        # Pair B: Bob + Beth
+        bob = _make_college(db_session, tid, team.id, 'Bob', gender='M')
+        beth = _make_college(db_session, tid, team.id, 'Beth', gender='F')
+
+        event = _make_event(db_session, tid, name='Jack & Jill',
+                            scoring_type='time', is_partnered=True,
+                            partner_gender_requirement='mixed', stand_type='saw_hand')
+
+        # Pair A wins with 22.0; Pair B places 2nd with 24.0.
+        _make_result(db_session, event, mike, 22.0, partner_name='Mary')
+        _make_result(db_session, event, mary, 22.0, partner_name='Mike')
+        _make_result(db_session, event, bob, 24.0, partner_name='Beth')
+        _make_result(db_session, event, beth, 24.0, partner_name='Bob')
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+
+        # Both Pair A members get full 1st-place points (10 each).
+        assert CollegeCompetitor.query.get(mike.id).individual_points == Decimal('10.00')
+        assert CollegeCompetitor.query.get(mary.id).individual_points == Decimal('10.00')
+        # Both Pair B members get full 2nd-place points (7 each).
+        assert CollegeCompetitor.query.get(bob.id).individual_points == Decimal('7.00')
+        assert CollegeCompetitor.query.get(beth.id).individual_points == Decimal('7.00')
+
+        # The team total reflects ALL FOUR contributions: 10 + 10 + 7 + 7 = 34
+        # (this is the AWFC "team gets points twice" rule from ProAM requirements).
+        assert Team.query.get(team.id).total_points == Decimal('34.00')
+
+    def test_partner_event_with_two_pairs_tied_for_first(self, db_session, tid):
+        """Two pairs tie for 1st: all 4 competitors get the split value (8.5)."""
+        from models.competitor import CollegeCompetitor
+        from models.team import Team
+        from services.scoring_engine import calculate_positions
+        team = _make_team(db_session, tid)
+        a1 = _make_college(db_session, tid, team.id, 'A1', gender='M')
+        a2 = _make_college(db_session, tid, team.id, 'A2', gender='F')
+        b1 = _make_college(db_session, tid, team.id, 'B1', gender='M')
+        b2 = _make_college(db_session, tid, team.id, 'B2', gender='F')
+
+        event = _make_event(db_session, tid, name='Jack & Jill Tied',
+                            scoring_type='time', is_partnered=True,
+                            partner_gender_requirement='mixed', stand_type='saw_hand')
+
+        # Both pairs tie at 22.0 — split position 1 + 2 → 8.5 each.
+        _make_result(db_session, event, a1, 22.0, partner_name='A2')
+        _make_result(db_session, event, a2, 22.0, partner_name='A1')
+        _make_result(db_session, event, b1, 22.0, partner_name='B2')
+        _make_result(db_session, event, b2, 22.0, partner_name='B1')
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+
+        for c in (a1, a2, b1, b2):
+            assert CollegeCompetitor.query.get(c.id).individual_points == Decimal('8.50')
+
+        # Team total: 8.5 * 4 = 34.0
+        assert Team.query.get(team.id).total_points == Decimal('34.00')
+
+
+# ===========================================================================
+# 5. Throw-off path uses the same SUM rebuild
+# ===========================================================================
+
+
+class TestRecordThrowoffResultRebuild:
+    """record_throwoff_result must use _rebuild_individual_points, not delta math."""
+
+    def test_throwoff_individual_points_match_sum_after_resolve(self, db_session, tid):
+        """After throw-off, individual_points must equal SUM(points_awarded)."""
+        from models.competitor import CollegeCompetitor
+        from services.scoring_engine import calculate_positions, record_throwoff_result
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'Pat')
+        c2 = _make_college(db_session, tid, team.id, 'Quinn')
+        event = _make_event(
+            db_session, tid, name='Axe Throw',
+            scoring_type='score', scoring_order='highest_wins',
+            requires_triple_runs=True, stand_type='axe_throw',
+        )
+        # Both end with cumulative 12 → tie → throw-off pending after calculate.
+        _make_result(db_session, event, c1, 12.0)
+        _make_result(db_session, event, c2, 12.0)
+        db_session.flush()
+
+        calculate_positions(event)
+        db_session.flush()
+
+        # The judge resolves: c1 → position 1, c2 → position 2.
+        r1 = event.results.filter_by(competitor_id=c1.id).first()
+        r2 = event.results.filter_by(competitor_id=c2.id).first()
+        record_throwoff_result(event, {r1.id: 1, r2.id: 2})
+        db_session.flush()
+
+        # individual_points must equal each row's points_awarded after rebuild.
+        c1_loaded = CollegeCompetitor.query.get(c1.id)
+        c2_loaded = CollegeCompetitor.query.get(c2.id)
+        assert c1_loaded.individual_points == r1.points_awarded
+        assert c2_loaded.individual_points == r2.points_awarded
+        assert c1_loaded.individual_points == Decimal('10.00')  # 1st place
+        assert c2_loaded.individual_points == Decimal('7.00')   # 2nd place
+
+
+# ===========================================================================
+# 6. JSON-boundary numerics — preview_positions and live_standings_data
+# ===========================================================================
+
+
+class TestJsonBoundaryFloatCast:
+    """preview_positions / live_standings_data must return plain floats (not Decimal)."""
+
+    def test_preview_positions_returns_float_points(self, db_session, tid):
+        from services.scoring_engine import preview_positions
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        c2 = _make_college(db_session, tid, team.id, 'B')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 20.0)
+        _make_result(db_session, event, c2, 25.0)
+        db_session.flush()
+
+        preview = preview_positions(event)
+        assert len(preview) == 2
+        for row in preview:
+            # The points field MUST be a plain float so jsonify works.
+            assert isinstance(row['points'], float)
+            # The result_value field also gets float-cast.
+            assert isinstance(row['result_value'], float)
+        # First place: 10.0
+        assert preview[0]['points'] == pytest.approx(10.0)
+        assert preview[1]['points'] == pytest.approx(7.0)
+
+    def test_preview_positions_split_tie_in_modal(self, db_session, tid):
+        """Two-way tie shows 8.5 in the preview modal."""
+        from services.scoring_engine import preview_positions
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        c2 = _make_college(db_session, tid, team.id, 'B')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 20.0)
+        _make_result(db_session, event, c2, 20.0)
+        db_session.flush()
+
+        preview = preview_positions(event)
+        for row in preview:
+            assert row['points'] == pytest.approx(8.5)
+            # tied_with annotation lets the UI show a "shared" badge.
+            assert row['tied_with'] == 2
+
+    def test_live_standings_data_returns_float_only(self, db_session, tid):
+        """live_standings_data must not contain any Decimal — jsonify would crash."""
+        from services.scoring_engine import live_standings_data
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 18.5)
+        db_session.flush()
+
+        data = live_standings_data(event)
+        assert 'rows' in data
+        for row in data['rows']:
+            for key in ('result_value', 'run1_value', 'run2_value', 'run3_value', 'best_run'):
+                v = row.get(key)
+                assert v is None or isinstance(v, float), \
+                    f'{key} = {v!r} (type {type(v).__name__}), expected float or None'
+
+    def test_jsonify_handles_live_standings(self, db_session, tid, app):
+        """Smoke test: actually run jsonify() on the dict to confirm it doesn't TypeError."""
+        from flask import jsonify
+
+        from services.scoring_engine import live_standings_data
+        team = _make_team(db_session, tid)
+        c1 = _make_college(db_session, tid, team.id, 'A')
+        event = _make_event(db_session, tid)
+        _make_result(db_session, event, c1, 18.5)
+        db_session.flush()
+
+        data = live_standings_data(event)
+        with app.test_request_context():
+            response = jsonify(data)
+            assert response.status_code == 200
+            assert b'18.5' in response.data


### PR DESCRIPTION
## Summary

Phase 3 of the V2.8.0 scoring system fix. **The big one.** Replaces the V2.7.0 duplicate-points tie handling with the AWFC fractional split-tie rule, switches the per-row strip-then-add cache to an idempotent SUM rebuild, fixes the partner-event dual-credit bug at the engine level, and resolves the Decimal/jsonify TypeError on the live standings poll.

**No new migration.** Builds on Phase 1B's Numeric points columns and Phase 2's dual-timer entry path.

## Why

Three of the four CRITICAL findings from `SCORING_AUDIT.md` get fixed in this one PR:

| Audit finding | Fix in this PR |
|---|---|
| Tied competitors get full points each, not split | New `split_tie_points()` helper + group-by-tie loop in `calculate_positions` |
| Partner events only credit one of two partners | Pair-aware grouping via `frozenset({competitor_name, partner_name})` |
| `record_throwoff_result` diverges from `calculate_positions` | Both paths now use `_rebuild_individual_points()` |

Plus PLAN_REVIEW.md findings: A4 + A5 + A6 + C2 + C3 + C4 + P3 + T2.

## What changed

### `services/scoring_engine.py`

- **`PLACEMENT_POINTS_DECIMAL`** — new Decimal source-of-truth for the 1-10-7-5-3-2-1 table.
- **`split_tie_points(start_rank, count)`** — pure helper that returns the per-competitor share for `count` competitors tied at `start_rank`. All Decimal, quantized to 2dp.
- **`_rebuild_individual_points(competitor_ids)`** — single batched GROUP BY query that recomputes `CollegeCompetitor.individual_points` from `SUM(EventResult.points_awarded)`. Replaces the old per-row += pattern.
- **`calculate_positions()`** — full rewrite. Walks the sorted completed list once, identifies tied groups by sort-key run length, counts UNIQUE PAIRS in each group (frozenset key — partnered events collapse two rows to one entity, solo events keep one row per entity), then writes `split_tie_points(position, unique_pairs)` to every row in the group. After the loop, rebuilds the cache via SUM.
- **`record_throwoff_result()`** — now uses the same SUM rebuild path. Two finalization paths stay consistent.
- **`preview_positions()`** + **`live_standings_data()`** — same pair-aware grouping; all numeric fields cast to float at the JSON boundary so `jsonify()` works on Decimal-typed columns. `preview_positions` returns a new `tied_with` field for the UI.

### `tests/test_split_tie_scoring.py` (NEW — 21 tests, 6 classes)

| Class | Tests | Coverage |
|---|---|---|
| `TestSplitTiePointsHelper` | 10 | Pure-function tests for every common tie shape |
| `TestCalculatePositionsSplitTie` | 3 | End-to-end 2-way / 3-way ties + team total |
| `TestRebuildIdempotency` | 1 | Running `calculate_positions` twice yields identical totals |
| `TestPartnerEventDualCredit` | 2 | AWFC dual-credit rule (full points to both partners) + tied pairs |
| `TestRecordThrowoffResultRebuild` | 1 | Throw-off path uses SUM rebuild (A6 regression) |
| `TestJsonBoundaryFloatCast` | 4 | jsonify smoke test on live data |

### `tests/test_scoring_college_points.py` + `tests/test_point_calculator.py`

5 pre-existing tests asserted the V2.7.0 wrong tie behavior. Updated to the correct AWFC values:

| Test | Was | Now |
|---|---|---|
| `test_tied_for_first` | 10 each | `Decimal('8.50')` each |
| `test_tied_for_second` | 7 each | `Decimal('6.00')` each |
| `test_stock_saw_m_real_tie` | 10 each | `Decimal('8.50')` each |
| `test_stock_saw_m_with_tie` | 10 each | `Decimal('8.50')` each |
| `test_tied_competitors_both_get_same_points` (renamed) | 10 each | `Decimal('8.50')` each |

## Verification

```
Local DB at HEAD f0a1b2c3d4e6 (Phase 1, no new migration)

pytest tests/test_split_tie_scoring.py
  → 21 passed in 1.09s

pytest (full suite)
  → 2162 passed, 4 skipped, 0 failed
  (Phase 2 baseline 2141 + 21 new tests)

ruff check .
  → All checks passed!
```

## What this PR does NOT do

- **Phase 4**: heat undo strip + savepoint + admin repair route + DNF team recalc.
- **Phase 5**: Bull/Belle multi-key tiebreak (1st-place count, etc).
- **Hard-Hit `tiebreak_value`** stays single-judge per scope.
- **Pro payouts on tie**: tied pro competitors still each get the full payout for the shared position. Splitting pro payouts is a separate business call, out of scope for V2.8.0.

## Test plan

- [x] CI lint + pip-audit + postgres-smoke + test (must all pass)
- [ ] Merge → Railway preDeployCommand runs `flask db upgrade` (no migrations to apply, exits 0)
- [ ] Read deploy logs via Railway CLI → confirm alembic ran cleanly with no upgrade lines
- [ ] `/health` returns `status:ok` with `migration_rev:f0a1b2c3d4e6` (unchanged)
- [ ] Spot-check production: open any college event with results → finalize → confirm no TypeError on the preview modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)