### PR TITLE
Fix server-default schema drift and remove migration carveouts

### DIFF
--- a/migrations/versions/d3e4f5a6b7c8_fix_server_default_drift.py
+++ b/migrations/versions/d3e4f5a6b7c8_fix_server_default_drift.py
@@ -1,0 +1,53 @@
+"""Fix server-default drift for handicap_factor.
+
+Revision ID: d3e4f5a6b7c8
+Revises: c2d3e4f5a6b7
+Create Date: 2026-04-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'd3e4f5a6b7c8'
+down_revision = 'c2d3e4f5a6b7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'sqlite':
+        with op.batch_alter_table('event_results') as batch_op:
+            batch_op.alter_column(
+                'handicap_factor',
+                existing_type=sa.Float(),
+                server_default='0.0',
+            )
+        return
+
+    op.alter_column(
+        'event_results',
+        'handicap_factor',
+        existing_type=sa.Float(),
+        server_default='0.0',
+    )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name == 'sqlite':
+        with op.batch_alter_table('event_results') as batch_op:
+            batch_op.alter_column(
+                'handicap_factor',
+                existing_type=sa.Float(),
+                server_default='1.0',
+            )
+        return
+
+    op.alter_column(
+        'event_results',
+        'handicap_factor',
+        existing_type=sa.Float(),
+        server_default='1.0',
+    )

--- a/models/competitor.py
+++ b/models/competitor.py
@@ -49,7 +49,9 @@ class CollegeCompetitor(db.Model):
 
     # Headshot and SMS (#14, #2)
     headshot_filename = db.Column(db.Text, nullable=True)
-    phone_opted_in = db.Column(db.Boolean, nullable=False, default=False)
+    phone_opted_in = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # Status
     status = db.Column(db.String(20), nullable=False, default='active')  # active, scratched
@@ -226,7 +228,9 @@ class ProCompetitor(db.Model):
 
     # Springboard specific
     is_left_handed_springboard = db.Column(db.Boolean, nullable=False, default=False)
-    springboard_slow_heat = db.Column(db.Boolean, nullable=False, default=False)
+    springboard_slow_heat = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.false()
+    )
 
     # Event and fee tracking - stored as JSON
     events_entered = db.Column(db.Text, nullable=False, default='[]')  # List of event IDs
@@ -238,11 +242,15 @@ class ProCompetitor(db.Model):
 
     # Earnings
     total_earnings = db.Column(db.Float, nullable=False, default=0.0)
-    payout_settled = db.Column(db.Boolean, nullable=False, default=False)  # #21 payout settlement checklist
+    payout_settled = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )  # #21 payout settlement checklist
 
     # Headshot and SMS (#14, #2)
     headshot_filename = db.Column(db.Text, nullable=True)
-    phone_opted_in = db.Column(db.Boolean, nullable=False, default=False)
+    phone_opted_in = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # Status
     status = db.Column(db.String(20), nullable=False, default='active')  # active, scratched

--- a/models/event.py
+++ b/models/event.py
@@ -32,7 +32,9 @@ class Event(db.Model):
     is_open = db.Column(db.Boolean, nullable=False, default=False)  # True = OPEN event, False = CLOSED
 
     # Competition format (underhand, standing block, springboard only)
-    is_handicap = db.Column(db.Boolean, nullable=False, default=False)  # False = Championship, True = Handicap
+    is_handicap = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )  # False = Championship, True = Handicap
 
     # Event characteristics
     is_partnered = db.Column(db.Boolean, nullable=False, default=False)
@@ -44,7 +46,9 @@ class Event(db.Model):
     requires_dual_runs = db.Column(db.Boolean, nullable=False, default=False)
     # requires_triple_runs: three throw inputs in a single heat; sum counts.
     #   Used by: Axe Throw, Partnered Axe Throw. Tie detected → throw-off required.
-    requires_triple_runs = db.Column(db.Boolean, nullable=False, default=False)
+    requires_triple_runs = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # Stand configuration
     stand_type = db.Column(db.String(50), nullable=True)
@@ -67,7 +71,9 @@ class Event(db.Model):
 
     # Explicit finalization lock — set True after _calculate_positions() succeeds.
     # Editing a result on a finalized event resets this to False, requiring re-finalization.
-    is_finalized = db.Column(db.Boolean, nullable=False, default=False)
+    is_finalized = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # Relationships
     heats = db.relationship('Heat', backref='event', lazy='dynamic', cascade='all, delete-orphan')
@@ -194,13 +200,17 @@ class EventResult(db.Model):
 
     # Throw-off flag — set True when the system detects a cumulative-score tie on axe throw.
     # Judge must record throw-off positions before is_finalized can be set True.
-    throwoff_pending = db.Column(db.Boolean, nullable=False, default=False)
+    throwoff_pending = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # STRATHMARK handicap start mark in seconds.
     # _metric() in scoring_engine subtracts this from raw time when event.is_handicap is True
     # and scoring_type == 'time'.  Default 0.0 means scratch (no start mark).
     # Populated by services/mark_assignment.py → assign_handicap_marks().
-    handicap_factor = db.Column(db.Float, nullable=False, default=0.0)
+    handicap_factor = db.Column(
+        db.Float, nullable=False, default=0.0, server_default=sa.text("'0.0'")
+    )
 
     # STRATHMARK predicted completion time in seconds — the raw time HandicapCalculator
     # expected this competitor to post.  Stored here so that after the event runs,
@@ -238,7 +248,9 @@ class EventResult(db.Model):
     )
 
     # Score discrepancy flag
-    is_flagged = db.Column(db.Boolean, nullable=False, default=False)
+    is_flagged = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # Status — allowed values: pending, completed, scratched, dnf, dq, partial
     # 'dq' (disqualified) was added alongside 'status_reason' so judges can record
@@ -247,7 +259,9 @@ class EventResult(db.Model):
     # explanation for any non-completion state.
     status = db.Column(db.String(20), nullable=False, default='pending')
     status_reason = db.Column(db.Text, nullable=True)
-    version_id = db.Column(db.Integer, nullable=False, default=1)
+    version_id = db.Column(
+        db.Integer, nullable=False, default=1, server_default=sa.text("'1'")
+    )
 
     __mapper_args__ = {
         'version_id_col': version_id,

--- a/models/heat.py
+++ b/models/heat.py
@@ -4,6 +4,8 @@ Heat and Flight models for scheduling competition runs.
 import json
 from datetime import datetime, timezone
 
+import sqlalchemy as sa
+
 from config import HEAT_LOCK_TTL_SECONDS  # noqa: F401 — single source in config.py
 from database import db
 
@@ -46,7 +48,9 @@ class Heat(db.Model):
 
     # Status
     status = db.Column(db.String(20), nullable=False, default='pending')  # pending, in_progress, completed
-    version_id = db.Column(db.Integer, nullable=False, default=1)
+    version_id = db.Column(
+        db.Integer, nullable=False, default=1, server_default=sa.text("'1'")
+    )
 
     __mapper_args__ = {
         'version_id_col': version_id,

--- a/models/payout_template.py
+++ b/models/payout_template.py
@@ -4,6 +4,8 @@ PayoutTemplate model — reusable payout structures for pro events.
 import json
 from datetime import datetime, timezone
 
+import sqlalchemy as sa
+
 from database import db
 
 
@@ -15,7 +17,9 @@ class PayoutTemplate(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False, unique=True)
     # JSON dict: {"1": 500.0, "2": 300.0, ...}
-    payouts = db.Column(db.Text, nullable=False, default='{}')
+    payouts = db.Column(
+        db.Text, nullable=False, default='{}', server_default=sa.text("'{}'")
+    )
     created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
 
     def __repr__(self):

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -3,6 +3,8 @@ Tournament model for managing overall tournament state.
 """
 from datetime import datetime
 
+import sqlalchemy as sa
+
 from config import TournamentStatus  # noqa: F401 — re-exported for convenience
 from database import db
 
@@ -25,7 +27,9 @@ class Tournament(db.Model):
     status = db.Column(db.String(50), nullable=False, default=TournamentStatus.SETUP)
 
     # Shirt logistics — True when the show provides shirts; controls shirt-size collection on pro entry
-    providing_shirts = db.Column(db.Boolean, nullable=False, default=False)
+    providing_shirts = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
 
     # Schedule config — persists friday_pro_event_ids / saturday_college_event_ids across sessions
     schedule_config = db.Column(db.Text, nullable=True)

--- a/models/user.py
+++ b/models/user.py
@@ -3,6 +3,8 @@ User model for role-based authentication.
 """
 from datetime import datetime
 
+import sqlalchemy as sa
+
 try:
     from flask_login import UserMixin
 except ModuleNotFoundError:
@@ -45,7 +47,9 @@ class User(UserMixin, db.Model):
     competitor_id = db.Column(db.Integer, nullable=True)
 
     display_name = db.Column(db.String(200), nullable=True)
-    is_active_user = db.Column(db.Boolean, nullable=False, default=True)
+    is_active_user = db.Column(
+        db.Boolean, nullable=False, default=True, server_default=sa.true()
+    )
 
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)

--- a/tests/test_migration_integrity.py
+++ b/tests/test_migration_integrity.py
@@ -369,8 +369,6 @@ class TestMigrationIntegrity:
                     continue
                 if mod_info['pk']:
                     continue  # PK is always NOT NULL
-                if (table, col) in self.KNOWN_NULLABLE_DRIFT:
-                    continue  # historical drift, tracked separately
                 mig_info = self.migration_detail[table][col]
                 model_notnull = mod_info['notnull']
                 mig_notnull = mig_info['notnull']
@@ -416,6 +414,7 @@ class TestMigrationIntegrity:
         ('users', 'is_active_user'),
         ('wood_configs', 'size_unit'),
     }
+    KNOWN_SERVER_DEFAULT_DRIFT = set()
 
     def test_server_default_parity(self):
         """Server defaults from migrations must match those from db.create_all().
@@ -435,8 +434,6 @@ class TestMigrationIntegrity:
                     continue
                 if mod_info['pk']:
                     continue
-                if (table, col) in self.KNOWN_SERVER_DEFAULT_DRIFT:
-                    continue  # historical drift, tracked separately
                 mig_info = self.migration_detail[table][col]
                 mod_default = mod_info['default']
                 mig_default = mig_info['default']


### PR DESCRIPTION
## Summary
Align DB-level server defaults with model declarations and remove the remaining migration integrity carveouts.

## Scope
- resolve `KNOWN_SERVER_DEFAULT_DRIFT`
- add model `server_default=` where DB default is canonical
- correct the one migration-side default that was inconsistent with the model (`event_results.handicap_factor`)
- remove temporary skip logic from migration integrity tests

## Validation
- `pytest tests/test_migration_integrity.py::TestMigrationIntegrity -q`
- `pytest tests/test_pg_migration_safety.py -q`
- `ruff check .`

## Done when
- both allowlists are empty
- no `historical drift` skips remain
- integrity tests pass without carveouts

Closes #8.