### PR TITLE
Extract reporting export workflows

### DIFF
--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -32,10 +32,16 @@ from models import Event, Tournament
 from services.audit import log_action
 from services.background_jobs import get as get_job
 from services.background_jobs import submit as submit_job
-from services.excel_io import export_results_to_excel
-from services.handicap_export import build_chopping_rows, export_chopping_results_to_excel
 from services.report_cache import get as cache_get
 from services.report_cache import set as cache_set
+from services.reporting_export import (
+    build_chopping_export,
+    build_chopping_json_payload,
+    build_results_export,
+    resolve_completed_export_path,
+    safe_download_name,
+    submit_results_export_job,
+)
 from services.restore_workflow import prepare_sqlite_restore
 from services.restore_workflow import sqlite_schema_info as _restore_schema_info
 
@@ -274,26 +280,23 @@ def all_results_print(tournament_id):
 def export_results(tournament_id):
     """Export standings and event results to Excel."""
     tournament = Tournament.query.get_or_404(tournament_id)
-    fd, path = tempfile.mkstemp(prefix=f'proam_{tournament_id}_', suffix='.xlsx')
-    os.close(fd)
-    export_results_to_excel(tournament, path)
+    export = build_results_export(tournament)
     log_action('report_export_downloaded', 'tournament', tournament.id, {
         'tournament_id': tournament.id,
-        'format': 'xlsx',
-        'kind': 'all_results',
+        'format': export['format'],
+        'kind': export['kind'],
     })
     db.session.commit()
 
     @after_this_request
     def cleanup_file(response):
         try:
-            os.remove(path)
+            os.remove(export['path'])
         except OSError:
             pass
         return response
 
-    download_name = f'{tournament.name}_{tournament.year}_results.xlsx'.replace(' ', '_')
-    return send_file(path, as_attachment=True, download_name=download_name)
+    return send_file(export['path'], as_attachment=True, download_name=export['download_name'])
 
 
 @reporting_bp.route('/<int:tournament_id>/export-chopping')
@@ -303,10 +306,7 @@ def export_chopping_results(tournament_id):
     fmt = (request.args.get('format') or 'xlsx').strip().lower()
 
     if fmt == 'json':
-        payload = {
-            'tournament': {'id': tournament.id, 'name': tournament.name, 'year': tournament.year},
-            'rows': build_chopping_rows(tournament),
-        }
+        payload = build_chopping_json_payload(tournament)
         log_action('report_export_downloaded', 'tournament', tournament.id, {
             'tournament_id': tournament.id,
             'format': 'json',
@@ -315,48 +315,30 @@ def export_chopping_results(tournament_id):
         db.session.commit()
         return Response(json.dumps(payload), mimetype='application/json')
 
-    fd, path = tempfile.mkstemp(prefix=f'proam_{tournament_id}_chopping_', suffix='.xlsx')
-    os.close(fd)
-    export_chopping_results_to_excel(tournament, path)
+    export = build_chopping_export(tournament)
     log_action('report_export_downloaded', 'tournament', tournament.id, {
         'tournament_id': tournament.id,
-        'format': 'xlsx',
-        'kind': 'chopping_results',
+        'format': export['format'],
+        'kind': export['kind'],
     })
     db.session.commit()
 
     @after_this_request
     def cleanup_file(response):
         try:
-            os.remove(path)
+            os.remove(export['path'])
         except OSError:
             pass
         return response
 
-    download_name = f'{tournament.name}_{tournament.year}_chopping_results.xlsx'.replace(' ', '_')
-    return send_file(path, as_attachment=True, download_name=download_name)
+    return send_file(export['path'], as_attachment=True, download_name=export['download_name'])
 
 
 @reporting_bp.route('/<int:tournament_id>/export-results/async', methods=['POST'])
 def export_results_async(tournament_id):
     """Start export generation as a background job for larger tournaments."""
     tournament = Tournament.query.get_or_404(tournament_id)
-
-    def _build_export(target_tournament_id: int) -> str:
-        export_tournament = Tournament.query.get(target_tournament_id)
-        if not export_tournament:
-            raise RuntimeError(f'Tournament {target_tournament_id} not found.')
-        fd, path = tempfile.mkstemp(prefix=f'proam_{tournament_id}_', suffix='.xlsx')
-        os.close(fd)
-        export_results_to_excel(export_tournament, path)
-        return path
-
-    job_id = submit_job(
-        f'export_results_{tournament_id}',
-        _build_export,
-        tournament_id,
-        metadata={'tournament_id': tournament_id, 'kind': 'export_results'},
-    )
+    job_id = submit_results_export_job(tournament_id)
     log_action('report_export_job_started', 'tournament', tournament.id, {'job_id': job_id})
     db.session.commit()
     return redirect(url_for('reporting.export_results_job_status', tournament_id=tournament_id, job_id=job_id))
@@ -365,10 +347,10 @@ def export_results_async(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/jobs/<job_id>')
 def export_results_job_status(tournament_id, job_id):
     tournament = Tournament.query.get_or_404(tournament_id)
-    job = get_job(job_id)
-    job_meta = job.get('metadata') if job else {}
-    if not job or int((job_meta or {}).get('tournament_id', -1)) != tournament_id:
+    job = resolve_completed_export_path(tournament_id, job_id, get_job)
+    if not job:
         abort(404)
+    job_meta = job.get('metadata') or {}
     job_kind = (job_meta or {}).get('kind') or ''
 
     if job['status'] != 'completed':
@@ -398,7 +380,7 @@ def export_results_job_status(tournament_id, job_id):
             pass
         return response
 
-    download_name = f'{tournament.name}_{tournament.year}_results.xlsx'.replace(' ', '_')
+    download_name = safe_download_name(tournament, 'results.xlsx')
     return send_file(path, as_attachment=True, download_name=download_name)
 
 

--- a/services/reporting_export.py
+++ b/services/reporting_export.py
@@ -1,0 +1,92 @@
+"""Reporting export workflow helpers.
+
+Routes should handle HTTP concerns; this module owns export file creation,
+download naming, JSON payload assembly, and async job submission details.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+from database import db
+from models import Tournament
+from services.background_jobs import submit as submit_job
+from services.excel_io import export_results_to_excel
+from services.handicap_export import build_chopping_rows, export_chopping_results_to_excel
+
+
+def safe_download_name(tournament: Tournament, suffix: str) -> str:
+    """Return a stable attachment filename for a tournament export."""
+    return f'{tournament.name}_{tournament.year}_{suffix}'.replace(' ', '_')
+
+
+def _reserve_export_path(tournament_id: int, *, suffix: str = '.xlsx', label: str = '') -> str:
+    prefix = f'proam_{tournament_id}_'
+    if label:
+        prefix = f'{prefix}{label}_'
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+    os.close(fd)
+    return path
+
+
+def build_results_export(tournament: Tournament) -> dict:
+    """Create a full results Excel export and return file metadata."""
+    path = _reserve_export_path(tournament.id, suffix='.xlsx')
+    export_results_to_excel(tournament, path)
+    return {
+        'path': path,
+        'download_name': safe_download_name(tournament, 'results.xlsx'),
+        'format': 'xlsx',
+        'kind': 'all_results',
+    }
+
+
+def build_chopping_export(tournament: Tournament) -> dict:
+    """Create a chopping-only Excel export and return file metadata."""
+    path = _reserve_export_path(tournament.id, suffix='.xlsx', label='chopping')
+    export_chopping_results_to_excel(tournament, path)
+    return {
+        'path': path,
+        'download_name': safe_download_name(tournament, 'chopping_results.xlsx'),
+        'format': 'xlsx',
+        'kind': 'chopping_results',
+    }
+
+
+def build_chopping_json_payload(tournament: Tournament) -> dict:
+    """Return the JSON payload for chopping-only handicap tooling."""
+    return {
+        'tournament': {
+            'id': tournament.id,
+            'name': tournament.name,
+            'year': tournament.year,
+        },
+        'rows': build_chopping_rows(tournament),
+    }
+
+
+def build_results_export_for_job(tournament_id: int) -> str:
+    """Background-job entry point for a full results export."""
+    tournament = db.session.get(Tournament, tournament_id)
+    if not tournament:
+        raise RuntimeError(f'Tournament {tournament_id} not found.')
+    return build_results_export(tournament)['path']
+
+
+def submit_results_export_job(tournament_id: int) -> str:
+    """Submit a tournament-bound background results export."""
+    return submit_job(
+        f'export_results_{tournament_id}',
+        build_results_export_for_job,
+        tournament_id,
+        metadata={'tournament_id': tournament_id, 'kind': 'export_results'},
+    )
+
+
+def resolve_completed_export_path(tournament_id: int, job_id: str, job_getter) -> dict | None:
+    """Return a validated export job snapshot or ``None`` for wrong tournament/missing jobs."""
+    job = job_getter(job_id)
+    job_meta = job.get('metadata') if job else {}
+    if not job or int((job_meta or {}).get('tournament_id', -1)) != tournament_id:
+        return None
+    return job

--- a/tests/test_reporting_export.py
+++ b/tests/test_reporting_export.py
@@ -1,0 +1,95 @@
+import os
+
+
+def test_build_results_export_returns_file_metadata(app, monkeypatch):
+    from database import db
+    from models import Tournament
+    from services import reporting_export
+
+    with app.app_context():
+        tournament = Tournament(name='Export Smoke', year=2026, status='setup')
+        db.session.add(tournament)
+        db.session.commit()
+
+        out = os.path.join(app.instance_path, 'reporting-export-results.xlsx')
+
+        def _fake_export(export_tournament, path):
+            assert export_tournament.id == tournament.id
+            with open(path, 'wb') as fh:
+                fh.write(b'xlsx')
+
+        monkeypatch.setattr(reporting_export, '_reserve_export_path', lambda *_a, **_k: out)
+        monkeypatch.setattr(reporting_export, 'export_results_to_excel', _fake_export)
+
+        result = reporting_export.build_results_export(tournament)
+
+    assert result == {
+        'path': out,
+        'download_name': 'Export_Smoke_2026_results.xlsx',
+        'format': 'xlsx',
+        'kind': 'all_results',
+    }
+    assert os.path.exists(out)
+    os.remove(out)
+
+
+def test_build_chopping_json_payload_uses_shared_rows(app, monkeypatch):
+    from database import db
+    from models import Tournament
+    from services import reporting_export
+
+    with app.app_context():
+        tournament = Tournament(name='Chop Tooling', year=2026, status='setup')
+        db.session.add(tournament)
+        db.session.commit()
+        tournament_id = tournament.id
+
+        monkeypatch.setattr(
+            reporting_export,
+            'build_chopping_rows',
+            lambda export_tournament: [{'tournament_id': export_tournament.id}],
+        )
+
+        payload = reporting_export.build_chopping_json_payload(tournament)
+
+    assert payload == {
+        'tournament': {'id': tournament_id, 'name': 'Chop Tooling', 'year': 2026},
+        'rows': [{'tournament_id': tournament_id}],
+    }
+
+
+def test_submit_results_export_job_is_tournament_bound(monkeypatch):
+    from services import reporting_export
+
+    captured = {}
+
+    def _fake_submit(label, fn, *args, metadata=None, **kwargs):
+        captured.update({
+            'label': label,
+            'fn': fn,
+            'args': args,
+            'metadata': metadata,
+            'kwargs': kwargs,
+        })
+        return 'job-123'
+
+    monkeypatch.setattr(reporting_export, 'submit_job', _fake_submit)
+
+    job_id = reporting_export.submit_results_export_job(42)
+
+    assert job_id == 'job-123'
+    assert captured['label'] == 'export_results_42'
+    assert captured['fn'] is reporting_export.build_results_export_for_job
+    assert captured['args'] == (42,)
+    assert captured['metadata'] == {'tournament_id': 42, 'kind': 'export_results'}
+    assert captured['kwargs'] == {}
+
+
+def test_resolve_completed_export_path_rejects_cross_tournament_jobs():
+    from services.reporting_export import resolve_completed_export_path
+
+    def _get_job(_job_id):
+        return {'metadata': {'tournament_id': 7}, 'status': 'completed', 'result': 'out.xlsx'}
+
+    assert resolve_completed_export_path(8, 'job-1', _get_job) is None
+    assert resolve_completed_export_path(7, 'job-1', _get_job)['result'] == 'out.xlsx'


### PR DESCRIPTION
## Summary
- Move full-results and chopping export file creation into services/reporting_export.py
- Move export async job submission and tournament-bound job validation into the service layer
- Keep reporting routes focused on HTTP response, audit logging, cleanup, and redirects
- Add focused unit coverage for export metadata, chopping JSON payloads, async job submission, and cross-tournament job rejection

## Verification
- python -m pytest tests\\test_reporting_export.py tests\\test_remedial_pr_fixes.py::test_export_job_status_is_tournament_bound tests\\test_remedial_pr_fixes.py::test_export_results_creates_placeholder_sheet_for_empty_tournament -q
- ruff check routes\\reporting.py services\\reporting_export.py tests\\test_reporting_export.py