### PR TITLE
Persist background job state for operator visibility

### DIFF
--- a/database.py
+++ b/database.py
@@ -21,6 +21,7 @@ def init_db(app):
     # Import all models to register them with SQLAlchemy
     from models import (
         AuditLog,
+        BackgroundJob,
         CollegeCompetitor,
         Event,
         EventResult,

--- a/migrations/versions/e4f5a6b7c8d9_add_background_jobs_table.py
+++ b/migrations/versions/e4f5a6b7c8d9_add_background_jobs_table.py
@@ -1,0 +1,42 @@
+"""Add durable background job records.
+
+Revision ID: e4f5a6b7c8d9
+Revises: d3e4f5a6b7c8
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'e4f5a6b7c8d9'
+down_revision = 'd3e4f5a6b7c8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'background_jobs',
+        sa.Column('id', sa.String(length=32), nullable=False),
+        sa.Column('label', sa.String(length=120), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('tournament_id', sa.Integer(), nullable=True),
+        sa.Column('submitted_at', sa.DateTime(), nullable=False),
+        sa.Column('started_at', sa.DateTime(), nullable=True),
+        sa.Column('finished_at', sa.DateTime(), nullable=True),
+        sa.Column('result_json', sa.Text(), nullable=True),
+        sa.Column('error_text', sa.Text(), nullable=True),
+        sa.Column('metadata_json', sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_background_jobs_status', 'background_jobs', ['status'])
+    op.create_index('ix_background_jobs_submitted_at', 'background_jobs', ['submitted_at'])
+    op.create_index('ix_background_jobs_tournament_id', 'background_jobs', ['tournament_id'])
+
+
+def downgrade():
+    op.drop_index('ix_background_jobs_tournament_id', table_name='background_jobs')
+    op.drop_index('ix_background_jobs_submitted_at', table_name='background_jobs')
+    op.drop_index('ix_background_jobs_status', table_name='background_jobs')
+    op.drop_table('background_jobs')

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,6 +2,7 @@
 SQLAlchemy models for the Missoula Pro Am Tournament Manager.
 """
 from .audit_log import AuditLog
+from .background_job import BackgroundJob
 from .competitor import CollegeCompetitor, ProCompetitor
 from .event import Event, EventResult
 from .heat import Flight, Heat, HeatAssignment
@@ -25,6 +26,7 @@ __all__ = [
     'Flight',
     'User',
     'AuditLog',
+    'BackgroundJob',
     'SchoolCaptain',
     'WoodConfig',
     'ProEventRank',

--- a/models/background_job.py
+++ b/models/background_job.py
@@ -1,0 +1,26 @@
+"""Durable record of async background job execution."""
+from datetime import datetime
+
+from database import db
+
+
+class BackgroundJob(db.Model):
+    """Persisted job status for operator visibility across process restarts."""
+
+    __tablename__ = 'background_jobs'
+    __table_args__ = (
+        db.Index('ix_background_jobs_status', 'status'),
+        db.Index('ix_background_jobs_submitted_at', 'submitted_at'),
+        db.Index('ix_background_jobs_tournament_id', 'tournament_id'),
+    )
+
+    id = db.Column(db.String(32), primary_key=True)
+    label = db.Column(db.String(120), nullable=False)
+    status = db.Column(db.String(20), nullable=False)
+    tournament_id = db.Column(db.Integer, nullable=True)
+    submitted_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    started_at = db.Column(db.DateTime, nullable=True)
+    finished_at = db.Column(db.DateTime, nullable=True)
+    result_json = db.Column(db.Text, nullable=True)
+    error_text = db.Column(db.Text, nullable=True)
+    metadata_json = db.Column(db.Text, nullable=True)

--- a/services/background_jobs.py
+++ b/services/background_jobs.py
@@ -1,10 +1,14 @@
 """In-process background job execution for long-running tasks."""
 from __future__ import annotations
 
+import json
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+
+from database import db
+from models.background_job import BackgroundJob
 
 _executor = ThreadPoolExecutor(max_workers=2)
 _jobs = {}
@@ -21,7 +25,8 @@ def configure(max_workers: int, app=None) -> None:
     except TypeError:
         _executor.shutdown(wait=False)
     _executor = ThreadPoolExecutor(max_workers=max_workers)
-    _app = app
+    if app is not None:
+        _app = app
 
 
 def _run_with_app_context(fn, *args, **kwargs):
@@ -31,19 +36,111 @@ def _run_with_app_context(fn, *args, **kwargs):
         return fn(*args, **kwargs)
 
 
+def _serialize_json(value):
+    if value is None:
+        return None
+    try:
+        return json.dumps(value)
+    except TypeError:
+        return json.dumps(str(value))
+
+
+def _deserialize_json(value):
+    if not value:
+        return None
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+
+
+def _persist_job(
+    job_id: str,
+    *,
+    label: str | None = None,
+    status: str | None = None,
+    submitted_at: datetime | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+    result=None,
+    error: str | None = None,
+    metadata: dict | None = None,
+):
+    if _app is None:
+        return
+
+    with _app.app_context():
+        row = db.session.get(BackgroundJob, job_id)
+        if row is None:
+            row = BackgroundJob(id=job_id)
+            db.session.add(row)
+        if label is not None:
+            row.label = label
+        if status is not None:
+            row.status = status
+        if submitted_at is not None:
+            row.submitted_at = submitted_at
+        if started_at is not None:
+            row.started_at = started_at
+        if finished_at is not None:
+            row.finished_at = finished_at
+        if error is not None:
+            row.error_text = error
+        if metadata is not None:
+            row.metadata_json = _serialize_json(metadata)
+            row.tournament_id = (metadata or {}).get('tournament_id')
+        if result is not None:
+            row.result_json = _serialize_json(result)
+        db.session.commit()
+
+
+def _snapshot(job: dict) -> dict:
+    return {
+        'id': job['id'],
+        'label': job['label'],
+        'status': job['status'],
+        'submitted_at': job['submitted_at'],
+        'finished_at': job['finished_at'],
+        'result': job['result'],
+        'error': job['error'],
+        'metadata': dict(job.get('metadata') or {}),
+    }
+
+
+def _row_to_dict(row: BackgroundJob) -> dict:
+    return {
+        'id': row.id,
+        'label': row.label,
+        'status': row.status,
+        'submitted_at': row.submitted_at,
+        'finished_at': row.finished_at,
+        'result': _deserialize_json(row.result_json),
+        'error': row.error_text,
+        'metadata': _deserialize_json(row.metadata_json) or {},
+    }
+
+
 def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str:
     job_id = uuid.uuid4().hex
+    submitted_at = datetime.utcnow()
     with _lock:
         _jobs[job_id] = {
             'id': job_id,
             'label': label,
             'status': 'queued',
-            'submitted_at': datetime.utcnow(),
+            'submitted_at': submitted_at,
             'finished_at': None,
             'result': None,
             'error': None,
             'metadata': dict(metadata or {}),
         }
+    _persist_job(
+        job_id,
+        label=label,
+        status='queued',
+        submitted_at=submitted_at,
+        metadata=dict(metadata or {}),
+    )
 
     future = _executor.submit(_run_with_app_context, fn, *args, **kwargs)
 
@@ -59,10 +156,21 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
                 job['status'] = 'failed'
                 job['error'] = str(exc)
             job['finished_at'] = datetime.utcnow()
+            snapshot = _snapshot(job)
+        _persist_job(
+            job_id,
+            status=snapshot['status'],
+            finished_at=snapshot['finished_at'],
+            result=snapshot['result'],
+            error=snapshot['error'],
+        )
 
     with _lock:
         _jobs[job_id]['status'] = 'running'
         _jobs[job_id]['future'] = future
+        started_at = datetime.utcnow()
+        _jobs[job_id]['started_at'] = started_at
+    _persist_job(job_id, status='running', started_at=started_at)
 
     future.add_done_callback(_done_callback)
     return job_id
@@ -71,38 +179,32 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
 def get(job_id: str) -> dict | None:
     with _lock:
         job = _jobs.get(job_id)
-        if not job:
+        if job:
+            return _snapshot(job)
+    if _app is None:
+        return None
+    with _app.app_context():
+        row = db.session.get(BackgroundJob, job_id)
+        if row is None:
             return None
-        return {
-            'id': job['id'],
-            'label': job['label'],
-            'status': job['status'],
-            'submitted_at': job['submitted_at'],
-            'finished_at': job['finished_at'],
-            'result': job['result'],
-            'error': job['error'],
-            'metadata': dict(job.get('metadata') or {}),
-        }
+        return _row_to_dict(row)
 
 
 def list_recent(limit: int = 20) -> list[dict]:
     """Return the most recent jobs first for operator diagnostics."""
     if limit < 1:
         return []
+    if _app is not None:
+        with _app.app_context():
+            rows = (
+                BackgroundJob.query
+                .order_by(BackgroundJob.submitted_at.desc())
+                .limit(limit)
+                .all()
+            )
+            return [_row_to_dict(row) for row in rows]
     with _lock:
-        rows = [
-            {
-                'id': job['id'],
-                'label': job['label'],
-                'status': job['status'],
-                'submitted_at': job['submitted_at'],
-                'finished_at': job['finished_at'],
-                'result': job['result'],
-                'error': job['error'],
-                'metadata': dict(job.get('metadata') or {}),
-            }
-            for job in _jobs.values()
-        ]
+        rows = [_snapshot(job) for job in _jobs.values()]
     rows.sort(
         key=lambda job: job.get('submitted_at') or datetime.min,
         reverse=True,

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -250,6 +250,12 @@ class TestBackgroundJobs:
         from services import background_jobs
         with background_jobs._lock:
             background_jobs._jobs.clear()
+        app = getattr(background_jobs, '_app', None)
+        if app is not None:
+            from models.background_job import BackgroundJob
+            with app.app_context():
+                BackgroundJob.query.delete()
+                background_jobs.db.session.commit()
 
     def test_submit_returns_job_id_string(self):
         from services.background_jobs import submit
@@ -348,6 +354,19 @@ class TestBackgroundJobs:
         assert rows[0]['id'] == second_id
         assert rows[1]['id'] == first_id
         assert rows[0]['metadata']['tournament_id'] == 1
+
+    def test_jobs_are_persisted_to_database(self, app):
+        from models.background_job import BackgroundJob
+        from services.background_jobs import submit
+
+        job_id = submit('persisted-job', lambda: 'stored', metadata={'tournament_id': 7})
+        time.sleep(0.1)
+
+        with app.app_context():
+            row = _db.session.get(BackgroundJob, job_id)
+            assert row is not None
+            assert row.label == 'persisted-job'
+            assert row.tournament_id == 7
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- add a durable ackground_jobs table and migration so async job status survives process restarts
- keep the existing thread-pool execution path but mirror job lifecycle state into the database
- preserve the configured Flask app binding when worker counts are reconfigured so persistence does not silently disable itself
- extend infrastructure tests to cover DB-backed job persistence

## Validation
- python -m pytest tests/test_infrastructure.py -q
- python -m pytest tests/test_remedial_pr_fixes.py::test_background_jobs_run_with_app_context -q
- python -m pytest tests/test_migration_integrity.py::TestMigrationIntegrity -q
- python -m pytest tests/test_pg_migration_safety.py -q
- uff check .
