### PR TITLE
Harden admin audit coverage for critical operations

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -254,6 +254,11 @@ def toggle_user_active(user_id):
 
     user = User.query.get_or_404(user_id)
     if user.id == current_user.id:
+        log_action('user_toggle_active_denied', 'user', user.id, {
+            'reason': 'self_disable_attempt',
+            'active': user.is_active_user,
+        })
+        db.session.commit()
         flash('You cannot disable your own account.', 'error')
         return redirect(url_for('auth.manage_users'))
 

--- a/routes/main.py
+++ b/routes/main.py
@@ -14,6 +14,7 @@ from config import TournamentStatus
 from database import db
 from models import Event, Flight, Heat, HeatAssignment, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
+from services.audit import log_action
 
 try:
     from flask_login import current_user
@@ -28,6 +29,13 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for stripped environm
 logger = logging.getLogger(__name__)
 
 main_bp = Blueprint('main', __name__)
+
+
+def _date_value(value):
+    """Return an ISO date string for audit payloads."""
+    if value is None:
+        return None
+    return value.isoformat()
 
 
 @main_bp.route('/health')
@@ -265,6 +273,13 @@ def new_tournament():
             status='setup'
         )
         db.session.add(tournament)
+        db.session.flush()
+        log_action('tournament_created', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'name': tournament.name,
+            'year': tournament.year,
+            'status': tournament.status,
+        })
         db.session.commit()
 
         flash(text.FLASH['tournament_created'].format(name=name, year=year), 'success')
@@ -411,6 +426,15 @@ def save_tournament_settings(tournament_id):
     # Shirt logistics checkbox — present in form means True
     tournament.providing_shirts = bool(request.form.get('providing_shirts'))
 
+    log_action('tournament_settings_updated', 'tournament', tournament.id, {
+        'tournament_id': tournament.id,
+        'name': tournament.name,
+        'year': tournament.year,
+        'college_date': _date_value(tournament.college_date),
+        'pro_date': _date_value(tournament.pro_date),
+        'friday_feature_date': _date_value(tournament.friday_feature_date),
+        'providing_shirts': tournament.providing_shirts,
+    })
     db.session.commit()
     flash('Tournament settings saved.', 'success')
     return redirect(url_for('main.tournament_setup', tournament_id=tournament_id, tab='settings'))
@@ -423,11 +447,26 @@ def activate_competition(tournament_id, competition_type):
 
     if competition_type == 'college':
         tournament.status = TournamentStatus.COLLEGE_ACTIVE
+        log_action('competition_activated', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'competition_type': competition_type,
+            'status': tournament.status,
+        })
         flash(text.FLASH['college_active'], 'success')
     elif competition_type == 'pro':
         tournament.status = TournamentStatus.PRO_ACTIVE
+        log_action('competition_activated', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'competition_type': competition_type,
+            'status': tournament.status,
+        })
         flash(text.FLASH['pro_active'], 'success')
     else:
+        log_action('competition_activation_rejected', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'competition_type': competition_type,
+            'reason': 'invalid_competition_type',
+        })
         flash(text.FLASH['invalid_comp_type'], 'error')
 
     db.session.commit()
@@ -442,6 +481,12 @@ def delete_tournament(tournament_id):
     confirmation = request.form.get('confirm_delete', '').strip()
 
     if confirmation != 'DELETE':
+        log_action('tournament_delete_denied', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'name': tournament_name,
+            'reason': 'confirmation_mismatch',
+        })
+        db.session.commit()
         flash(f'Deletion cancelled for "{tournament_name}". Type DELETE to confirm.', 'warning')
         return redirect(url_for('main.judge_dashboard'))
 
@@ -462,11 +507,21 @@ def delete_tournament(tournament_id):
             )
             Flight.query.filter(Flight.id.in_(flight_ids)).delete(synchronize_session=False)
 
+        log_action('tournament_deleted', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'name': tournament_name,
+        })
         db.session.delete(tournament)
         db.session.commit()
         flash(f'Deleted tournament: {tournament_name}', 'success')
     except Exception as exc:
         db.session.rollback()
+        log_action('tournament_delete_failed', 'tournament', tournament_id, {
+            'tournament_id': tournament_id,
+            'name': tournament_name,
+            'error': str(exc),
+        })
+        db.session.commit()
         flash(f'Could not delete tournament "{tournament_name}": {exc}', 'error')
 
     return redirect(url_for('main.judge_dashboard'))
@@ -647,12 +702,12 @@ def clone_tournament(tournament_id):
         )
         db.session.add(new_event)
 
-    db.session.commit()
-    from services.audit import log_action
     log_action('tournament_cloned', 'tournament', new_tournament.id, {
+        'tournament_id': new_tournament.id,
         'source_id': source.id,
         'source_name': source.name,
     })
+    db.session.commit()
     flash(f'Tournament cloned as "{new_tournament.name}". Update the name and dates before use.', 'success')
     return redirect(url_for('main.tournament_detail', tournament_id=new_tournament.id))
 

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -289,6 +289,12 @@ def export_results(tournament_id):
     fd, path = tempfile.mkstemp(prefix=f'proam_{tournament_id}_', suffix='.xlsx')
     os.close(fd)
     export_results_to_excel(tournament, path)
+    log_action('report_export_downloaded', 'tournament', tournament.id, {
+        'tournament_id': tournament.id,
+        'format': 'xlsx',
+        'kind': 'all_results',
+    })
+    db.session.commit()
 
     @after_this_request
     def cleanup_file(response):
@@ -313,11 +319,23 @@ def export_chopping_results(tournament_id):
             'tournament': {'id': tournament.id, 'name': tournament.name, 'year': tournament.year},
             'rows': build_chopping_rows(tournament),
         }
+        log_action('report_export_downloaded', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'format': 'json',
+            'kind': 'chopping_results',
+        })
+        db.session.commit()
         return Response(json.dumps(payload), mimetype='application/json')
 
     fd, path = tempfile.mkstemp(prefix=f'proam_{tournament_id}_chopping_', suffix='.xlsx')
     os.close(fd)
     export_chopping_results_to_excel(tournament, path)
+    log_action('report_export_downloaded', 'tournament', tournament.id, {
+        'tournament_id': tournament.id,
+        'format': 'xlsx',
+        'kind': 'chopping_results',
+    })
+    db.session.commit()
 
     @after_this_request
     def cleanup_file(response):
@@ -483,6 +501,13 @@ def restore_database(tournament_id):
         db.session.commit()
         flash('Database restore complete.', 'success')
     except Exception as exc:
+        db.session.rollback()
+        log_action('database_restore_failed', 'tournament', tournament_id, {
+            'tournament_id': tournament_id,
+            'filename': f.filename,
+            'error': str(exc),
+        })
+        db.session.commit()
         flash(f'Database restore failed: {exc}', 'error')
     finally:
         try:
@@ -760,6 +785,11 @@ def ala_membership_report_pdf(tournament_id):
         return response
 
     from datetime import datetime
+    log_action('ala_report_downloaded', 'tournament', tournament.id, {
+        'tournament_id': tournament.id,
+        'format': 'pdf',
+    })
+    db.session.commit()
     download_name = f'ala_report_{datetime.now().strftime("%Y%m%d")}.pdf'
     return send_file(path, as_attachment=True, download_name=download_name)
 
@@ -786,8 +816,20 @@ def ala_email_report(tournament_id):
 
     try:
         _send_ala_email(path, tournament, report)
+        log_action('ala_report_emailed', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'recipient': ALA_EMAIL,
+        })
+        db.session.commit()
         flash(f'ALA report emailed to {ALA_EMAIL}.', 'success')
     except Exception as exc:
+        db.session.rollback()
+        log_action('ala_report_email_failed', 'tournament', tournament.id, {
+            'tournament_id': tournament.id,
+            'recipient': ALA_EMAIL,
+            'error': str(exc),
+        })
+        db.session.commit()
         flash(f'Email failed: {exc}', 'error')
     finally:
         try:

--- a/tests/test_admin_audit_hardening.py
+++ b/tests/test_admin_audit_hardening.py
@@ -1,0 +1,189 @@
+import io
+import json
+import os
+import tempfile
+
+from models.audit_log import AuditLog
+from models.user import User
+from routes import reporting as reporting_routes
+from tests.conftest import make_tournament
+
+
+def _login_as(client, user_id: int) -> None:
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+
+
+def _make_user(db_session, username: str, role: str = 'admin') -> User:
+    user = User(username=username, role=role)
+    user.set_password('testpass123')
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def _make_logged_in_client(app, db_session, username: str, role: str = 'admin'):
+    client = app.test_client()
+    user = _make_user(db_session, username=username, role=role)
+    _login_as(client, user.id)
+    return client, user
+
+
+def test_clone_tournament_writes_audit_log(app, db_session):
+    client, _admin = _make_logged_in_client(app, db_session, 'clone_admin')
+    tournament = make_tournament(db_session, name='Source Tournament', year=2026)
+
+    response = client.post(f'/tournament/{tournament.id}/clone', follow_redirects=False)
+
+    assert response.status_code == 302
+    entry = (
+        AuditLog.query
+        .filter_by(action='tournament_cloned')
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert entry is not None
+    details = json.loads(entry.details_json)
+    assert details['source_id'] == tournament.id
+    assert details['source_name'] == 'Source Tournament'
+
+
+def test_tournament_settings_update_writes_audit_log(app, db_session):
+    client, _admin = _make_logged_in_client(app, db_session, 'settings_admin')
+    tournament = make_tournament(db_session, name='Before Name', year=2025)
+
+    response = client.post(
+        f'/tournament/{tournament.id}/setup/settings',
+        data={
+            'name': 'After Name',
+            'year': '2026',
+            'college_date': '2026-05-01',
+            'pro_date': '2026-05-02',
+            'providing_shirts': '1',
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    entry = (
+        AuditLog.query
+        .filter_by(action='tournament_settings_updated', entity_id=tournament.id)
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert entry is not None
+    details = json.loads(entry.details_json)
+    assert details['name'] == 'After Name'
+    assert details['year'] == 2026
+    assert details['college_date'] == '2026-05-01'
+    assert details['pro_date'] == '2026-05-02'
+    assert details['providing_shirts'] is True
+
+
+def test_self_disable_attempt_is_audited(app, db_session):
+    client, admin_user = _make_logged_in_client(app, db_session, 'self_disable_admin')
+    tournament = make_tournament(db_session)
+
+    response = client.post(
+        f'/auth/users/{admin_user.id}/toggle-active',
+        data={'tournament_id': tournament.id},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    entry = (
+        AuditLog.query
+        .filter_by(action='user_toggle_active_denied', entity_id=admin_user.id)
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert entry is not None
+    details = json.loads(entry.details_json)
+    assert details['reason'] == 'self_disable_attempt'
+
+
+def test_restore_failure_writes_audit_log(app, db_session):
+    client, _admin = _make_logged_in_client(app, db_session, 'restore_admin')
+    tournament = make_tournament(db_session)
+    db_session.commit()
+
+    response = client.post(
+        f'/reporting/{tournament.id}/restore',
+        data={'backup_file': (io.BytesIO(b'SQLite format 3\x00broken payload'), 'broken.db')},
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    entry = (
+        AuditLog.query
+        .filter_by(action='database_restore_failed', entity_id=tournament.id)
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert entry is not None
+    details = json.loads(entry.details_json)
+    assert details['filename'] == 'broken.db'
+    assert details['error']
+
+
+def test_ala_email_success_writes_audit_log(app, db_session, monkeypatch):
+    client, _admin = _make_logged_in_client(app, db_session, 'ala_admin')
+    tournament = make_tournament(db_session)
+    db_session.commit()
+    fd, pdf_path = tempfile.mkstemp(prefix='ala-report-', suffix='.pdf')
+    os.close(fd)
+    with open(pdf_path, 'wb') as handle:
+        handle.write(b'%PDF-1.4\n%test\n')
+
+    from services import ala_report as ala_report_module
+
+    monkeypatch.setattr(
+        ala_report_module,
+        'build_ala_report',
+        lambda _tournament: {
+            'all_attendees': [],
+            'non_members': [],
+            'generated_at': '2026-04-20T12:00:00Z',
+            'year': tournament.year,
+        },
+    )
+    monkeypatch.setattr(ala_report_module, 'generate_ala_pdf', lambda _report: str(pdf_path))
+    monkeypatch.setattr(reporting_routes, '_send_ala_email', lambda *_args, **_kwargs: None)
+
+    try:
+        response = client.post(
+            f'/reporting/ala-membership-report/{tournament.id}/email',
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        entry = (
+            AuditLog.query
+            .filter_by(action='ala_report_emailed', entity_id=tournament.id)
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert entry is not None
+        details = json.loads(entry.details_json)
+        assert details['recipient'] == reporting_routes.ALA_EMAIL
+    finally:
+        try:
+            os.remove(pdf_path)
+        except OSError:
+            pass
+
+
+def test_judge_cannot_restore_database(app, db_session, judge_user):
+    tournament = make_tournament(db_session)
+    client = app.test_client()
+    _login_as(client, judge_user.id)
+
+    response = client.post(
+        f'/reporting/{tournament.id}/restore',
+        data={'backup_file': (io.BytesIO(b'SQLite format 3\x00broken payload'), 'broken.db')},
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- write audit entries for tournament lifecycle changes, including create, settings updates, activation, delete, and clone
- record denied self-disable attempts in user management so operator mistakes are attributable
- add failure/success audit coverage for restore and ALA report email/download paths, plus export downloads
- add focused regression tests for the new audit trail and admin-only restore guard

## Validation
- python -m pytest tests/test_admin_audit_hardening.py -q
- python -m pytest tests/test_route_smoke_qa.py::TestMainRoutes::test_smoke_main_tournament_detail -q
- uff check .
