### PR TITLE
Add first-pass database integrity constraints

### DIFF
--- a/migrations/versions/f5a6b7c8d9e0_add_first_pass_integrity_checks.py
+++ b/migrations/versions/f5a6b7c8d9e0_add_first_pass_integrity_checks.py
@@ -1,0 +1,115 @@
+"""Add first-pass database integrity check constraints.
+
+Revision ID: f5a6b7c8d9e0
+Revises: e4f5a6b7c8d9
+Create Date: 2026-04-20
+"""
+
+from alembic import op
+
+
+revision = 'f5a6b7c8d9e0'
+down_revision = 'e4f5a6b7c8d9'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    with op.batch_alter_table('teams') as batch_op:
+        batch_op.create_check_constraint('ck_teams_status_valid', "status IN ('active', 'scratched', 'invalid')")
+        batch_op.create_check_constraint('ck_teams_total_points_nonnegative', 'total_points >= 0')
+
+    with op.batch_alter_table('college_competitors') as batch_op:
+        batch_op.create_check_constraint('ck_college_competitors_gender_valid', "gender IN ('M', 'F')")
+        batch_op.create_check_constraint('ck_college_competitors_status_valid', "status IN ('active', 'scratched')")
+        batch_op.create_check_constraint('ck_college_competitors_points_nonnegative', 'individual_points >= 0')
+
+    with op.batch_alter_table('pro_competitors') as batch_op:
+        batch_op.create_check_constraint('ck_pro_competitors_gender_valid', "gender IN ('M', 'F')")
+        batch_op.create_check_constraint('ck_pro_competitors_status_valid', "status IN ('active', 'scratched')")
+        batch_op.create_check_constraint('ck_pro_competitors_earnings_nonnegative', 'total_earnings >= 0')
+        batch_op.create_check_constraint('ck_pro_competitors_total_fees_nonnegative', 'total_fees >= 0')
+
+    with op.batch_alter_table('events') as batch_op:
+        batch_op.create_check_constraint('ck_events_event_type_valid', "event_type IN ('college', 'pro')")
+        batch_op.create_check_constraint(
+            'ck_events_scoring_order_valid',
+            "scoring_order IN ('lowest_wins', 'highest_wins')",
+        )
+        batch_op.create_check_constraint(
+            'ck_events_status_valid',
+            "status IN ('pending', 'in_progress', 'completed')",
+        )
+        batch_op.create_check_constraint(
+            'ck_events_max_stands_valid',
+            '(max_stands IS NULL) OR (max_stands >= 1)',
+        )
+
+    with op.batch_alter_table('event_results') as batch_op:
+        batch_op.create_check_constraint(
+            'ck_event_results_competitor_type_valid',
+            "competitor_type IN ('college', 'pro')",
+        )
+        batch_op.create_check_constraint(
+            'ck_event_results_status_valid',
+            "status IN ('pending', 'completed', 'scratched', 'dnf', 'dq', 'partial')",
+        )
+        batch_op.create_check_constraint(
+            'ck_event_results_final_position_valid',
+            '(final_position IS NULL) OR (final_position >= 1)',
+        )
+        batch_op.create_check_constraint('ck_event_results_points_nonnegative', 'points_awarded >= 0')
+        batch_op.create_check_constraint('ck_event_results_payout_nonnegative', 'payout_amount >= 0')
+
+    with op.batch_alter_table('heats') as batch_op:
+        batch_op.create_check_constraint('ck_heats_heat_number_positive', 'heat_number >= 1')
+        batch_op.create_check_constraint('ck_heats_run_number_positive', 'run_number >= 1')
+        batch_op.create_check_constraint(
+            'ck_heats_status_valid',
+            "status IN ('pending', 'in_progress', 'completed')",
+        )
+
+    with op.batch_alter_table('flights') as batch_op:
+        batch_op.create_check_constraint('ck_flights_flight_number_positive', 'flight_number >= 1')
+        batch_op.create_check_constraint(
+            'ck_flights_status_valid',
+            "status IN ('pending', 'in_progress', 'completed')",
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('flights') as batch_op:
+        batch_op.drop_constraint('ck_flights_status_valid', type_='check')
+        batch_op.drop_constraint('ck_flights_flight_number_positive', type_='check')
+
+    with op.batch_alter_table('heats') as batch_op:
+        batch_op.drop_constraint('ck_heats_status_valid', type_='check')
+        batch_op.drop_constraint('ck_heats_run_number_positive', type_='check')
+        batch_op.drop_constraint('ck_heats_heat_number_positive', type_='check')
+
+    with op.batch_alter_table('event_results') as batch_op:
+        batch_op.drop_constraint('ck_event_results_payout_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_event_results_points_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_event_results_final_position_valid', type_='check')
+        batch_op.drop_constraint('ck_event_results_status_valid', type_='check')
+        batch_op.drop_constraint('ck_event_results_competitor_type_valid', type_='check')
+
+    with op.batch_alter_table('events') as batch_op:
+        batch_op.drop_constraint('ck_events_max_stands_valid', type_='check')
+        batch_op.drop_constraint('ck_events_status_valid', type_='check')
+        batch_op.drop_constraint('ck_events_scoring_order_valid', type_='check')
+        batch_op.drop_constraint('ck_events_event_type_valid', type_='check')
+
+    with op.batch_alter_table('pro_competitors') as batch_op:
+        batch_op.drop_constraint('ck_pro_competitors_total_fees_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_pro_competitors_earnings_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_pro_competitors_status_valid', type_='check')
+        batch_op.drop_constraint('ck_pro_competitors_gender_valid', type_='check')
+
+    with op.batch_alter_table('college_competitors') as batch_op:
+        batch_op.drop_constraint('ck_college_competitors_points_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_college_competitors_status_valid', type_='check')
+        batch_op.drop_constraint('ck_college_competitors_gender_valid', type_='check')
+
+    with op.batch_alter_table('teams') as batch_op:
+        batch_op.drop_constraint('ck_teams_total_points_nonnegative', type_='check')
+        batch_op.drop_constraint('ck_teams_status_valid', type_='check')

--- a/models/competitor.py
+++ b/models/competitor.py
@@ -19,6 +19,11 @@ class CollegeCompetitor(db.Model):
     """Represents a college competitor."""
 
     __tablename__ = 'college_competitors'
+    __table_args__ = (
+        db.CheckConstraint("gender IN ('M', 'F')", name='ck_college_competitors_gender_valid'),
+        db.CheckConstraint("status IN ('active', 'scratched')", name='ck_college_competitors_status_valid'),
+        db.CheckConstraint('individual_points >= 0', name='ck_college_competitors_points_nonnegative'),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     tournament_id = db.Column(db.Integer, db.ForeignKey('tournaments.id'), nullable=False)
@@ -208,6 +213,12 @@ class ProCompetitor(db.Model):
     """Represents a professional competitor."""
 
     __tablename__ = 'pro_competitors'
+    __table_args__ = (
+        db.CheckConstraint("gender IN ('M', 'F')", name='ck_pro_competitors_gender_valid'),
+        db.CheckConstraint("status IN ('active', 'scratched')", name='ck_pro_competitors_status_valid'),
+        db.CheckConstraint('total_earnings >= 0', name='ck_pro_competitors_earnings_nonnegative'),
+        db.CheckConstraint('total_fees >= 0', name='ck_pro_competitors_total_fees_nonnegative'),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     tournament_id = db.Column(db.Integer, db.ForeignKey('tournaments.id'), nullable=False)

--- a/models/event.py
+++ b/models/event.py
@@ -14,6 +14,16 @@ class Event(db.Model):
     __tablename__ = 'events'
     __table_args__ = (
         db.Index('ix_events_tournament_type_status', 'tournament_id', 'event_type', 'status'),
+        db.CheckConstraint("event_type IN ('college', 'pro')", name='ck_events_event_type_valid'),
+        db.CheckConstraint(
+            "scoring_order IN ('lowest_wins', 'highest_wins')",
+            name='ck_events_scoring_order_valid',
+        ),
+        db.CheckConstraint(
+            "status IN ('pending', 'in_progress', 'completed')",
+            name='ck_events_status_valid',
+        ),
+        db.CheckConstraint('(max_stands IS NULL) OR (max_stands >= 1)', name='ck_events_max_stands_valid'),
     )
 
     id = db.Column(db.Integer, primary_key=True)
@@ -146,6 +156,17 @@ class EventResult(db.Model):
     __table_args__ = (
         db.UniqueConstraint('event_id', 'competitor_id', 'competitor_type', name='uq_event_result_competitor'),
         db.Index('ix_event_results_event_status', 'event_id', 'status'),
+        db.CheckConstraint("competitor_type IN ('college', 'pro')", name='ck_event_results_competitor_type_valid'),
+        db.CheckConstraint(
+            "status IN ('pending', 'completed', 'scratched', 'dnf', 'dq', 'partial')",
+            name='ck_event_results_status_valid',
+        ),
+        db.CheckConstraint(
+            '(final_position IS NULL) OR (final_position >= 1)',
+            name='ck_event_results_final_position_valid',
+        ),
+        db.CheckConstraint('points_awarded >= 0', name='ck_event_results_points_nonnegative'),
+        db.CheckConstraint('payout_amount >= 0', name='ck_event_results_payout_nonnegative'),
     )
 
     id = db.Column(db.Integer, primary_key=True)

--- a/models/heat.py
+++ b/models/heat.py
@@ -33,6 +33,12 @@ class Heat(db.Model):
         db.UniqueConstraint('event_id', 'heat_number', 'run_number', name='uq_event_heat_run'),
         db.Index('ix_heats_event_status', 'event_id', 'status'),
         db.Index('ix_heats_flight_id', 'flight_id'),
+        db.CheckConstraint('heat_number >= 1', name='ck_heats_heat_number_positive'),
+        db.CheckConstraint('run_number >= 1', name='ck_heats_run_number_positive'),
+        db.CheckConstraint(
+            "status IN ('pending', 'in_progress', 'completed')",
+            name='ck_heats_status_valid',
+        ),
     )
 
     id = db.Column(db.Integer, primary_key=True)
@@ -162,6 +168,13 @@ class Flight(db.Model):
     """Represents a flight in pro competition (group of heats from different events)."""
 
     __tablename__ = 'flights'
+    __table_args__ = (
+        db.CheckConstraint('flight_number >= 1', name='ck_flights_flight_number_positive'),
+        db.CheckConstraint(
+            "status IN ('pending', 'in_progress', 'completed')",
+            name='ck_flights_status_valid',
+        ),
+    )
 
     id = db.Column(db.Integer, primary_key=True)
     tournament_id = db.Column(db.Integer, db.ForeignKey('tournaments.id'), nullable=False)

--- a/models/team.py
+++ b/models/team.py
@@ -42,6 +42,8 @@ class Team(db.Model):
 
     __table_args__ = (
         db.UniqueConstraint('tournament_id', 'team_code', name='unique_team_code_per_tournament'),
+        db.CheckConstraint("status IN ('active', 'scratched', 'invalid')", name='ck_teams_status_valid'),
+        db.CheckConstraint('total_points >= 0', name='ck_teams_total_points_nonnegative'),
     )
 
     def __repr__(self):

--- a/tests/test_db_constraints.py
+++ b/tests/test_db_constraints.py
@@ -285,3 +285,61 @@ class TestDataIntegrity:
 
         assert f.heat_count == 2
         assert f.event_variety == 1  # same event
+
+
+class TestCheckConstraints:
+    """Verify DB-level check constraints reject impossible states."""
+
+    def test_college_competitor_invalid_gender_rejected(self, db_session):
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+
+        with pytest.raises(IntegrityError):
+            make_college_competitor(db_session, t, team, 'Invalid Gender', gender='X')
+            db_session.flush()
+        db_session.rollback()
+
+    def test_pro_competitor_negative_earnings_rejected(self, db_session):
+        t = make_tournament(db_session)
+        competitor = make_pro_competitor(db_session, t, 'Negative Earner', 'M')
+        competitor.total_earnings = -5.0
+
+        with pytest.raises(IntegrityError):
+            db_session.flush()
+        db_session.rollback()
+
+    def test_event_invalid_status_rejected(self, db_session):
+        t = make_tournament(db_session)
+        event = make_event(db_session, t, 'Bad Status', event_type='pro')
+        event.status = 'broken'
+
+        with pytest.raises(IntegrityError):
+            db_session.flush()
+        db_session.rollback()
+
+    def test_event_result_negative_payout_rejected(self, db_session):
+        t = make_tournament(db_session)
+        competitor = make_pro_competitor(db_session, t, 'Negative Payout', 'M')
+        event = make_event(db_session, t, 'Payout Event', event_type='pro')
+        result = make_event_result(
+            db_session,
+            event,
+            competitor,
+            competitor_type='pro',
+            result_value=20.0,
+            status='completed',
+        )
+        result.payout_amount = -10.0
+
+        with pytest.raises(IntegrityError):
+            db_session.flush()
+        db_session.rollback()
+
+    def test_heat_run_number_must_be_positive(self, db_session):
+        t = make_tournament(db_session)
+        event = make_event(db_session, t, 'Run Guard', event_type='pro')
+
+        with pytest.raises(IntegrityError):
+            make_heat(db_session, event, heat_number=1, run_number=0)
+            db_session.flush()
+        db_session.rollback()

--- a/tests/test_pg_migration_safety.py
+++ b/tests/test_pg_migration_safety.py
@@ -103,7 +103,7 @@ class TestNoBatchAlterTableInUpgrades:
 
     # Operations that REQUIRE batch mode on SQLite
     _BATCH_REQUIRED_OPS = {
-        'create_foreign_key', 'create_unique_constraint',
+        'create_foreign_key', 'create_unique_constraint', 'create_check_constraint',
         'drop_constraint', 'alter_column',
     }
 


### PR DESCRIPTION
## Summary
- add DB-level check constraints for valid status/enum values across teams, competitors, events, heats, and flights
- enforce non-negative score and payout fields where the app already assumes negative values are impossible
- add a migration to apply the first-pass integrity checks
- extend constraint regression coverage and keep the PG migration safety policy aligned with check-constraint migrations

## Validation
- python -m pytest tests/test_db_constraints.py -q
- python -m pytest tests/test_migration_integrity.py::TestMigrationIntegrity -q
- python -m pytest tests/test_pg_migration_safety.py -q
- uff check .
