### PR TITLE
Fix UTC helper Python 3.10 compatibility

### DIFF
--- a/models/background_job.py
+++ b/models/background_job.py
@@ -1,7 +1,7 @@
 """Durable record of async background job execution."""
-from datetime import datetime
 
 from database import db
+from services.time_utils import utc_now_naive
 
 
 class BackgroundJob(db.Model):
@@ -18,7 +18,7 @@ class BackgroundJob(db.Model):
     label = db.Column(db.String(120), nullable=False)
     status = db.Column(db.String(20), nullable=False)
     tournament_id = db.Column(db.Integer, nullable=True)
-    submitted_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    submitted_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
     started_at = db.Column(db.DateTime, nullable=True)
     finished_at = db.Column(db.DateTime, nullable=True)
     result_json = db.Column(db.Text, nullable=True)

--- a/services/background_jobs.py
+++ b/services/background_jobs.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from database import db
 from models.background_job import BackgroundJob
+from services.time_utils import utc_now_naive
 
 _executor = ThreadPoolExecutor(max_workers=2)
 _jobs = {}
@@ -122,7 +123,7 @@ def _row_to_dict(row: BackgroundJob) -> dict:
 
 def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str:
     job_id = uuid.uuid4().hex
-    submitted_at = datetime.utcnow()
+    submitted_at = utc_now_naive()
     with _lock:
         _jobs[job_id] = {
             'id': job_id,
@@ -155,7 +156,7 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
             except Exception as exc:
                 job['status'] = 'failed'
                 job['error'] = str(exc)
-            job['finished_at'] = datetime.utcnow()
+            job['finished_at'] = utc_now_naive()
             snapshot = _snapshot(job)
         _persist_job(
             job_id,
@@ -168,7 +169,7 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
     with _lock:
         _jobs[job_id]['status'] = 'running'
         _jobs[job_id]['future'] = future
-        started_at = datetime.utcnow()
+        started_at = utc_now_naive()
         _jobs[job_id]['started_at'] = started_at
     _persist_job(job_id, status='running', started_at=started_at)
 

--- a/services/backup.py
+++ b/services/backup.py
@@ -19,8 +19,9 @@ import os
 import shutil
 import subprocess
 import tempfile
-from datetime import datetime
 from urllib.parse import urlparse
+
+from services.time_utils import utc_timestamp_for_filename
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _timestamp() -> str:
-    return datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+    return utc_timestamp_for_filename()
 
 
 def is_postgres(uri: str) -> bool:

--- a/services/time_utils.py
+++ b/services/time_utils.py
@@ -1,10 +1,10 @@
 """Time helpers for UTC-safe service code."""
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 
 def utc_now_naive() -> datetime:
     """Return current UTC time as a naive datetime for legacy DateTime columns."""
-    return datetime.now(UTC).replace(tzinfo=None)
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def utc_timestamp_for_filename() -> str:

--- a/services/time_utils.py
+++ b/services/time_utils.py
@@ -1,0 +1,12 @@
+"""Time helpers for UTC-safe service code."""
+from datetime import UTC, datetime
+
+
+def utc_now_naive() -> datetime:
+    """Return current UTC time as a naive datetime for legacy DateTime columns."""
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def utc_timestamp_for_filename() -> str:
+    """Return a compact UTC timestamp safe for filenames."""
+    return utc_now_naive().strftime('%Y%m%d_%H%M%S')

--- a/tests/test_sms_backup.py
+++ b/tests/test_sms_backup.py
@@ -266,17 +266,14 @@ class TestBackupTimestamp:
         # All chars except underscore should be digits
         assert ts.replace('_', '').isdigit()
 
-    def test_timestamp_uses_utcnow(self):
-        """_timestamp() uses datetime.utcnow() for consistency."""
-        from datetime import datetime
-
+    def test_timestamp_uses_utc_filename_helper(self):
+        """_timestamp() delegates UTC filename formatting to the shared helper."""
         from services.backup import _timestamp
-        with patch('services.backup.datetime') as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 20, 14, 30, 45)
-            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        with patch('services.backup.utc_timestamp_for_filename') as mock_ts:
+            mock_ts.return_value = '20260320_143045'
             result = _timestamp()
             assert result == '20260320_143045'
-            mock_dt.utcnow.assert_called_once()
+            mock_ts.assert_called_once()
 
 
 class TestDbPathFromUri:

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+
+def test_utc_now_naive_returns_naive_datetime():
+    from services.time_utils import utc_now_naive
+
+    value = utc_now_naive()
+
+    assert isinstance(value, datetime)
+    assert value.tzinfo is None
+
+
+def test_utc_timestamp_for_filename_is_compact():
+    from services.time_utils import utc_timestamp_for_filename
+
+    value = utc_timestamp_for_filename()
+
+    assert len(value) == 15
+    assert value[8] == '_'
+    assert value.replace('_', '').isdigit()


### PR DESCRIPTION
## Summary
- Replace datetime.UTC with datetime.timezone.utc so CI/runtime on Python 3.10 can import services.time_utils
- Repairs the import failure introduced by PR #38 after auto-merge raced ahead of the follow-up fix commit

## Verification
- python -m pytest tests\\test_time_utils.py tests\\test_sms_backup.py::TestBackupTimestamp tests\\test_remedial_pr_fixes.py::test_background_jobs_run_with_app_context tests\\test_remedial_pr_fixes.py::test_export_job_status_is_tournament_bound -q
- ruff check services\\time_utils.py services\\background_jobs.py models\\background_job.py services\\backup.py tests\\test_time_utils.py tests\\test_sms_backup.py