### PR TITLE
Extract database restore validation service

### DIFF
--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -3,7 +3,6 @@ Reporting routes for standings, results, and exports.
 """
 import json
 import os
-import sqlite3
 import tempfile
 
 from flask import (
@@ -37,26 +36,15 @@ from services.excel_io import export_results_to_excel
 from services.handicap_export import build_chopping_rows, export_chopping_results_to_excel
 from services.report_cache import get as cache_get
 from services.report_cache import set as cache_set
-from services.upload_security import malware_scan
+from services.restore_workflow import prepare_sqlite_restore
+from services.restore_workflow import sqlite_schema_info as _restore_schema_info
 
 reporting_bp = Blueprint('reporting', __name__)
 
 
 def _sqlite_schema_info(path: str) -> dict:
     """Read lightweight schema metadata from a SQLite database file."""
-    conn = sqlite3.connect(path)
-    try:
-        tables = {
-            row[0]
-            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        }
-        revision = None
-        if 'alembic_version' in tables:
-            row = conn.execute('SELECT version_num FROM alembic_version LIMIT 1').fetchone()
-            revision = row[0] if row else None
-        return {'tables': tables, 'revision': revision}
-    finally:
-        conn.close()
+    return _restore_schema_info(path)
 
 
 def _cached_payload(key: str, builder):
@@ -471,29 +459,14 @@ def restore_database(tournament_id):
     f.save(temp_path)
 
     try:
-        malware_scan(
-            temp_path,
-            enabled=bool(current_app.config.get('ENABLE_UPLOAD_MALWARE_SCAN', False)),
-            command_template=current_app.config.get('MALWARE_SCAN_COMMAND', '')
+        restore_plan = prepare_sqlite_restore(
+            upload_path=temp_path,
+            db_uri=uri,
+            instance_path=current_app.instance_path,
+            malware_scan_enabled=bool(current_app.config.get('ENABLE_UPLOAD_MALWARE_SCAN', False)),
+            malware_scan_command=current_app.config.get('MALWARE_SCAN_COMMAND', ''),
         )
-        db_path = uri.replace('sqlite:///', '', 1)
-        if not os.path.isabs(db_path):
-            db_path = os.path.join(current_app.instance_path, db_path)
-        current_info = _sqlite_schema_info(db_path)
-        uploaded_info = _sqlite_schema_info(temp_path)
-        required_tables = {'tournaments', 'events', 'event_results', 'heats', 'users'}
-        missing_tables = sorted(required_tables - set(uploaded_info['tables']))
-        if missing_tables:
-            raise RuntimeError(
-                f'Restore file is missing required tables: {", ".join(missing_tables)}'
-            )
-        if not uploaded_info.get('revision'):
-            raise RuntimeError('Restore file is missing Alembic migration metadata.')
-        if current_info.get('revision') and uploaded_info['revision'] != current_info['revision']:
-            raise RuntimeError(
-                'Restore file schema revision does not match the current application schema. '
-                f"Expected {current_info['revision']}, got {uploaded_info['revision']}."
-            )
+        db_path = restore_plan['target_path']
         db.session.remove()
         db.engine.dispose()
         os.replace(temp_path, db_path)

--- a/services/restore_workflow.py
+++ b/services/restore_workflow.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+
+from services.upload_security import malware_scan
+
+REQUIRED_SQLITE_TABLES = {'tournaments', 'events', 'event_results', 'heats', 'users'}
+
+
+def sqlite_schema_info(path: str) -> dict:
+    conn = sqlite3.connect(path)
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        revision = None
+        if 'alembic_version' in tables:
+            row = conn.execute('SELECT version_num FROM alembic_version LIMIT 1').fetchone()
+            revision = row[0] if row else None
+        return {'tables': tables, 'revision': revision}
+    finally:
+        conn.close()
+
+
+def sqlite_db_path_from_uri(uri: str, instance_path: str) -> str:
+    if not uri.startswith('sqlite:///'):
+        raise RuntimeError('Database restore is only available for SQLite in this environment.')
+    db_path = uri.replace('sqlite:///', '', 1)
+    if not os.path.isabs(db_path):
+        db_path = os.path.join(instance_path, db_path)
+    return db_path
+
+
+def validate_sqlite_restore_file(upload_path: str, current_db_path: str) -> dict:
+    current_info = sqlite_schema_info(current_db_path)
+    uploaded_info = sqlite_schema_info(upload_path)
+    missing_tables = sorted(REQUIRED_SQLITE_TABLES - set(uploaded_info['tables']))
+    if missing_tables:
+        raise RuntimeError(
+            f'Restore file is missing required tables: {", ".join(missing_tables)}'
+        )
+    if not uploaded_info.get('revision'):
+        raise RuntimeError('Restore file is missing Alembic migration metadata.')
+    if current_info.get('revision') and uploaded_info['revision'] != current_info['revision']:
+        raise RuntimeError(
+            'Restore file schema revision does not match the current application schema. '
+            f"Expected {current_info['revision']}, got {uploaded_info['revision']}."
+        )
+    return {
+        'target_path': current_db_path,
+        'current_revision': current_info.get('revision'),
+        'uploaded_revision': uploaded_info.get('revision'),
+        'tables': uploaded_info['tables'],
+    }
+
+
+def prepare_sqlite_restore(
+    *,
+    upload_path: str,
+    db_uri: str,
+    instance_path: str,
+    malware_scan_enabled: bool = False,
+    malware_scan_command: str = '',
+) -> dict:
+    target_path = sqlite_db_path_from_uri(db_uri, instance_path)
+    malware_scan(
+        upload_path,
+        enabled=malware_scan_enabled,
+        command_template=malware_scan_command,
+    )
+    return validate_sqlite_restore_file(upload_path, target_path)

--- a/tests/test_restore_workflow.py
+++ b/tests/test_restore_workflow.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from services.restore_workflow import (
+    prepare_sqlite_restore,
+    sqlite_db_path_from_uri,
+    validate_sqlite_restore_file,
+)
+
+
+@pytest.fixture
+def workspace_tmpdir() -> Path:
+    path = Path.cwd() / 'instance' / f'restore-workflow-{uuid.uuid4().hex}'
+    path.mkdir(parents=True, exist_ok=False)
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def _make_sqlite_db(path, *, revision='rev1', tables=None):
+    tables = tables or {'tournaments', 'events', 'event_results', 'heats', 'users'}
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute('CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)')
+        conn.execute('INSERT INTO alembic_version (version_num) VALUES (?)', (revision,))
+        for table in tables:
+            conn.execute(f'CREATE TABLE {table} (id INTEGER PRIMARY KEY)')
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_validate_sqlite_restore_file_accepts_matching_schema(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head')
+
+    result = validate_sqlite_restore_file(str(upload), str(current))
+
+    assert result['target_path'] == str(current)
+    assert result['current_revision'] == 'head'
+    assert result['uploaded_revision'] == 'head'
+
+
+def test_validate_sqlite_restore_file_rejects_missing_tables(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head', tables={'tournaments'})
+
+    with pytest.raises(RuntimeError, match='missing required tables'):
+        validate_sqlite_restore_file(str(upload), str(current))
+
+
+def test_validate_sqlite_restore_file_rejects_revision_mismatch(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='old')
+
+    with pytest.raises(RuntimeError, match='schema revision does not match'):
+        validate_sqlite_restore_file(str(upload), str(current))
+
+
+def test_sqlite_db_path_from_uri_rejects_non_sqlite(workspace_tmpdir):
+    with pytest.raises(RuntimeError, match='only available for SQLite'):
+        sqlite_db_path_from_uri('postgresql://example/db', str(workspace_tmpdir))
+
+
+def test_prepare_sqlite_restore_runs_scan_and_returns_plan(workspace_tmpdir, monkeypatch):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head')
+    calls = []
+
+    def _scan(path, *, enabled, command_template):
+        calls.append((path, enabled, command_template))
+
+    monkeypatch.setattr('services.restore_workflow.malware_scan', _scan)
+
+    result = prepare_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        malware_scan_enabled=True,
+        malware_scan_command='scan {path}',
+    )
+
+    assert result['target_path'] == str(current)
+    assert calls == [(str(upload), True, 'scan {path}')]


### PR DESCRIPTION
## Summary
- move SQLite restore schema/revision validation into a dedicated service
- keep the reporting route focused on upload handling, DB disposal, and user messaging
- add direct restore workflow tests for valid schema, missing tables, revision mismatch, non-SQLite URIs, and malware-scan invocation

## Validation
- python -m pytest tests/test_restore_workflow.py tests/test_admin_audit_hardening.py::test_restore_failure_writes_audit_log tests/test_admin_audit_hardening.py::test_judge_cannot_restore_database tests/test_remedial_pr_fixes.py::test_restore_rejects_schema_mismatch -q
- ruff check routes/reporting.py services/restore_workflow.py tests/test_restore_workflow.py

## Notes
Local Windows temp directory permissions are broken in this workspace, so the new tests create UUID-named workspace-local directories under instance/ instead of pytest tmp_path.