### PR TITLE
fix(migrations): update env.py _compare_server_default to 6-arg signature

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -28,14 +28,25 @@ def _compare_type(context, inspected_column, metadata_column, inspected_type, me
     return False
 
 
-def _compare_server_default(context, inspected_column, metadata_column, inspected_default, metadata_default):
+def _compare_server_default(context, inspected_column, metadata_column,
+                            inspected_default, metadata_default,
+                            rendered_metadata_default):
     """Suppress server_default diffs on SQLite.
 
     SQLite reports defaults differently than PostgreSQL (e.g. '0' vs
     "'0'" vs "false").  Auto-detecting these diffs produces false positives
     that get committed as unintended alter_column calls.
 
+    The 6-parameter signature matches modern Alembic (>=1.5).  This was
+    previously a 5-parameter version which crashed `flask db migrate` with
+    "TypeError: _compare_server_default() takes 5 positional arguments but
+    6 were given" — meaning every developer in this codebase had to either
+    pin Alembic to an ancient version or hand-write migrations.  Both Phase
+    1A and Phase 1B of the V2.8.0 scoring fix were hand-written for exactly
+    this reason.  Fixed in V2.8.1 (tech debt #9).
+
     Return False = "defaults match, skip this diff".
+    Return None  = "use default comparison".
     """
     # On SQLite, always suppress — too many false positives.
     if context.connection.dialect.name == 'sqlite':


### PR DESCRIPTION
## Summary

Fixes Open Tech Debt #9 from MEMORY.md. One-line change to `migrations/env.py` that makes \`flask db migrate\` actually work in this codebase.

## Why

Modern Alembic (>=1.5) passes **6** positional arguments to user-defined `compare_server_default` callbacks:

```python
def my_compare_server_default(context, inspected_column,
            metadata_column, inspected_default, metadata_default,
            rendered_metadata_default):
```

The hook in `migrations/env.py` was stuck on the OLD 5-arg signature, which crashed `flask db migrate` with:

```
TypeError: _compare_server_default() takes 5 positional arguments but 6 were given
```

This made auto-generated migrations impossible in this codebase. Every developer had to either pin Alembic to an ancient version or hand-write migrations. **V2.8.0 Phase 1A and Phase 1B were both hand-written for exactly this reason** — see PR #16 commit body for the call-out.

## What changed

`migrations/env.py` — `_compare_server_default` now accepts the 6th `rendered_metadata_default` argument. Function body unchanged; same SQLite-vs-Postgres suppression logic.

## Verification

```
flask db migrate -m "noop test"
  → produces a candidate migration file (no longer crashes)
  → the detected drift in that file is exactly the KNOWN_NULLABLE_DRIFT
    list from test_migration_integrity.py, which is tech debt #8

pytest tests/test_migration_integrity.py tests/test_pg_migration_safety.py tests/test_postgres_compat.py
  → 63 passed, 2 skipped (no regression)

pytest (full suite)
  → 2182 passed, 4 skipped, 0 failed

ruff check .
  → All checks passed!
```

## Next up

**Tech debt #8** — with `flask db migrate` now functional, we can iterate on the 40 nullable + 16 server_default drift entries in `KNOWN_NULLABLE_DRIFT` and `KNOWN_SERVER_DEFAULT_DRIFT`, generating real fix-up migrations for each batch. That work lands in separate PRs.

## Test plan

- [x] CI lint + pip-audit + postgres-smoke + test (must all pass)
- [ ] Merge → Railway preDeployCommand runs alembic (no migrations to apply)
- [ ] `/health` returns `status:ok` with `migration_rev:f0a1b2c3d4e6` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)