### PR TITLE
Extract reporting backup workflows

### DIFF
--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -31,9 +31,9 @@ from database import db
 from models import Event, Tournament
 from services.audit import log_action
 from services.background_jobs import get as get_job
-from services.background_jobs import submit as submit_job
 from services.report_cache import get as cache_get
 from services.report_cache import set as cache_set
+from services.reporting_backup import sqlite_backup_download_plan, submit_database_backup_job
 from services.reporting_export import (
     build_chopping_export,
     build_chopping_json_payload,
@@ -392,18 +392,13 @@ def backup_database(tournament_id):
         abort(403)
 
     uri = current_app.config.get('SQLALCHEMY_DATABASE_URI', '')
-    if not uri.startswith('sqlite:///'):
-        flash('Database backup download is only available for SQLite in this environment.', 'warning')
+    backup_plan = sqlite_backup_download_plan(uri, current_app.instance_path)
+    if not backup_plan['ok']:
+        category = 'warning' if backup_plan['reason'] == 'unsupported' else 'error'
+        flash(backup_plan['message'], category)
         return redirect(url_for('main.tournament_detail', tournament_id=tournament_id))
 
-    db_path = uri.replace('sqlite:///', '', 1)
-    if not os.path.isabs(db_path):
-        db_path = os.path.join(current_app.instance_path, db_path)
-
-    if not os.path.exists(db_path):
-        flash('Database file not found.', 'error')
-        return redirect(url_for('main.tournament_detail', tournament_id=tournament_id))
-
+    db_path = backup_plan['path']
     log_action('database_backup_downloaded', 'tournament', tournament_id, {'path': db_path})
     db.session.commit()
     return send_file(db_path, as_attachment=True, download_name=f'proam_backup_{tournament_id}.db')
@@ -667,16 +662,7 @@ def cloud_backup(tournament_id):
 
     uri = current_app.config.get('SQLALCHEMY_DATABASE_URI', '')
     instance_path = current_app.instance_path
-    from services.backup import backup_database
-
-    def _run_backup():
-        return backup_database(uri, tournament_id, instance_path)
-
-    job_id = submit_job(
-        f'backup:t{tournament_id}',
-        _run_backup,
-        metadata={'tournament_id': tournament_id, 'kind': 'backup'},
-    )
+    job_id = submit_database_backup_job(uri, tournament_id, instance_path)
 
     log_action('cloud_backup_triggered', 'tournament', tournament_id, {'job_id': job_id})
     db.session.commit()

--- a/services/reporting_backup.py
+++ b/services/reporting_backup.py
@@ -1,0 +1,47 @@
+"""Reporting backup workflow helpers."""
+from __future__ import annotations
+
+import os
+
+from services.background_jobs import submit as submit_job
+from services.backup import backup_database as run_backup_database
+
+
+def sqlite_backup_download_plan(db_uri: str, instance_path: str) -> dict:
+    """Return a validated SQLite backup download plan."""
+    if not db_uri.startswith('sqlite:///'):
+        return {
+            'ok': False,
+            'reason': 'unsupported',
+            'message': 'Database backup download is only available for SQLite in this environment.',
+        }
+
+    db_path = db_uri.replace('sqlite:///', '', 1)
+    if not os.path.isabs(db_path):
+        db_path = os.path.join(instance_path, db_path)
+
+    if not os.path.exists(db_path):
+        return {
+            'ok': False,
+            'reason': 'missing',
+            'message': 'Database file not found.',
+        }
+
+    return {'ok': True, 'path': db_path}
+
+
+def run_database_backup(db_uri: str, tournament_id: int, instance_path: str) -> dict:
+    """Background-job entry point for unified database backup."""
+    return run_backup_database(db_uri, tournament_id, instance_path)
+
+
+def submit_database_backup_job(db_uri: str, tournament_id: int, instance_path: str) -> str:
+    """Submit a tournament-bound database backup job."""
+    return submit_job(
+        f'backup:t{tournament_id}',
+        run_database_backup,
+        db_uri,
+        tournament_id,
+        instance_path,
+        metadata={'tournament_id': tournament_id, 'kind': 'backup'},
+    )

--- a/tests/test_reporting_backup.py
+++ b/tests/test_reporting_backup.py
@@ -1,0 +1,65 @@
+import os
+
+
+def test_sqlite_backup_download_plan_accepts_existing_relative_db(app):
+    from services.reporting_backup import sqlite_backup_download_plan
+
+    db_path = os.path.join(app.instance_path, 'backup-plan.db')
+    with open(db_path, 'wb') as fh:
+        fh.write(b'SQLite format 3\x00')
+
+    try:
+        result = sqlite_backup_download_plan('sqlite:///backup-plan.db', app.instance_path)
+    finally:
+        os.remove(db_path)
+
+    assert result == {'ok': True, 'path': db_path}
+
+
+def test_sqlite_backup_download_plan_rejects_non_sqlite(app):
+    from services.reporting_backup import sqlite_backup_download_plan
+
+    result = sqlite_backup_download_plan('postgresql://example/db', app.instance_path)
+
+    assert result['ok'] is False
+    assert result['reason'] == 'unsupported'
+    assert 'SQLite' in result['message']
+
+
+def test_sqlite_backup_download_plan_rejects_missing_file(app):
+    from services.reporting_backup import sqlite_backup_download_plan
+
+    result = sqlite_backup_download_plan('sqlite:///missing-backup-plan.db', app.instance_path)
+
+    assert result == {
+        'ok': False,
+        'reason': 'missing',
+        'message': 'Database file not found.',
+    }
+
+
+def test_submit_database_backup_job_is_tournament_bound(monkeypatch):
+    from services import reporting_backup
+
+    captured = {}
+
+    def _fake_submit(label, fn, *args, metadata=None, **kwargs):
+        captured.update({
+            'label': label,
+            'fn': fn,
+            'args': args,
+            'metadata': metadata,
+            'kwargs': kwargs,
+        })
+        return 'backup-job-123'
+
+    monkeypatch.setattr(reporting_backup, 'submit_job', _fake_submit)
+
+    job_id = reporting_backup.submit_database_backup_job('sqlite:///proam.db', 42, '/instance')
+
+    assert job_id == 'backup-job-123'
+    assert captured['label'] == 'backup:t42'
+    assert captured['fn'] is reporting_backup.run_database_backup
+    assert captured['args'] == ('sqlite:///proam.db', 42, '/instance')
+    assert captured['metadata'] == {'tournament_id': 42, 'kind': 'backup'}
+    assert captured['kwargs'] == {}


### PR DESCRIPTION
## Summary
- Move SQLite backup-download validation into services/reporting_backup.py
- Move cloud/local backup job submission into the service layer
- Keep reporting routes focused on auth, HTTP responses, audit logging, and redirects
- Add focused unit coverage for SQLite backup eligibility and tournament-bound backup job submission

## Verification
- python -m pytest tests\\test_reporting_backup.py tests\\test_admin_audit_hardening.py::test_judge_cannot_restore_database tests\\test_remedial_pr_fixes.py::test_export_job_status_is_tournament_bound -q
- ruff check routes\\reporting.py services\\reporting_backup.py tests\\test_reporting_backup.py