### PR TITLE
Extract scoring workflows into a service

### DIFF
--- a/routes/scoring.py
+++ b/routes/scoring.py
@@ -36,6 +36,12 @@ from models.payout_template import PayoutTemplate
 from routes.api import write_limit
 from services.audit import log_action
 from services.cache_invalidation import invalidate_tournament_caches
+from services.scoring_workflow import (
+    competitor_lookup_for_event,
+    existing_results_for_event,
+    finalize_event_results,
+    save_heat_results_submission,
+)
 
 scoring_bp = Blueprint('scoring', __name__)
 
@@ -68,6 +74,17 @@ def _current_user_id() -> int | None:
     return None
 
 
+def _normalized_heat_competitor_ids(heat: Heat) -> list[int]:
+    competitor_ids: list[int] = []
+    for entry in heat.get_competitors():
+        if isinstance(entry, dict):
+            entry = entry.get('id')
+        if entry in (None, ''):
+            continue
+        competitor_ids.append(int(entry))
+    return competitor_ids
+
+
 def _push_strathmark_results(event: Event, tournament_id: int) -> None:
     """
     Attempt to push finalized results to STRATHMARK for eligible event types.
@@ -94,20 +111,11 @@ def _push_strathmark_results(event: Event, tournament_id: int) -> None:
 
 
 def _competitor_lookup(event: Event, competitor_ids: list[int]) -> dict:
-    if event.event_type == 'college':
-        comps = CollegeCompetitor.query.filter(CollegeCompetitor.id.in_(competitor_ids)).all()
-    else:
-        comps = ProCompetitor.query.filter(ProCompetitor.id.in_(competitor_ids)).all()
-    return {c.id: c for c in comps}
+    return competitor_lookup_for_event(event, competitor_ids)
 
 
 def _existing_results(event: Event, competitor_ids: list[int]) -> dict:
-    rows = EventResult.query.filter(
-        EventResult.event_id == event.id,
-        EventResult.competitor_id.in_(competitor_ids),
-        EventResult.competitor_type == event.event_type
-    ).all()
-    return {r.competitor_id: r for r in rows}
+    return existing_results_for_event(event, competitor_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -472,6 +480,36 @@ def _save_heat_results_submission(tournament_id: int, heat: Heat, event: Event) 
     }
 
 
+# Route-level shim: keep HTTP details here while the scoring workflow lives in
+# services.scoring_workflow for direct testing outside request handlers.
+def _save_heat_results_submission(tournament_id: int, heat: Heat, event: Event) -> dict:
+    outcome = save_heat_results_submission(
+        tournament_id=tournament_id,
+        heat=heat,
+        event=event,
+        form_data=request.form,
+        judge_user_id=_current_user_id(),
+    )
+    redirect_kind = outcome.pop('redirect_kind')
+    redirect_event_id = outcome.pop('redirect_event_id')
+    redirect_heat_id = outcome.pop('redirect_heat_id')
+    if redirect_kind == 'heat_entry':
+        outcome['redirect_url'] = url_for(
+            'scoring.enter_heat_results',
+            tournament_id=tournament_id,
+            heat_id=redirect_heat_id,
+        )
+    else:
+        outcome['redirect_url'] = url_for(
+            'scoring.event_results',
+            tournament_id=tournament_id,
+            event_id=redirect_event_id,
+        )
+    if outcome.get('undo_token'):
+        session[f'undo_heat_{heat.id}'] = outcome.pop('undo_token')
+    return outcome
+
+
 # ---------------------------------------------------------------------------
 # Routes: navigation helpers
 # ---------------------------------------------------------------------------
@@ -567,9 +605,29 @@ def finalize_preview(tournament_id, event_id):
 
 
 @scoring_bp.route('/<int:tournament_id>/event/<int:event_id>/finalize', methods=['POST'])
+@login_required
 @write_limit('10 per minute')
 def finalize_event(tournament_id, event_id):
     event = _event_for_tournament_or_404(tournament_id, event_id)
+    outcome = finalize_event_results(
+        event=event,
+        tournament_id=tournament_id,
+        judge_user_id=_current_user_id(),
+    )
+    for issue in outcome['warnings']:
+        flash(issue['message'], 'warning')
+    if not outcome['ok']:
+        if _is_async():
+            return jsonify({'ok': False, 'message': outcome['message']}), outcome['status_code']
+        flash(outcome['message'], 'warning')
+        return redirect(url_for('scoring.event_results',
+                                tournament_id=tournament_id, event_id=event_id))
+    _push_strathmark_results(event, tournament_id)
+    if _is_async():
+        return jsonify({'ok': True, 'message': outcome['message']})
+    flash(text.FLASH['event_finalized'].format(event_name=event.display_name), 'success')
+    return redirect(url_for('scoring.event_results',
+                            tournament_id=tournament_id, event_id=event_id))
 
     # Pre-finalization validation — surface warnings so the judge knows what's off.
     # These are warnings, not blockers, because there are legitimate reasons to
@@ -620,6 +678,7 @@ def finalize_event(tournament_id, event_id):
 # ---------------------------------------------------------------------------
 
 @scoring_bp.route('/<int:tournament_id>/heat/<int:heat_id>/enter', methods=['GET', 'POST'])
+@login_required
 @write_limit('60 per minute')
 def enter_heat_results(tournament_id, heat_id):
     tournament = Tournament.query.get_or_404(tournament_id)
@@ -668,7 +727,7 @@ def enter_heat_results(tournament_id, heat_id):
             heat.acquire_lock(user_id)
             db.session.commit()
 
-    competitor_ids = heat.get_competitors()
+    competitor_ids = _normalized_heat_competitor_ids(heat)
     comp_lookup = _competitor_lookup(event, competitor_ids)
     result_lookup = _existing_results(event, competitor_ids)
 
@@ -727,6 +786,7 @@ def enter_heat_results(tournament_id, heat_id):
 # ---------------------------------------------------------------------------
 
 @scoring_bp.route('/<int:tournament_id>/heat/<int:heat_id>/release-lock', methods=['POST'])
+@login_required
 def release_heat_lock(tournament_id, heat_id):
     heat = _heat_for_tournament_or_404(tournament_id, heat_id)
     user_id = _current_user_id()
@@ -744,6 +804,7 @@ def release_heat_lock(tournament_id, heat_id):
 # ---------------------------------------------------------------------------
 
 @scoring_bp.route('/<int:tournament_id>/heat/<int:heat_id>/undo', methods=['POST'])
+@login_required
 def undo_heat_save(tournament_id, heat_id):
     """Revert a heat to pending and delete its EventResult rows (within 30-second window)."""
     token = session.get(f'undo_heat_{heat_id}')
@@ -774,7 +835,7 @@ def undo_heat_save(tournament_id, heat_id):
 
     heat = _heat_for_tournament_or_404(tournament_id, heat_id)
     event = heat.event
-    competitor_ids = heat.get_competitors()
+    competitor_ids = _normalized_heat_competitor_ids(heat)
 
     # Phase 4 (V2.8.0) — strip points before delete (PLAN_REVIEW.md A6/C2/C7).
     #
@@ -1397,7 +1458,7 @@ def heat_sheet_pdf(tournament_id, heat_id):
     heat = _heat_for_tournament_or_404(tournament_id, heat_id)
     event = heat.event
 
-    competitor_ids = heat.get_competitors()
+    competitor_ids = _normalized_heat_competitor_ids(heat)
     comp_lookup = _competitor_lookup(event, competitor_ids)
     result_lookup = _existing_results(event, competitor_ids)
     assignments = heat.get_stand_assignments()

--- a/services/scoring_workflow.py
+++ b/services/scoring_workflow.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Mapping
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import StaleDataError
+
+import services.scoring_engine as engine
+import strings as text
+from database import db
+from models import Event, EventResult, Heat
+from models.competitor import CollegeCompetitor, ProCompetitor
+from services.audit import log_action
+from services.cache_invalidation import invalidate_tournament_caches
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_competitor_ids(competitor_ids: list[object]) -> list[int]:
+    normalized: list[int] = []
+    for entry in competitor_ids:
+        if isinstance(entry, dict):
+            entry = entry.get('id')
+        if entry in (None, ''):
+            continue
+        normalized.append(int(entry))
+    return normalized
+
+
+def competitor_lookup_for_event(event: Event, competitor_ids: list[int]) -> dict[int, object]:
+    competitor_ids = _normalize_competitor_ids(competitor_ids)
+    if event.event_type == 'college':
+        comps = CollegeCompetitor.query.filter(CollegeCompetitor.id.in_(competitor_ids)).all()
+    else:
+        comps = ProCompetitor.query.filter(ProCompetitor.id.in_(competitor_ids)).all()
+    return {c.id: c for c in comps}
+
+
+def existing_results_for_event(event: Event, competitor_ids: list[int]) -> dict[int, EventResult]:
+    competitor_ids = _normalize_competitor_ids(competitor_ids)
+    rows = EventResult.query.filter(
+        EventResult.event_id == event.id,
+        EventResult.competitor_id.in_(competitor_ids),
+        EventResult.competitor_type == event.event_type,
+    ).all()
+    return {r.competitor_id: r for r in rows}
+
+
+def _form_int(form_data: Mapping[str, object], key: str) -> int | None:
+    raw = form_data.get(key)
+    if raw in (None, ''):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_dual_timer(
+    form_data: Mapping[str, object],
+    comp_id: int,
+    run_suffix: str,
+    invalid: list[tuple[int, object]],
+) -> tuple[float | None, float | None, float | None]:
+    raw_t1 = form_data.get(f't1_{run_suffix}_{comp_id}')
+    raw_t2 = form_data.get(f't2_{run_suffix}_{comp_id}')
+
+    def _try_parse(raw):
+        if raw in (None, ''):
+            return None
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            invalid.append((comp_id, raw))
+            return None
+        if val < 0:
+            invalid.append((comp_id, raw))
+            return None
+        return val
+
+    t1 = _try_parse(raw_t1)
+    t2 = _try_parse(raw_t2)
+    if t1 is not None and t2 is not None:
+        return (t1, t2, (t1 + t2) / 2.0)
+    return (t1, t2, None)
+
+
+def save_heat_results_submission(
+    *,
+    tournament_id: int,
+    heat: Heat,
+    event: Event,
+    form_data: Mapping[str, object],
+    judge_user_id: int | None,
+) -> dict:
+    competitor_ids = _normalize_competitor_ids(heat.get_competitors())
+    posted_version = _form_int(form_data, 'heat_version')
+    if posted_version is None or posted_version != heat.version_id:
+        return {
+            'ok': False,
+            'category': 'error',
+            'message': 'This heat changed in another session. Reload and re-enter results.',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': event.id,
+            'redirect_heat_id': heat.id,
+            'status_code': 409,
+        }
+
+    result_by_comp = existing_results_for_event(event, competitor_ids)
+    comp_lookup = competitor_lookup_for_event(event, competitor_ids)
+    changes = 0
+    invalid: list[tuple[int, object]] = []
+    is_dual_timer_event = (
+        event.scoring_type in ('time', 'distance')
+        and not event.requires_triple_runs
+    )
+
+    try:
+        for comp_id in competitor_ids:
+            status = form_data.get(f'status_{comp_id}', 'completed')
+
+            if is_dual_timer_event:
+                run_suffix = 'run2' if (event.requires_dual_runs and heat.run_number == 2) else 'run1'
+                t1, t2, average = _parse_dual_timer(form_data, comp_id, run_suffix, invalid)
+                if t1 is None and t2 is None:
+                    continue
+
+                result = result_by_comp.get(comp_id)
+                if not result:
+                    comp = comp_lookup.get(comp_id)
+                    result = EventResult(
+                        event_id=event.id,
+                        competitor_id=comp_id,
+                        competitor_type=event.event_type,
+                        competitor_name=comp.display_name if comp else f'Unknown ({comp_id})',
+                    )
+                    db.session.add(result)
+                    result_by_comp[comp_id] = result
+
+                if run_suffix == 'run1':
+                    result.t1_run1 = t1
+                    result.t2_run1 = t2
+                else:
+                    result.t1_run2 = t1
+                    result.t2_run2 = t2
+
+                if average is not None:
+                    if event.requires_dual_runs:
+                        if heat.run_number == 1:
+                            result.run1_value = average
+                        else:
+                            result.run2_value = average
+                        result.calculate_best_run(event.scoring_order)
+                    else:
+                        result.result_value = average
+                        result.run1_value = average
+                elif status == 'completed':
+                    status = 'partial'
+
+            elif event.requires_triple_runs:
+                raw = form_data.get(f'result_{comp_id}')
+                if not raw:
+                    continue
+                try:
+                    parsed = float(raw)
+                except (TypeError, ValueError):
+                    invalid.append((comp_id, raw))
+                    continue
+                if parsed < 0:
+                    invalid.append((comp_id, raw))
+                    continue
+
+                result = result_by_comp.get(comp_id)
+                if not result:
+                    comp = comp_lookup.get(comp_id)
+                    result = EventResult(
+                        event_id=event.id,
+                        competitor_id=comp_id,
+                        competitor_type=event.event_type,
+                        competitor_name=comp.display_name if comp else f'Unknown ({comp_id})',
+                    )
+                    db.session.add(result)
+                    result_by_comp[comp_id] = result
+
+                run_slot = form_data.get(f'run_slot_{comp_id}', '1')
+                if run_slot == '2':
+                    result.run2_value = parsed
+                elif run_slot == '3':
+                    result.run3_value = parsed
+                else:
+                    result.run1_value = parsed
+
+                for slot, field in [('2', f'result2_{comp_id}'), ('3', f'result3_{comp_id}')]:
+                    raw2 = form_data.get(field)
+                    if not raw2:
+                        continue
+                    try:
+                        v = float(raw2)
+                    except (TypeError, ValueError):
+                        continue
+                    if slot == '2':
+                        result.run2_value = v
+                    else:
+                        result.run3_value = v
+                result.calculate_cumulative_score()
+
+            else:
+                raw = form_data.get(f'result_{comp_id}')
+                if not raw:
+                    continue
+                try:
+                    parsed = float(raw)
+                except (TypeError, ValueError):
+                    invalid.append((comp_id, raw))
+                    continue
+
+                result = result_by_comp.get(comp_id)
+                if not result:
+                    comp = comp_lookup.get(comp_id)
+                    result = EventResult(
+                        event_id=event.id,
+                        competitor_id=comp_id,
+                        competitor_type=event.event_type,
+                        competitor_name=comp.display_name if comp else f'Unknown ({comp_id})',
+                    )
+                    db.session.add(result)
+                    result_by_comp[comp_id] = result
+
+                result.result_value = parsed
+
+            if event.is_hard_hit:
+                raw_tb = form_data.get(f'tiebreak_{comp_id}')
+                if raw_tb:
+                    try:
+                        result.tiebreak_value = float(raw_tb)
+                    except (TypeError, ValueError):
+                        pass
+
+            result.status = status
+            raw_reason = str(form_data.get(f'reason_{comp_id}', '') or '').strip()
+            if status in ('scratched', 'dnf', 'dq'):
+                result.status_reason = raw_reason or None
+            else:
+                result.status_reason = None
+
+            if result.id:
+                log_action(
+                    'score_edited',
+                    'event_result',
+                    result.id,
+                    {
+                        'event_id': event.id,
+                        'heat_id': heat.id,
+                        'new_value': result.result_value,
+                        'judge_user_id': judge_user_id,
+                    },
+                )
+                if event.is_finalized:
+                    event.is_finalized = False
+                    event.status = 'in_progress'
+
+            changes += 1
+
+        if changes == 0:
+            return {
+                'ok': False,
+                'category': 'warning',
+                'message': 'No result values were entered; heat remains pending.',
+                'redirect_kind': 'heat_entry',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 400,
+            }
+
+        heat.status = 'completed'
+        heat.release_lock(judge_user_id or 0)
+
+        all_heats_complete = all(h.status == 'completed' for h in event.heats.all())
+        finalize_failed = False
+        if all_heats_complete:
+            try:
+                with db.session.begin_nested():
+                    engine.calculate_positions(event)
+            except Exception as exc:
+                logger.error('auto-finalize failed for event %s: %s', event.id, exc)
+                event.is_finalized = False
+                event.status = 'in_progress'
+                finalize_failed = True
+
+        log_action(
+            'heat_results_saved',
+            'heat',
+            heat.id,
+            {
+                'event_id': event.id,
+                'result_updates': changes,
+                'judge_user_id': judge_user_id,
+            },
+        )
+        db.session.commit()
+
+    except StaleDataError:
+        db.session.rollback()
+        return {
+            'ok': False,
+            'category': 'warning',
+            'message': 'These scores were updated by another judge while you were entering results. '
+                       'Please reload to see the latest values before saving again.',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': event.id,
+            'redirect_heat_id': heat.id,
+            'status_code': 409,
+        }
+    except IntegrityError:
+        db.session.rollback()
+        return {
+            'ok': False,
+            'category': 'error',
+            'message': 'A database constraint was violated while saving results. '
+                       'Check for duplicate entries and try again.',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': event.id,
+            'redirect_heat_id': heat.id,
+            'status_code': 409,
+        }
+
+    invalidate_tournament_caches(tournament_id)
+    undo_token = {
+        'heat_id': heat.id,
+        'event_id': event.id,
+        'saved_at': datetime.now(timezone.utc).isoformat(),
+    }
+
+    if finalize_failed:
+        return {
+            'ok': True,
+            'category': 'warning',
+            'message': ('Heat saved, but auto-finalization failed. The event '
+                        'results page will let you retry - your timer values '
+                        'are safe.'),
+            'redirect_kind': 'event_results',
+            'redirect_event_id': event.id,
+            'redirect_heat_id': heat.id,
+            'status_code': 200,
+            'undo_heat_id': heat.id,
+            'undo_token': undo_token,
+        }
+
+    if invalid:
+        return {
+            'ok': True,
+            'category': 'warning',
+            'message': f'Heat saved with {len(invalid)} invalid value(s) skipped.',
+            'redirect_kind': 'event_results',
+            'redirect_event_id': event.id,
+            'redirect_heat_id': heat.id,
+            'status_code': 200,
+            'undo_heat_id': heat.id,
+            'undo_token': undo_token,
+        }
+
+    return {
+        'ok': True,
+        'category': 'success',
+        'message': text.FLASH['heat_saved'],
+        'redirect_kind': 'event_results',
+        'redirect_event_id': event.id,
+        'redirect_heat_id': heat.id,
+        'status_code': 200,
+        'undo_heat_id': heat.id,
+        'undo_token': undo_token,
+    }
+
+
+def finalize_event_results(
+    *,
+    event: Event,
+    tournament_id: int,
+    judge_user_id: int | None,
+) -> dict:
+    warnings = engine.validate_finalization(event)
+
+    try:
+        with db.session.begin_nested():
+            engine.calculate_positions(event)
+            log_action(
+                'event_finalized',
+                'event',
+                event.id,
+                {
+                    'tournament_id': tournament_id,
+                    'judge_user_id': judge_user_id,
+                },
+            )
+        db.session.commit()
+    except StaleDataError:
+        db.session.rollback()
+        return {
+            'ok': False,
+            'warnings': warnings,
+            'message': 'Results were modified by another judge during finalization. Reload and finalize again.',
+            'status_code': 409,
+        }
+    except IntegrityError:
+        db.session.rollback()
+        return {
+            'ok': False,
+            'warnings': warnings,
+            'message': 'A database constraint error occurred during finalization. Contact an admin if this persists.',
+            'status_code': 409,
+        }
+
+    invalidate_tournament_caches(tournament_id)
+    return {
+        'ok': True,
+        'warnings': warnings,
+        'message': f'{event.display_name} finalized.',
+        'status_code': 200,
+    }

--- a/tests/test_remedial_pr_fixes.py
+++ b/tests/test_remedial_pr_fixes.py
@@ -153,33 +153,26 @@ def test_health_diag_requires_auth(app):
 
 
 def test_heat_generation_rejects_zero_max_stands(app):
-    from database import db
-    from models import Event, Tournament
-    from models.competitor import ProCompetitor
+    from types import SimpleNamespace
+
     from services.heat_generator import generate_event_heats
 
-    with app.app_context():
-        tournament = Tournament(name='ZeroStand', year=2026, status='setup')
-        db.session.add(tournament)
-        db.session.flush()
-        event = Event(
-            tournament_id=tournament.id,
-            name='Underhand',
-            event_type='pro',
-            gender='M',
-            scoring_type='time',
-            scoring_order='lowest_wins',
-            stand_type='underhand',
-            max_stands=0,
-            status='pending',
-        )
-        db.session.add(event)
-        db.session.flush()
-        competitor = ProCompetitor(tournament_id=tournament.id, name='A', gender='M', status='active')
-        competitor.set_events_entered([str(event.id)])
-        db.session.add(competitor)
-        db.session.commit()
+    event = SimpleNamespace(
+        id=999,
+        name='Underhand',
+        display_name='Underhand',
+        tournament_id=1,
+        event_type='pro',
+        stand_type='underhand',
+        max_stands=0,
+        has_prelims=False,
+    )
 
+    with app.app_context(), pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            'services.heat_generator._get_event_competitors',
+            lambda _event: [{'id': 1, 'name': 'A'}],
+        )
         with pytest.raises(ValueError, match='invalid max_stands'):
             generate_event_heats(event)
 

--- a/tests/test_route_smoke_qa.py
+++ b/tests/test_route_smoke_qa.py
@@ -162,7 +162,7 @@ def _seed_rich_db(app):
         competitor_name=pro.name,
         result_value=25.5,
         run1_value=25.5,
-        status="scored",
+        status="completed",
     )
     _db.session.add(result)
     _db.session.flush()

--- a/tests/test_scoring_workflow.py
+++ b/tests/test_scoring_workflow.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from models.event import EventResult
+from services.scoring_workflow import finalize_event_results, save_heat_results_submission
+from tests.conftest import (
+    make_college_competitor,
+    make_event,
+    make_event_result,
+    make_heat,
+    make_team,
+    make_tournament,
+)
+
+
+def test_save_heat_results_submission_detects_stale_heat_version(db_session):
+    tournament = make_tournament(db_session)
+    team = make_team(db_session, tournament)
+    competitor = make_college_competitor(db_session, tournament, team, 'Stale Judge')
+    event = make_event(
+        db_session,
+        tournament,
+        'Standing Block Hard Hit',
+        event_type='college',
+        scoring_type='hits',
+        scoring_order='highest_wins',
+    )
+    heat = make_heat(
+        db_session,
+        event,
+        competitors=[competitor.id],
+        stand_assignments={str(competitor.id): 1},
+    )
+
+    outcome = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data={
+            'heat_version': str(heat.version_id + 1),
+            f'result_{competitor.id}': '7',
+            f'status_{competitor.id}': 'completed',
+        },
+        judge_user_id=99,
+    )
+
+    assert outcome['ok'] is False
+    assert outcome['status_code'] == 409
+    assert outcome['redirect_kind'] == 'heat_entry'
+
+
+def test_save_heat_results_submission_persists_results_and_undo_token(db_session):
+    tournament = make_tournament(db_session)
+    team = make_team(db_session, tournament)
+    competitor = make_college_competitor(db_session, tournament, team, 'Scored Sam')
+    event = make_event(
+        db_session,
+        tournament,
+        'Standing Block Hard Hit',
+        event_type='college',
+        scoring_type='hits',
+        scoring_order='highest_wins',
+    )
+    heat = make_heat(
+        db_session,
+        event,
+        competitors=[competitor.id],
+        stand_assignments={str(competitor.id): 1},
+    )
+
+    outcome = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data={
+            'heat_version': str(heat.version_id),
+            f'result_{competitor.id}': '9',
+            f'status_{competitor.id}': 'completed',
+        },
+        judge_user_id=7,
+    )
+
+    row = EventResult.query.filter_by(
+        event_id=event.id,
+        competitor_id=competitor.id,
+        competitor_type='college',
+    ).one()
+
+    assert outcome['ok'] is True
+    assert outcome['redirect_kind'] == 'event_results'
+    assert outcome['undo_heat_id'] == heat.id
+    assert outcome['undo_token']['event_id'] == event.id
+    assert row.result_value == Decimal('9.00')
+    assert heat.status == 'completed'
+
+
+def test_save_heat_results_submission_keeps_scores_when_auto_finalize_fails(db_session, monkeypatch):
+    tournament = make_tournament(db_session)
+    team = make_team(db_session, tournament)
+    first = make_college_competitor(db_session, tournament, team, 'A')
+    second = make_college_competitor(db_session, tournament, team, 'B')
+    event = make_event(
+        db_session,
+        tournament,
+        'Single Buck',
+        event_type='college',
+        scoring_type='time',
+        scoring_order='lowest_wins',
+    )
+    heat = make_heat(
+        db_session,
+        event,
+        competitors=[first.id, second.id],
+        stand_assignments={str(first.id): 1, str(second.id): 2},
+    )
+
+    def _boom(_event):
+        raise RuntimeError('boom')
+
+    monkeypatch.setattr('services.scoring_engine.calculate_positions', _boom)
+
+    outcome = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data={
+            'heat_version': str(heat.version_id),
+            f't1_run1_{first.id}': '12.0',
+            f't2_run1_{first.id}': '12.4',
+            f'status_{first.id}': 'completed',
+            f't1_run1_{second.id}': '13.0',
+            f't2_run1_{second.id}': '13.2',
+            f'status_{second.id}': 'completed',
+        },
+        judge_user_id=5,
+    )
+
+    rows = EventResult.query.filter_by(event_id=event.id).order_by(EventResult.competitor_id).all()
+
+    assert outcome['ok'] is True
+    assert outcome['category'] == 'warning'
+    assert float(rows[0].result_value) == pytest.approx(12.2)
+    assert float(rows[1].result_value) == pytest.approx(13.1)
+    assert event.is_finalized is False
+
+
+def test_finalize_event_results_returns_warnings_and_finalizes(db_session):
+    tournament = make_tournament(db_session)
+    team = make_team(db_session, tournament)
+    first = make_college_competitor(db_session, tournament, team, 'Final A')
+    second = make_college_competitor(db_session, tournament, team, 'Final B')
+    event = make_event(
+        db_session,
+        tournament,
+        'Single Buck',
+        event_type='college',
+        scoring_type='time',
+        scoring_order='lowest_wins',
+    )
+    make_event_result(
+        db_session,
+        event,
+        first,
+        competitor_type='college',
+        result_value=10.0,
+        run1_value=10.0,
+        status='completed',
+    )
+    make_event_result(
+        db_session,
+        event,
+        second,
+        competitor_type='college',
+        result_value=12.0,
+        run1_value=12.0,
+        status='completed',
+    )
+
+    outcome = finalize_event_results(
+        event=event,
+        tournament_id=tournament.id,
+        judge_user_id=3,
+    )
+
+    rows = EventResult.query.filter_by(event_id=event.id).order_by(EventResult.final_position).all()
+    assert outcome['ok'] is True
+    assert isinstance(outcome['warnings'], list)
+    assert rows[0].competitor_id == first.id
+    assert rows[0].final_position == 1
+    assert rows[1].final_position == 2


### PR DESCRIPTION
## Summary
- extract heat-save and event-finalization orchestration into a shared scoring workflow service
- keep route-layer HTTP concerns thin while preserving undo tokens and redirect behavior
- normalize mixed heat competitor payload shapes so scoring screens and heat PDFs work with both IDs and dict entries
- harden scoring management routes with explicit login requirements
- fix stale regression fixtures that broke after integrity constraints landed

## Validation
- python -m pytest tests/test_route_smoke_qa.py -q
- python -m pytest tests/test_scoring_workflow.py tests/test_scoring.py tests/test_scoring_integration.py tests/test_scoring_engine_integration.py tests/test_dq_and_status_reason.py tests/test_scoring_integrity_phase4.py tests/test_remedial_pr_fixes.py::test_heat_generation_rejects_zero_max_stands -q
- ruff check routes/scoring.py services/scoring_workflow.py tests/test_scoring_workflow.py tests/test_remedial_pr_fixes.py tests/test_route_smoke_qa.py