### PR TITLE
Extract schedule generation workflows into a service

### DIFF
--- a/routes/scheduling/preflight.py
+++ b/routes/scheduling/preflight.py
@@ -7,11 +7,15 @@ from flask import flash, jsonify, redirect, render_template, request, session, u
 
 import config
 from database import db
-from models import Event, Heat, HeatAssignment, Tournament
+from models import Tournament
 from services.audit import log_action
 from services.background_jobs import submit as submit_job
+from services.schedule_generation import (
+    generate_tournament_schedule_artifacts,
+    run_preflight_autofix,
+)
 
-from . import _build_pro_flights_if_possible, _generate_all_heats, scheduling_bp
+from . import scheduling_bp
 
 
 @scheduling_bp.route('/<int:tournament_id>/preflight', methods=['GET', 'POST'])
@@ -29,56 +33,24 @@ def preflight_check(tournament_id):
     if request.method == 'POST':
         action = request.form.get('action', 'autofix')
         if action == 'autofix':
-            from services.gear_sharing import complete_one_sided_pairs, parse_all_gear_details
-
-            # 1) Heat assignment sync for all events
-            heats_fixed = 0
-            for event in tournament.events.all():
-                for heat in event.heats.all():
-                    json_ids = heat.get_competitors()
-                    HeatAssignment.query.filter_by(heat_id=heat.id).delete()
-                    assignments = heat.get_stand_assignments()
-                    for comp_id in json_ids:
-                        db.session.add(HeatAssignment(
-                            heat_id=heat.id,
-                            competitor_id=comp_id,
-                            competitor_type=event.event_type,
-                            stand_number=assignments.get(str(comp_id)),
-                        ))
-                    heats_fixed += 1
-
-            # 2) Parse unstructured gear-sharing details into structured maps
-            gear_parse_result = parse_all_gear_details(tournament)
-
-            # 3) Write reciprocals for all one-sided gear pairs
-            pairs_result = complete_one_sided_pairs(tournament)
-
-            # 4) Auto-partner assignments
-            partner_summary = auto_assign_pro_partners(tournament)
-
-            # 5) Saturday spillover integration
-            integration = integrate_college_spillover_into_flights(tournament, saturday_ids)
-
+            result = run_preflight_autofix(tournament, saturday_ids)
             db.session.commit()
             log_action('preflight_autofix_applied', 'tournament', tournament_id, {
-                'heats_fixed': heats_fixed,
-                'gear_parsed': gear_parse_result,
-                'gear_pairs_completed': pairs_result['completed'],
-                'partner_summary': partner_summary,
-                'spillover': integration,
+                **result,
+                'tournament_id': tournament_id,
             })
             gear_msg = (
-                f" parsed {gear_parse_result['parsed']} gear detail(s),"
-                if gear_parse_result['parsed'] else ''
+                f" parsed {result['gear_parsed']['parsed']} gear detail(s),"
+                if result['gear_parsed']['parsed'] else ''
             )
             pairs_msg = (
-                f" completed {pairs_result['completed']} one-sided gear pair(s),"
-                if pairs_result['completed'] else ''
+                f" completed {result['gear_pairs_completed']} one-sided gear pair(s),"
+                if result['gear_pairs_completed'] else ''
             )
             flash(
-                f"Auto-fix complete: synced {heats_fixed} heats,{gear_msg}{pairs_msg} "
-                f"assigned {partner_summary['assigned_pairs']} pairs, "
-                f"integrated {integration['integrated_heats']} spillover heats.",
+                f"Auto-fix complete: synced {result['heats_fixed']} heats,{gear_msg}{pairs_msg} "
+                f"assigned {result['partner_summary']['assigned_pairs']} pairs, "
+                f"integrated {result['spillover']['integrated_heats']} spillover heats.",
                 'success'
             )
             return redirect(url_for('scheduling.preflight_check', tournament_id=tournament_id))
@@ -120,51 +92,6 @@ def preflight_json(tournament_id):
     })
 
 
-# ---------------------------------------------------------------------------
-# #4 — Async heat / flight generation  (#4)
-# ---------------------------------------------------------------------------
-
-def _async_generate_all(tournament_id: int) -> dict:
-    """Background task: generate all heats + pro flights for a tournament.
-
-    Runs inside a new application context so the ThreadPoolExecutor worker
-    has access to the DB session and Flask app.
-    """
-    from flask import current_app
-    app = current_app._get_current_object()
-    with app.app_context():
-        from models import Event as _Event
-        from models import Tournament as _Tournament
-        from services.flight_builder import build_pro_flights
-        from services.heat_generator import generate_event_heats
-
-        tournament = _Tournament.query.get(tournament_id)
-        if not tournament:
-            return {'ok': False, 'error': f'Tournament {tournament_id} not found.'}
-
-        generated, skipped, errors = 0, 0, []
-        for event in tournament.events.order_by(_Event.event_type, _Event.name, _Event.gender).all():
-            try:
-                generate_event_heats(event)
-                generated += 1
-            except Exception as exc:
-                if 'No competitors entered' in str(exc):
-                    skipped += 1
-                else:
-                    errors.append(str(exc))
-
-        db.session.commit()  # Persist heats before building flights
-
-        pro_flights = _build_pro_flights_if_possible(tournament, build_pro_flights)
-        return {
-            'ok': True,
-            'generated': generated,
-            'skipped': skipped,
-            'errors': errors,
-            'flights': pro_flights,
-        }
-
-
 @scheduling_bp.route('/<int:tournament_id>/events/generate-async', methods=['POST'])
 def generate_async(tournament_id):
     """Submit heat + flight generation as a background job and return a job_id."""
@@ -172,7 +99,7 @@ def generate_async(tournament_id):
 
     job_id = submit_job(
         f'generate_all:{tournament_id}',
-        _async_generate_all,
+        generate_tournament_schedule_artifacts,
         tournament_id,
         metadata={'tournament_id': tournament_id, 'kind': 'generate_all'},
     )

--- a/services/schedule_generation.py
+++ b/services/schedule_generation.py
@@ -1,0 +1,80 @@
+"""Application services for schedule autofix and bulk generation workflows."""
+from __future__ import annotations
+
+from database import db
+from models import Event, HeatAssignment, Tournament
+
+
+def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None = None) -> dict:
+    """Apply the one-click preflight autofix workflow and return a summary."""
+    from services.flight_builder import integrate_college_spillover_into_flights
+    from services.gear_sharing import complete_one_sided_pairs, parse_all_gear_details
+    from services.partner_matching import auto_assign_pro_partners
+
+    heats_fixed = 0
+    for event in tournament.events.all():
+        for heat in event.heats.all():
+            json_ids = heat.get_competitors()
+            HeatAssignment.query.filter_by(heat_id=heat.id).delete()
+            assignments = heat.get_stand_assignments()
+            for comp_id in json_ids:
+                db.session.add(HeatAssignment(
+                    heat_id=heat.id,
+                    competitor_id=comp_id,
+                    competitor_type=event.event_type,
+                    stand_number=assignments.get(str(comp_id)),
+                ))
+            heats_fixed += 1
+
+    gear_parse_result = parse_all_gear_details(tournament)
+    pairs_result = complete_one_sided_pairs(tournament)
+    partner_summary = auto_assign_pro_partners(tournament)
+    integration = integrate_college_spillover_into_flights(tournament, saturday_ids or [])
+
+    return {
+        'heats_fixed': heats_fixed,
+        'gear_parsed': gear_parse_result,
+        'gear_pairs_completed': pairs_result['completed'],
+        'partner_summary': partner_summary,
+        'spillover': integration,
+    }
+
+
+def generate_tournament_schedule_artifacts(tournament_id: int) -> dict:
+    """Generate heats for every event, then build pro flights when possible."""
+    from services.flight_builder import build_pro_flights
+    from services.heat_generator import generate_event_heats
+
+    tournament = db.session.get(Tournament, tournament_id)
+    if not tournament:
+        return {'ok': False, 'error': f'Tournament {tournament_id} not found.'}
+
+    generated = 0
+    skipped = 0
+    errors = []
+    for event in tournament.events.order_by(Event.event_type, Event.name, Event.gender).all():
+        try:
+            generate_event_heats(event)
+            generated += 1
+        except Exception as exc:
+            if 'No competitors entered' in str(exc):
+                skipped += 1
+            else:
+                errors.append(str(exc))
+
+    db.session.commit()
+
+    pro_heats = sum(
+        1
+        for event in tournament.events.filter_by(event_type='pro').all()
+        for heat in event.heats.all()
+        if heat.run_number == 1
+    )
+    flights = build_pro_flights(tournament) if pro_heats else None
+    return {
+        'ok': True,
+        'generated': generated,
+        'skipped': skipped,
+        'errors': errors,
+        'flights': flights,
+    }

--- a/tests/test_schedule_generation.py
+++ b/tests/test_schedule_generation.py
@@ -1,0 +1,147 @@
+"""Tests for schedule-generation application services."""
+import os
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope='module')
+def app():
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+def _make_tournament(db_session):
+    from models import Tournament
+
+    tournament = Tournament(name='Schedule Generation Test', year=2026, status='setup')
+    db_session.add(tournament)
+    db_session.flush()
+    return tournament
+
+
+def _make_event(db_session, tournament, name, event_type='pro'):
+    from models import Event
+
+    event = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type=event_type,
+        scoring_type='time',
+        scoring_order='lowest_wins',
+        status='pending',
+    )
+    db_session.add(event)
+    db_session.flush()
+    return event
+
+
+def _make_heat(db_session, event, competitor_ids=None):
+    from models import Heat
+
+    heat = Heat(event_id=event.id, heat_number=1, run_number=1)
+    if competitor_ids is not None:
+        heat.set_competitors(competitor_ids)
+    db_session.add(heat)
+    db_session.flush()
+    return heat
+
+
+def test_run_preflight_autofix_syncs_heat_assignments(db_session, monkeypatch):
+    from models.heat import HeatAssignment
+    from services.schedule_generation import run_preflight_autofix
+
+    tournament = _make_tournament(db_session)
+    event = _make_event(db_session, tournament, 'Underhand')
+    heat = _make_heat(db_session, event, competitor_ids=[101, 202])
+    heat.set_stand_assignment(101, 1)
+    heat.set_stand_assignment(202, 2)
+    db_session.flush()
+
+    monkeypatch.setattr(
+        'services.gear_sharing.parse_all_gear_details',
+        lambda _tournament: {'parsed': 2},
+    )
+    monkeypatch.setattr(
+        'services.gear_sharing.complete_one_sided_pairs',
+        lambda _tournament: {'completed': 1},
+    )
+    monkeypatch.setattr(
+        'services.partner_matching.auto_assign_pro_partners',
+        lambda _tournament: {'assigned_pairs': 3},
+    )
+    monkeypatch.setattr(
+        'services.flight_builder.integrate_college_spillover_into_flights',
+        lambda _tournament, _ids: {'integrated_heats': 4},
+    )
+
+    result = run_preflight_autofix(tournament, saturday_ids=[999])
+    db_session.flush()
+
+    rows = HeatAssignment.query.filter_by(heat_id=heat.id).order_by(HeatAssignment.competitor_id).all()
+    assert [row.competitor_id for row in rows] == [101, 202]
+    assert [row.stand_number for row in rows] == [1, 2]
+    assert result['heats_fixed'] == 1
+    assert result['gear_parsed']['parsed'] == 2
+    assert result['gear_pairs_completed'] == 1
+    assert result['partner_summary']['assigned_pairs'] == 3
+    assert result['spillover']['integrated_heats'] == 4
+
+
+def test_generate_tournament_schedule_artifacts_returns_error_for_missing_tournament():
+    from services.schedule_generation import generate_tournament_schedule_artifacts
+
+    result = generate_tournament_schedule_artifacts(999999)
+
+    assert result['ok'] is False
+    assert 'not found' in result['error']
+
+
+def test_generate_tournament_schedule_artifacts_orchestrates_heat_and_flight_generation(
+    db_session,
+    monkeypatch,
+):
+    from models import Heat
+    from services.schedule_generation import generate_tournament_schedule_artifacts
+
+    tournament = _make_tournament(db_session)
+    success_event = _make_event(db_session, tournament, 'Success Event', event_type='pro')
+    skipped_event = _make_event(db_session, tournament, 'Skip Event', event_type='pro')
+    error_event = _make_event(db_session, tournament, 'Error Event', event_type='college')
+
+    def _fake_generate(event):
+        if event.id == skipped_event.id:
+            raise RuntimeError('No competitors entered for this event')
+        if event.id == error_event.id:
+            raise RuntimeError('kaboom')
+        heat = Heat(event_id=event.id, heat_number=1, run_number=1)
+        _db.session.add(heat)
+        _db.session.flush()
+
+    monkeypatch.setattr('services.heat_generator.generate_event_heats', _fake_generate)
+    monkeypatch.setattr('services.flight_builder.build_pro_flights', lambda _tournament: 2)
+
+    result = generate_tournament_schedule_artifacts(tournament.id)
+
+    assert result['ok'] is True
+    assert result['generated'] == 1
+    assert result['skipped'] == 1
+    assert result['errors'] == ['kaboom']
+    assert result['flights'] == 2


### PR DESCRIPTION
## Summary
- move preflight autofix orchestration into services/schedule_generation.py
- move async heat+flight generation orchestration out of the route layer into the same service
- keep outes/scheduling/preflight.py focused on HTTP/session/flash behavior
- add direct service tests for autofix syncing and bulk generation orchestration

## Validation
- python -m pytest tests/test_schedule_generation.py -q
- python -m pytest tests/test_preflight.py -q
- uff check .
