### PR TITLE
Fix UTC helper on Python 3.10

### DIFF
--- a/services/time_utils.py
+++ b/services/time_utils.py
@@ -1,10 +1,10 @@
 """Time helpers for UTC-safe service code."""
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 
 def utc_now_naive() -> datetime:
     """Return current UTC time as a naive datetime for legacy DateTime columns."""
-    return datetime.now(UTC).replace(tzinfo=None)
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def utc_timestamp_for_filename() -> str:


### PR DESCRIPTION
## Summary
- Replace datetime.UTC with datetime.timezone.utc in services/time_utils.py
- Restores Python 3.10 compatibility for app imports, migrations, and CI after PR #38

## Verification
- python -m pytest tests\\test_time_utils.py tests\\test_sms_backup.py::TestBackupTimestamp tests\\test_remedial_pr_fixes.py::test_background_jobs_run_with_app_context tests\\test_remedial_pr_fixes.py::test_export_job_status_is_tournament_bound -q
- ruff check services\\time_utils.py services\\background_jobs.py models\\background_job.py services\\backup.py tests\\test_time_utils.py tests\\test_sms_backup.py