### PR TITLE
Fix L/R springboard bugs: importer + heat gen + flight builder

### DIFF
--- a/docs/VIDEO_JUDGE_BRACKET_PLAN.md
+++ b/docs/VIDEO_JUDGE_BRACKET_PLAN.md
@@ -1,0 +1,332 @@
+# Plan: Video Judge Workbook + Birling Blank Bracket + Birling Nav + L/R Springboard Bug Fix
+
+Branch: `reporting-export-service`
+Target ship: April 24-25, 2026
+Repo: Missoula-Pro-Am-Manager (Flask 3.1, SQLAlchemy 2.0, pandas 2.1, openpyxl 3.1, Windows/Railway PG prod, SQLite dev)
+
+**Revision: v2 (post-Codex)**. Incorporates 15 findings from Codex outside-voice review (2026-04-20). See "Changes from v1" section at bottom.
+
+## Context
+
+Three show-prep deliverables for the April 24-25 Missoula Pro-Am event:
+
+1. **Video Judge Excel Workbook** — one xlsx, tab per event, long-format rows (one per
+   competitor per run; one per partnered pair per run), two video-judge-time columns per
+   row. Generated during show-prep after events are configured. Sync and async routes.
+
+2. **Birling Blank Bracket Print** — printable (PDF/HTML) double-elimination bracket
+   with round-1 matchups populated and all advancement slots blank. Filled by hand by
+   the birling judge, returned for data entry.
+
+3. **Birling Nav Surfacing** — multiple discoverable entry points to the bracket
+   management page so judges in training can find it.
+
+During the recon for these three, we found six pre-existing production bugs in the
+pro-competitor xlsx importer and springboard heat/flight logic. Must be fixed as one
+atomic PR BEFORE the three deliverables ship.
+
+## Existing infrastructure (reuse, do not rebuild)
+
+- `services/reporting_export.py` — **canonical export service** (extracted this branch, commit `cbe8802`):
+  - `build_results_export(tournament) -> dict` (path + download_name + kind)
+  - `build_chopping_export(tournament) -> dict`
+  - `safe_download_name(tournament, suffix) -> str` (handles space→underscore)
+  - `_reserve_export_path(tid, suffix, label) -> str` (tempfile.mkstemp wrapper)
+  - `submit_results_export_job(tid) -> job_id`
+  - `resolve_completed_export_path(tid, job_id, job_getter) -> dict | None`
+  - **VJ workbook must follow this pattern, not inline `mkstemp` in routes.**
+- `services/excel_io.py:1054` — `export_results_to_excel()` — reference for pandas+openpyxl xlsx emission
+- `services/handicap_export.py:62` — `export_chopping_results_to_excel()` — second reference
+- `routes/reporting.py` (current state) — delegates all xlsx flows to `services.reporting_export`; do NOT import `_safe_filename_part` from `routes/scoring.py` (private helper)
+- `routes/scoring.py:1527-1537` — WeasyPrint-optional PDF response (`try: from weasyprint...except ImportError: return html`); extract into a shared helper (`services/print_response.py`) if reused by birling print
+- `services/judge_sheet.py:64` — `get_event_heats_for_judging()` — similar data shape but filters run 2 and lacks partner resolution
+- `services/birling_bracket.py:48` — `BirlingBracket.generate_bracket()` — populates round-1 in `Event.payouts` JSON, leaves later slots `None`
+- `templates/scheduling/heat_sheets_print.html:443-570` — `hs-bracket-*` CSS + `bracket_match` macro already render `TBD` for `None` slots
+- `templates/scoring/judge_sheet.html` — standalone inline-CSS template with `@page` declaration (pattern for new print templates)
+- `routes/scheduling/__init__.py:130` + `routes/scheduling/heat_sheets.py:25-49, 147, 218` — partner resolution via `_resolve_partner_name` + `_lookup_partner_cid` + `consumed` set (DRY bleeding — extract before 4th copy)
+
+## Decisions
+
+| ID | Topic | Decision |
+|---|---|---|
+| Q1 | Partner pairing | Extract `services/partner_resolver.py` first with 3 regression tests before building VJ workbook |
+| Q2 | Blank bracket print UX if bracket not yet generated | Flash + redirect to seeding page |
+| Q3 | VJ workbook routes | Ship both sync and async (mirror `export_results` pattern) |
+| Q4 | Multi-run row layout | Split dual-run day-split events (Chokerman, Speed Climb) into one tab per run. Triple-run events (Axe Throw) stay on one tab with 3 rows per competitor. |
+| Q5 | Event scope in VJ workbook | Include hits/score events with `Score 1 / Score 2` columns (flip labels by scoring_type). Skip only: bracket events (Birling) and LIST_ONLY events (no heats). |
+| Q6 | Bracket PDF aggregation | Per-event "Print Blank Bracket" button on each `birling_manage` page + tournament-wide "Print All Birling Brackets" button |
+| Q7 | Birling nav surfacing | All three surfaces: sidebar entry under Run Show + "Bracket" action button on events.html bracket rows + tournament_detail phase-link card |
+| Q8a | VJ workbook filename | `{tournament.name}_{year}_video_judge_sheets.xlsx` |
+| Q8b | Partnered event row format | Single cell `"Smith / Jones"` (matches heat_sheets pattern) |
+| Q8c | Left-handed flag in VJ rows | Skip — handedness doesn't affect video timing |
+| Priority | Bugs vs features | Fix all 6 L/R bugs atomically first. Feature work blocked until bug PR merges. |
+
+## Bugs to fix in PR A (atomic, must ship first)
+
+| # | File:Line | Severity | Problem |
+|---|---|---|---|
+| 1 | `services/pro_entry_importer.py:165-171` | P2 | `events_entered` can contain duplicates if both `Springboard (L)` and `Springboard (R)` boxes are Yes. Loop appends per matched form header with no canonical dedup. |
+| 2 | `services/pro_entry_importer.py:168-171` | P2 | `chopping_fees += 10` fires per matched form header → $20 charged for one entry if both L+R boxes Yes. Written to `competitor.total_fees`. |
+| 3 | `services/pro_entry_importer.py` + `routes/import_routes.py:274` | **P1 active** | `is_left_handed_springboard` is NEVER set by the xlsx importer. Only manual-form flows set it. Every xlsx-imported competitor defaults to `False`. Template `templates/pro/import_upload.html:67` literally advertises "left-handed and slow-heat designation (when present in sheet)" but only slow-heat is wired. |
+| 4 | `services/pro_entry_importer.py:20-47` | P2 | Same dedup trap on Pro 1-Board (3 keys→1 event), Jack & Jill (3→1), Partnered Axe Throw (2→1), Stock Saw (2→1), Speed Climb / Pole Climb (2→1). Currently latent (usually only one header variant in a given form) but same code path as #1. |
+| 5 | `services/heat_generator.py:566-615` | **P1 active** | `_generate_springboard_heats` GROUPS all left-handed cutters into heat 0 (docstring says `"Left-handed cutters need to be grouped into the same heat."`). User's actual stated rule: SPREAD one LH cutter per heat. Only 1 LH-configured springboard dummy exists on site. Grouping all LH cutters into heat 0 means they'd all need the LH dummy simultaneously — impossible. Fixing #3 without #5 would actively break the show. |
+| 5b | `services/flight_builder.py` | **P1 active** | Flight builder has no "max 1 LH-containing springboard heat per flight" constraint. User's rule: 3 LH cutters across 3 flights → each flight has exactly 1 LH-containing heat. Current flight builder cares about event variety + 4-heat spacing + Cookie Stack/Standing Block conflict. No LH awareness. |
+
+## PR breakdown
+
+### PR A — L/R springboard bug atomic fix (priority 1, blocks all else)
+
+Modified:
+- `services/pro_entry_importer.py` `parse_pro_entries`
+  - **Preserve raw L/R state** in entry dict as `_raw_springboard_l: bool`, `_raw_springboard_r: bool` (underscore prefix = internal, stripped before DB write)
+  - Add `seen_canonical_events: set` dedup so L+R-both-checked doesn't produce duplicate events/fees
+  - Compute `is_left_handed_springboard` from `_raw_springboard_l` (True iff L is checked; R-only and neither-checked → False; both-checked → True with warning flag)
+  - When both L and R are column-absent from the form (different form version), use sentinel `None` so re-import doesn't clobber manually-corrected flag
+- `services/pro_entry_importer.py` `compute_review_flags`
+  - Warn (Yellow): `entry['_raw_springboard_l'] and entry['_raw_springboard_r']` → `'CONFLICT: BOTH L AND R SPRINGBOARD CHECKED'` (flag reads raw state, not deduped events)
+- `routes/import_routes.py` `confirm_pro_entries` around line 274
+  - `lh = entry.get('is_left_handed_springboard')`
+  - `if lh is not None: competitor.is_left_handed_springboard = bool(lh)` (None sentinel → preserve existing value; protects against re-import wiping manual corrections)
+- `services/heat_generator.py` `_generate_springboard_heats`
+  - Replace `_place_group(left_handed, left_heat_idx)` cluster logic with SPREAD: `for i, lh in enumerate(left_handed[:num_heats]): heats[i].append(lh)` (one LH cutter per heat 0..N-1)
+  - **Overflow rule (user-specified):** if `len(left_handed) > num_heats`, extra LH cutters go into the FINAL heat (`heats[num_heats - 1]`), mixing with RH cutters there. Return a warning tuple the caller can flash: `f'Warning: {overflow_count} LH cutter(s) overflow into heat {num_heats}. Expect LH dummy contention.'`
+  - Preserve existing slow_heat placement; add test for LH + slow_heat collision at `left_heat_idx=0` vs `slow_heat_idx=num_heats-1` (which is also the overflow target — document the interaction)
+- `services/flight_builder.py` **(architecture-correct approach)**
+  - Flight builder is global-optimize-then-slice, not per-flight placement. Cannot use "skip this flight" loop.
+  - **Chosen approach: scoring penalty in `_score_ordering`.** Add a negative score term: for each flight window of `heats_per_flight` heats in the flat ordering, if >1 heat contains an LH-tagged competitor, add penalty `LH_FLIGHT_PENALTY = 1000`. Large enough to always dominate unless spacing would be catastrophically broken.
+  - **Load LH flags explicitly**: `build_pro_flights` currently loads `Heat.get_competitors()` as integer IDs only (line 120). Need to batch-load `ProCompetitor.is_left_handed_springboard` with one `.in_()` query keyed by the union of competitor IDs across all springboard-stand-type heats. Cache in `all_heats[i]['contains_lh'] = bool`. No N+1.
+  - **Post-slice sanity check**: after slicing, walk each flight and log a warning if any flight has >1 LH-containing heat (penalty wasn't strong enough or all permutations violate). Fail open (proceed with the schedule) but flash a warning to the admin.
+
+New tests (~18):
+- `tests/test_pro_entry_importer_handedness.py` (~8 tests)
+  - `test_springboard_l_only_sets_true`
+  - `test_springboard_r_only_keeps_false`
+  - `test_both_checked_sets_true_and_flags_conflict`
+  - `test_neither_checked_defaults_false`
+  - `test_columns_absent_sets_none_sentinel`
+  - `test_reimport_preserves_manual_handedness_when_sentinel_none`
+  - `test_pro_1board_three_headers_dedup_to_one_entry_one_fee`
+  - `test_jack_jill_three_headers_dedup_to_one_entry_one_fee`
+- `tests/test_heat_generator_lh_spread.py` (~6 tests)
+  - `test_one_lh_cutter_placed_in_heat_0`
+  - `test_two_lh_cutters_placed_in_heat_0_and_heat_1_not_clustered`
+  - `test_four_lh_cutters_four_heats_one_per_heat`
+  - `test_overflow_lh_goes_to_final_heat_with_warning`
+  - `test_lh_and_slow_heat_collision_final_heat_mixes_both`
+  - `test_regression_slow_heat_placement_unchanged_when_no_lh`
+  - `test_heat_assignment_rows_sync_after_lh_reassignment`
+  - `test_gear_sharing_conflict_respected_among_prespread_lh`
+- `tests/test_flight_builder_lh_constraint.py` (~4 tests)
+  - `test_three_lh_heats_three_flights_scoring_penalty_spreads_them`
+  - `test_two_lh_heats_three_flights_optimizer_puts_them_in_different_flights`
+  - `test_more_lh_heats_than_flights_overflow_logs_warning`
+  - `test_single_lh_heat_placed_respecting_spacing`
+  - `test_build_pro_flights_loads_is_left_handed_springboard_in_single_query`
+
+Repair script (new, ships with PR A):
+- `scripts/repair_springboard_handedness.py` or route `POST /admin/repair/springboard-handedness/<tid>` (admin-only, audit-logged)
+  - Scan `uploads/` directory for the last xlsx import for the target tournament (or take a path param)
+  - Re-run `parse_pro_entries` with the fixed parser
+  - For each competitor matched by email: update `is_left_handed_springboard` if currently False and xlsx said L
+  - After update: identify all pro springboard events (`stand_type == 'springboard'`) and re-run `generate_event_heats` for each (if heats exist already, regenerate — users get a confirmation prompt)
+  - Audit log each update
+  - 2 tests: `test_repair_sets_flag_on_xlsx_l_row`, `test_repair_regenerates_pro_springboard_heats`
+
+Estimated effort: ~2.5 hours CC (up from ~75 min — scope grew with repair script, flight_builder correctness, expanded tests).
+
+### PR B — partner_resolver extraction (foundation for PR C)
+
+New:
+- `services/partner_resolver.py` with `pair_competitors_in_heat(event, comp_ids, competitor_lookup) -> list[PairRow]` returning `consumed`-filtered pairs
+- `tests/test_partner_resolver.py` (~8 tests, 3 CRITICAL regressions marked below)
+  - `test_non_partnered_event_one_row_per_cid`
+  - `test_partnered_event_both_partners_present`
+  - `test_partnered_event_partner_missing_from_pool`
+  - `test_partnered_event_first_name_fuzzy_match`
+  - `test_consumed_set_prevents_double_row`
+  - `test_regression_heat_sheets_serialize_heat_detail_output_identical`  # CRITICAL
+  - `test_regression_heat_sheets_route_body_output_identical`  # CRITICAL
+  - `test_regression_first_name_fallback_behavior_unchanged`  # CRITICAL
+
+Modified:
+- `routes/scheduling/heat_sheets.py:147` `_serialize_heat_detail` uses partner_resolver
+- `routes/scheduling/heat_sheets.py:218` main heat_sheets route body uses partner_resolver
+
+Estimated effort: ~25 min CC.
+
+### PR C — Video Judge workbook (depends on PR B)
+
+New:
+- `services/video_judge_export.py`
+  - `build_video_judge_rows(tournament) -> dict[sheet_name, list[Row]]` walks heats, uses partner_resolver, includes run 2, emits row per pair per run
+  - **Stable row order** (Codex C9): `event.id → heat.heat_number → heat.run_number → stand_number → competitor_name`
+  - `write_workbook(rows_by_sheet, path)`:
+    - Truncate sheet names to 31 chars (openpyxl limit)
+    - Strip Excel-invalid chars `[]:*?/\\` from sheet names
+    - **Dedup after truncation**: if two events produce the same truncated name, append ` (2)`, ` (3)`, etc.
+    - Wrap workbook save in try/except; on any openpyxl error, raise a custom `VideoJudgeWorkbookError` the route flashes cleanly
+  - Skips `event.scoring_type == 'bracket'` and `LIST_ONLY_EVENT_NAMES`
+  - Dual-run day-split events emit two sheets: `"Speed Climb - Run 1"`, `"Speed Climb - Run 2"`
+  - Hits/score events use `Score 1 / Score 2` column labels (flip based on scoring_type); timed events use `Timer 1 / Timer 2`
+- **Extend `services/reporting_export.py`** (Codex C12):
+  - `build_video_judge_export(tournament) -> dict` — returns `{path, download_name, format, kind}` following existing pattern
+  - `build_video_judge_export_for_job(tid) -> str`
+  - `submit_video_judge_export_job(tid) -> job_id`
+  - Reuses `_reserve_export_path` and `safe_download_name('video_judge_sheets.xlsx')` helpers
+- `tests/test_video_judge_export.py` (~12 tests, expanded per Codex C10 feedback)
+  - `test_simple_timed_event_single_run`
+  - `test_partnered_event_row_per_pair`
+  - `test_dual_run_event_two_tabs`
+  - `test_triple_run_event_stacked_rows`
+  - `test_skips_bracket_scoring_type`
+  - `test_skips_list_only_events`
+  - `test_college_event_includes_team_code`
+  - `test_pro_event_no_team_code`
+  - `test_hits_event_uses_score_labels`
+  - `test_sheet_name_truncated_to_31_chars`
+  - `test_sheet_name_invalid_chars_stripped`
+  - `test_sheet_name_duplicate_after_truncation_suffixed`
+  - `test_stable_row_ordering`
+  - `test_openpyxl_write_error_raises_custom_exception`
+- `tests/test_routes_video_judge.py` (~5 tests)
+  - `test_sync_get_returns_xlsx`
+  - `test_sync_unauthorized_redirects`
+  - `test_async_post_returns_job_id`
+  - `test_async_status_shows_download_when_complete`
+  - `test_missing_tournament_404`
+  - `test_empty_tournament_graceful_empty_workbook_or_flash`
+
+Modified:
+- `routes/reporting.py`
+  - `GET /reporting/<tid>/video-judge-workbook` (sync) — calls `build_video_judge_export`, uses `send_file` + `@after_this_request`
+  - `POST /reporting/<tid>/video-judge-workbook/async` — calls `submit_video_judge_export_job`; redirect to status page
+  - Status page reuses `resolve_completed_export_path`
+- `templates/tournament_detail.html` (+ button in "Ready for Game Day" action bar + phase-link card in Before-the-Show)
+- `templates/_sidebar.html` (+ "Video Judge Workbook" entry as `sidebar-child` under Run Show, near Heat Sheets)
+- `strings.py` (+ `NAV['video_judge_workbook'] = 'Video Judge Workbook'`)
+
+Filename pattern: `{tournament.name}_{year}_video_judge_sheets.xlsx` via `safe_download_name(tournament, 'video_judge_sheets.xlsx')` from `services/reporting_export.py`. Do NOT import `_safe_filename_part` from `routes/scoring.py` (Codex C13 — private helper).
+
+Estimated effort: ~75 min CC (up from 45 — service extension + 17 tests).
+
+### PR D — Birling blank bracket + nav surfacing (serial with PR C — template conflicts)
+
+New:
+- `services/birling_print.py`
+  - `build_birling_print_context(event) -> dict | None` — returns `None` if bracket not generated; caller handles redirect
+  - **Blank-bracket scrub (Codex C14):** explicitly strip result fields from match copies before render:
+    - Drop `winner`, `loser`, `falls`, `placements` from every match
+    - For losers bracket rounds ≥ 2: set all `competitor1`/`competitor2` back to `None` (only round-1 matchups render)
+    - For winners bracket rounds ≥ 2: same — all `None`
+    - For `finals` + `true_finals`: blank everything
+    - Function returns a DEEP COPY of `bracket_data`, never mutates the live `event.payouts`
+- `services/print_response.py` (new, extracted per Codex C13)
+  - `weasyprint_or_html(html: str, filename: str) -> tuple` — shared WeasyPrint-optional response helper
+  - Used by judge_sheet, heat_sheet PDF, birling print
+  - Replaces private `_judge_sheet_response` in `routes/scoring.py` with a public import
+- `templates/scoring/birling_bracket_print.html` — standalone (no base.html extend), inline CSS, `@page { size: Letter landscape; ... }`, `@bottom-center` page counter. Copies `hs-bracket-*` CSS and `bracket_slot`/`bracket_match` macros from `heat_sheets_print.html:453-516`.
+- `tests/test_birling_print.py` (~7 tests, expanded per Codex C14/C15)
+  - `test_generated_bracket_round_1_populated`
+  - `test_ungenerated_bracket_returns_none`
+  - `test_bracket_size_8_with_byes`
+  - `test_bracket_size_16_full_layout`
+  - `test_mens_and_womens_separate_events_both_render`
+  - `test_partially_played_bracket_strips_winners_and_placements_from_print_context`
+  - `test_context_does_not_mutate_live_event_payouts`
+- `tests/test_routes_birling_print.py` (~5 tests)
+  - `test_print_before_generate_flashes_and_redirects`
+  - `test_print_after_generate_returns_200_html_or_pdf`
+  - `test_non_bracket_event_404`
+  - `test_wrong_tournament_404`
+  - `test_print_all_mixed_generation_skips_ungenerated_with_warning`
+
+Modified:
+- `routes/scheduling/birling.py`
+  - `GET /scheduling/<tid>/event/<eid>/birling/print-blank` (per-event)
+  - `GET /scheduling/<tid>/birling/print-all` (combined)
+  - **Print-all mixed state (Codex C15):** iterate all bracket events; skip ungenerated (log and flash "Skipped N birling event(s) that have not been seeded yet: [names]"); render the rest in one combined document
+  - Uses `services/print_response.weasyprint_or_html` helper
+- `templates/scheduling/birling_manage.html` (+ "Print Blank Bracket" button next to "Finalize Results" / "Reset Bracket" in Actions row)
+- `templates/scheduling/events.html:627-636` (+ "Bracket" action button on `event.scoring_type == 'bracket'` rows, linking to `scheduling.birling_manage`; keeps existing "Always Last" badge or consolidates into button label)
+- `templates/tournament_detail.html` (+ Birling Brackets phase-link card in Before-the-Show panel, between "Preflight Check" and "Print Heat Sheets")
+- `templates/_sidebar.html` (+ "Birling Brackets" entry as `sidebar-child` under Run Show, near Heat Sheets)
+- `strings.py` (+ `NAV['birling_bracket'] = 'Birling Brackets'`)
+
+Estimated effort: ~60 min CC (up from 35 — shared print helper extraction + scrub logic + mixed-state print-all + 2 extra tests).
+
+## Sequencing (revised per Codex C16)
+
+PR A ships alone first (bug fix is atomic, must merge before any feature work).
+After PR A merges:
+- PR B runs alone (foundation refactor with regression tests).
+- **PR C runs after PR B** (PR C depends on `services/partner_resolver.py`).
+- **PR D runs after PR C** — NOT in parallel. Both PR C and PR D modify `templates/tournament_detail.html`, `templates/_sidebar.html`, and `strings.py`. Merging in parallel would produce three-way conflicts on each file. Agree NAV keys up front (`video_judge_workbook`, `birling_bracket`) so both PRs import the same constant, minimizing actual merge churn.
+- **Optional parallel**: PR D's `services/birling_print.py` + `services/print_response.py` + standalone `birling_bracket_print.html` template are independent of PR C. If a worktree-splitter is confident about merging the shared template/sidebar/strings diffs manually, these three new files could start in parallel and merge the template bits serially. Cost-benefit marginal at this scale; default to strict serial.
+
+Total: 4 PRs, **~5.5 hours CC** (up from 3), **~50 new tests** (up from 40), expected merge window: **2-3 days** (up from 1-2).
+
+## Risk and failure modes
+
+| Codepath | Failure mode | Mitigation |
+|---|---|---|
+| `build_video_judge_rows` | Partner name has no match in pool | `partner_resolver` returns raw name fallback (no crash, row mildly wrong) |
+| `write_workbook` | Sheet name > 31 chars | Truncate to 31 chars in writer; test covers it |
+| Birling print route | `event.payouts` corrupt JSON | `_load_bracket_data` has bare except returning default shape; print route checks `has_bracket` and redirects if missing |
+| VJ workbook route | Openpyxl raises during write | Try/except wraps write; flash error + redirect to tournament_detail |
+| Heat generator LH spread | Only 1 LH cutter but 0 heats (edge) | Fallback to old single-heat placement |
+| Flight builder LH constraint | More LH heats than flights | Overflow: once every flight has 1 LH heat, additional LH heats use spacing-only placement. Log a warning. |
+| PR B partner_resolver extraction | Regression in heat_sheets output | 3 CRITICAL regression tests gate the PR |
+
+## NOT in scope (deferred)
+
+- Dedicated Reports/Exports hub page — scattered exports remain scattered
+- Fix for same dedup trap on Jack & Jill / Partnered Axe / Stock Saw / Speed Climb non-L/R collisions beyond PR A's Springboard-specific fix — PR A's `seen_canonical_events` set fixes all of them but only LH handedness is behavior-tested; other collisions are latent
+- A3/multi-page bracket layout for N > 8 birling competitors — Letter landscape assumed sufficient
+- Left-handed column in VJ workbook rows (Q8c decided: skip)
+- Async variant of birling bracket print — output is small HTML, no reason to async
+- Partner pair support in paper judge_sheet.html — pre-existing gap, not created by VJ scope
+- Pro birling references — already confirmed absent from config
+
+## Open risks to watch
+
+1. **Flight builder LH scoring penalty interaction.** `LH_FLIGHT_PENALTY = 1000` must dominate the existing spacing penalties but not trash variety. Risk: if the optimizer is at a local minimum that needs 2 LH in one flight to unlock spacing elsewhere, the penalty breaks it. Mitigation: test with realistic roster data (full 2025 if available); tune penalty if needed; the post-slice sanity check catches any permutation that ends up with 2 LH in one flight anyway.
+2. **Heat generator LH spread + slow_heat + overflow all land on final heat.** User rule: overflow LH goes to heat `num_heats-1`. Existing rule: slow_heat also goes to `heats[num_heats-1]`. If both overflow AND slow-heat cutters exist, the final heat gets stuffed. Add test. Document behavior: "overflow + slow_heat stack in final heat; admin should reduce one of the two pools."
+3. **Repair script side effects on partially-played events.** If some heats have already been scored when admin runs the repair, regenerating springboard heats destroys the results. Repair script must check `event.is_finalized` and `heat.status in ('in_progress', 'completed')` — skip regeneration if any event is live, only update the flag and log a warning that admin must manually rebuild the affected heats.
+4. **Re-import idempotency.** Importing the same xlsx twice should be a no-op on `is_left_handed_springboard`. With the `None`-sentinel approach: first import writes True/False; re-import sees the column is still there and writes the same True/False. OK. Edge case: admin manually flips a competitor's LH flag, then re-imports a newer xlsx that has a DIFFERENT L/R answer. Plan: re-import wins. Document this. Add test.
+5. **PR C needs the partner_resolver from PR B.** If a developer starts PR C in a worktree before PR B merges, they'll need to stub the service. Prefer strict serial unless worktree-splitter is CI-confident.
+
+---
+
+## Changes from v1 (Codex outside-voice review, 2026-04-20)
+
+Codex challenged 15 points. User-decided tensions are ABOVE; objective corrections applied to the plan are listed here for audit.
+
+**Architecture corrections (applied):**
+- C4: Flight builder is global-optimize-then-slice. Replaced "track `flights_with_lh_springboard_heat: set[int]`" loop with scoring penalty in `_score_ordering` + post-slice sanity check.
+- C5: Flight builder was not loading `is_left_handed_springboard`. Added explicit batched `.in_()` query path in PR A.
+- C12: `routes/reporting.py` already delegates to `services/reporting_export.py` (commit `cbe8802` on this branch). Updated PR C to extend the service module instead of adding inline `mkstemp` to the route.
+- C13: Replaced reference to private `_safe_filename_part` from `routes/scoring.py` with public `safe_download_name` from `services/reporting_export.py`. Added `services/print_response.py` extraction in PR D so judge_sheet + heat_sheet + birling_print share one WeasyPrint-optional helper.
+
+**Test corrections (applied):**
+- C7: Expanded test list for `_generate_springboard_heats` to include LH+slow_heat collision, overflow-to-final-heat, gear-sharing-conflict-among-prespread-LH, HeatAssignment sync after reassignment. Total PR A tests: 18 (up from 13).
+- C10: Expanded VJ workbook tests to cover sheet-name dedup-after-truncation, invalid-char stripping, custom exception on openpyxl write failure. Total PR C tests: 17 (up from 14).
+
+**Underspecification fixes (applied):**
+- C2: Preserve raw L/R checkbox state in entry dict as `_raw_springboard_l`/`_raw_springboard_r` BEFORE canonical dedup so `compute_review_flags` can surface the both-checked conflict.
+- C3: Use `None`-sentinel in entry dict when L/R columns are column-absent (vs explicitly False). Confirmer only overwrites `competitor.is_left_handed_springboard` when entry value is not None. Protects manually-corrected flags from being clobbered on re-import.
+- C6: Changed LH overflow rule per user decision: spread 1 per heat 0..N-1, overflow goes to FINAL heat with warning flash. (Codex suggested hard fail; user overrode with pragmatic rule.)
+- C9: Defined stable VJ row order: `event.id → heat.heat_number → heat.run_number → stand_number → competitor_name`.
+- C10: Defined sheet name rules: truncate to 31 chars, strip `[]:*?/\\`, suffix ` (2)` / ` (3)` for dedup collisions.
+- C14: Birling blank print context does a deep copy and explicitly strips `winner`/`loser`/`falls`/`placements` from all matches; rounds 2+ get `None` competitors. Bracket data on live event is never mutated.
+- C15: "Print all birling brackets" skips ungenerated events with a flash listing which were skipped.
+
+**Scope and sequencing (applied):**
+- C1: Added one-time repair script (`scripts/repair_springboard_handedness.py` or admin route) to PR A. Updates `is_left_handed_springboard` for existing imported competitors and regenerates affected pro springboard heats (skipping any that are live/finalized). User-decided.
+- C8: PR B extraction kept on the ship path (user override — chose DRY over Codex's defer recommendation). 3 CRITICAL regression tests gate it.
+- C11: VJ workbook includes hits/score events with Score 1 / Score 2 labels (user reaffirmed original decision).
+- C16: PR C and PR D serialized (not parallel) due to shared `tournament_detail.html`, `_sidebar.html`, `strings.py`.
+- C17: Effort estimate revised upward: ~5.5 hours CC (from 3), ~50 tests (from 40), 2-3 day ship window (from 1-2).
+
+**Unchallenged (kept from v1):**
+- Q1-Q8 decisions (partner resolver extraction, flash+redirect blank bracket UX, sync+async VJ routes, split day-split runs, include hits/score events, per-event + combined bracket PDF, all-three nav surfacing, filename pattern, partner cell format, skip LH column in VJ rows).
+- Priority: PR A (bug fix) ships first before any feature work.

--- a/docs/VIDEO_JUDGE_BRACKET_RECON.md
+++ b/docs/VIDEO_JUDGE_BRACKET_RECON.md
@@ -1,0 +1,661 @@
+# Recon: Video Judge Excel Workbook + Birling Blank Bracket Print + Birling Nav Surfacing
+
+Read-only audit of existing infrastructure relevant to three April 24–25 show-prep
+deliverables. No code changes made.
+
+Deliverables under recon:
+1. **Video Judge Excel Workbook** — one .xlsx, tab per event, long format (row per
+   competitor per run, row per partnered pair per run), two video-judge-time columns
+   per row. Generated in show-prep.
+2. **Birling Blank Bracket Print (seeded)** — printable PDF/HTML of the seeded
+   double-elimination bracket with round-1 matchups populated and all advancement
+   slots blank. Generated in show-prep.
+3. **Birling Nav Surfacing** — a discoverable sidebar/nav path to the birling
+   management page so a judge-in-training can find it without coaching.
+
+---
+
+## TASK 1 — Show-prep route surface
+
+### Primary show-prep entry points
+
+- **Tournament detail page** (`main.tournament_detail`) — route surfaces a
+  "Ready for Game Day" action bar at
+  [templates/tournament_detail.html:338-359](../templates/tournament_detail.html#L338-L359)
+  with three pre-show export buttons:
+  - `scheduling.heat_sheets` → Heat Sheets (print-friendly HTML)
+  - `scoring.judge_sheets_all` → Print All Judge Sheets (PDF if WeasyPrint, else HTML)
+  - `scheduling.preflight_check` → Preflight Check
+- **"Before the Show" phase panel** at
+  [templates/tournament_detail.html:430-501](../templates/tournament_detail.html#L430-L501)
+  lists eight phase-link cards. Existing last card is "Print Heat Sheets"
+  ([line 492](../templates/tournament_detail.html#L492)). A new "Video Judge
+  Workbook" and "Birling Blank Bracket" card fit naturally in the same list.
+- **Sidebar** ([templates/_sidebar.html](../templates/_sidebar.html)) has four
+  show-prep-relevant rows under the "Setup" and "Run Show" groups. Heat Sheets
+  is a `sidebar-child` under Run Show at
+  [line 190](../templates/_sidebar.html#L190). No judge-sheet shortcut in the
+  sidebar; nav for judge sheet lives only on tournament_detail and on the
+  reports/all_results page banner.
+
+### URL patterns (existing show-prep exports)
+
+| Route | URL | File | Notes |
+|---|---|---|---|
+| `scheduling.heat_sheets` | `/scheduling/<tid>/heat-sheets` | [routes/scheduling/heat_sheets.py:193](../routes/scheduling/heat_sheets.py#L193) | Print-friendly HTML; renders `scheduling/heat_sheets_print.html` |
+| `scoring.judge_sheet_for_event` | `/scoring/<tid>/event/<eid>/judge-sheet` | [routes/scoring.py:1540](../routes/scoring.py#L1540) | WeasyPrint PDF, HTML fallback |
+| `scoring.judge_sheets_all` | `/scoring/<tid>/judge-sheets/all` | [routes/scoring.py:1556](../routes/scoring.py#L1556) | One doc, all events w/ heats |
+| `scoring.heat_sheet_pdf` | `/scoring/<tid>/heat/<hid>/pdf` | (per CLAUDE.md) | Single-heat print PDF |
+| `reporting.export_results` | `/reporting/<tid>/export-results` | [routes/reporting.py:273](../routes/reporting.py#L273) | **Direct sync .xlsx download** via `send_file()` — template for new xlsx routes |
+| `reporting.export_results_async` | `/reporting/<tid>/export-results/async` | [routes/reporting.py:340](../routes/reporting.py#L340) | Background job + status page |
+| `reporting.export_chopping_results` | `/reporting/<tid>/export-chopping` | [routes/reporting.py:299](../routes/reporting.py#L299) | Scoped .xlsx, json alt |
+| `reporting.ala_membership_report` | sidebar group "Show Entries" | [templates/_sidebar.html:112](../templates/_sidebar.html#L112) | |
+
+### Best fit for new buttons
+- **Video Judge Workbook**: most natural next to "Print All Judge Sheets" on the
+  tournament_detail action bar ([line 343](../templates/tournament_detail.html#L343))
+  and as a `phase-link` card in the Before-the-Show panel. Also add a sidebar
+  entry under "Run Show" alongside Heat Sheets.
+- **Birling Blank Bracket**: two places. (a) Action button on the per-event
+  bracket management page (`scheduling.birling_manage`) — natural location
+  because it's specific to a single birling event (men's or women's).
+  (b) A phase-link card in Before-the-Show on tournament_detail.
+
+### No dedicated "Reports/Exports" section exists
+
+No single "Reports" dashboard page. Exports are scattered across
+tournament_detail buttons, the sidebar "Show Entries" and "Results" groups,
+and the bottom of individual report screens (all_results, payout_summary,
+fee_tracker). If cleanup is desired long term, a new Reports hub could unify
+these — out of scope for this recon.
+
+---
+
+## TASK 2 — Existing judge sheet infrastructure (mirror target)
+
+### `get_event_heats_for_judging(event_id: int) -> JudgeSheetData | None`
+
+File: [services/judge_sheet.py:64](../services/judge_sheet.py#L64)
+
+TypedDict shape:
+```python
+JudgeSheetData = {
+    "event_name": str,              # event.display_name
+    "event_type": str,              # stand_type or event name
+    "num_runs": int,                # 3 if requires_triple_runs, 2 if dual, else 1
+    "scoring_type": str,            # 'timed' or 'scored' (flattened)
+    "heats": [
+        {
+            "heat_number": int,
+            "competitors": [
+                {"name": str, "team_code": str | None},
+                ...
+            ],
+        },
+        ...
+    ],
+}
+```
+
+- **Returns None** if event not found; empty `heats` list is legal.
+- **Filters out run 2** — only `Heat.run_number != 2` is returned.
+  ([line 86-91](../services/judge_sheet.py#L86-L91)) The judge sheet uses
+  multi-column layout per heat (two timer cols × num_runs), not separate sheets
+  per run.
+- **Batched competitor lookup** — single `.in_()` per type, no N+1.
+- **College team_code** populated via `comp.team.team_code` if available.
+- **`num_runs` derivation** — `_num_runs_for_event()` at
+  [line 49](../services/judge_sheet.py#L49): `triple_runs → 3`,
+  `dual_runs → 2`, else `1`.
+- **`scoring_type` flattening** — `_sheet_scoring_type()` at
+  [line 57](../services/judge_sheet.py#L57): `'time'` or `'distance'` → `'timed'`;
+  everything else → `'scored'`.
+
+### Judge sheet routes
+
+| Route | URL | Function |
+|---|---|---|
+| Single event | `/scoring/<tid>/event/<eid>/judge-sheet` | `judge_sheet_for_event()` at [routes/scoring.py:1540](../routes/scoring.py#L1540) |
+| All events | `/scoring/<tid>/judge-sheets/all` | `judge_sheets_all()` at [routes/scoring.py:1556](../routes/scoring.py#L1556) |
+
+Response built via shared helpers
+[`_render_judge_sheet_html()` / `_judge_sheet_response()`](../routes/scoring.py#L1517-L1537):
+WeasyPrint PDF if installed, plain HTML fallback; `Content-Disposition`
+filename built via `_safe_filename_part()` which strips non-alphanumeric
+characters. Filename pattern: `judge_sheet_<Event_Display_Name>.pdf`
+or `judge_sheets_tournament_<tid>.pdf`.
+
+### Judge sheet template
+
+File: [templates/scoring/judge_sheet.html](../templates/scoring/judge_sheet.html)
+
+- **Standalone HTML** (does NOT extend base.html) — WeasyPrint requires inline CSS.
+- `@page` declaration at [line 8](../templates/scoring/judge_sheet.html#L8):
+  `Letter landscape if num_runs > 1 else Letter portrait`, 0.5in/0.4in margins,
+  bottom-center page counter + "STRATHEX Tournament Management" footer.
+- **Column layout** for N runs: one name col + (N × 2 timer/judge cols) + status
+  col + reason col. Dual-run events use 2×2 = 4 timer/judge columns.
+- **Header row structure** at [lines 131-151](../templates/scoring/judge_sheet.html#L131-L151):
+  `<th rowspan="2">Competitor</th>` then per-run `<th colspan="2">Run N</th>`
+  over `Timer 1 / Timer 2` (if timed) or `Judge 1 / Judge 2` (if scored).
+- **Data rows** at [lines 153-164](../templates/scoring/judge_sheet.html#L153-L164):
+  competitor name + team_code, then blank `.blank-cell` (0.62in tall) for each
+  timer/judge column, then status + reason blanks.
+
+### Partner handling gap
+
+`get_event_heats_for_judging()` does NOT resolve partners. Each competitor in a
+partnered event heat shows up as a separate row with just their own name. For
+Jack & Jill / Double Buck / Peavey / Pulp / Partnered Axe, the judge sheet
+today shows each competitor separately — the PDF does not render
+"Smith / Jones" pairs. This is a pre-existing gap, not created by the VJ spec.
+
+The **partner resolution pattern** for name-pair rendering already exists in
+four places, all using the same helper chain:
+- [routes/scheduling/__init__.py:130](../routes/scheduling/__init__.py#L130) —
+  `_resolve_partner_name(competitor, event)` returns partner name string
+  from `competitor.get_partners()` dict, keyed by event id / name / display_name.
+- [routes/scheduling/__init__.py:148](../routes/scheduling/__init__.py#L148) —
+  `_build_signup_rows(event)` pairs competitors using `_resolve_partner_name()`
+  + a by-name index; renders as `"{comp.name} + {partner.name}"`.
+- [routes/scheduling/heat_sheets.py:147](../routes/scheduling/heat_sheets.py#L147) —
+  `_serialize_heat_detail()` renders `"{name} & {partner_label}"` and `consumed`-
+  tracks IDs to avoid duplicating partnered pairs across rows.
+- [routes/scheduling/heat_sheets.py:218](../routes/scheduling/heat_sheets.py#L218) —
+  same consumed-set / `_lookup_partner_cid()` pattern inside
+  `heat_sheets()` route, with first-name fuzzy fallback.
+
+**Partner storage** (CLAUDE.md section 4): `ProCompetitor.partners` and
+`CollegeCompetitor.partners` are JSON dict columns keyed `event_id → partner_name`
+(strings, not FKs). There is NO `Partnership` / `Pair` model and no `partner_id`
+FK. Partner resolution is always name-matching across the active-competitor pool.
+This means the VJ workbook builder needs to mirror the `_lookup_partner_cid()`
++ `consumed` pattern from heat_sheets.py to emit one row per pair.
+
+### Data adequacy for the VJ workbook
+
+`get_event_heats_for_judging()` returns enough for the **simple** (non-partnered)
+case: heat_number, competitor name, team_code, num_runs. For partnered events
+the builder must either (a) extend `get_event_heats_for_judging()` with partner
+resolution or (b) bypass the helper and walk heats directly, reusing
+`_resolve_partner_name()` + `_lookup_partner_cid()` from the heat-sheets module.
+Option (b) is closer to the established pattern and does not modify the
+existing judge sheet output.
+
+Also missing from the helper for the VJ spec: **division flag** (college vs pro)
+for the sheet name / tab title, and **Birling exclusion** (see Task 4).
+
+---
+
+## TASK 3 — Excel library status
+
+### Already installed
+
+[requirements.txt](../requirements.txt):
+- `pandas==2.1.3`
+- `openpyxl==3.1.2`
+
+CLAUDE.md Tech Stack table (section 2): "Excel I/O — pandas 2.1, openpyxl 3.1".
+
+### Existing .xlsx emission paths (all via openpyxl through pandas)
+
+- [services/excel_io.py:1054](../services/excel_io.py#L1054) —
+  `export_results_to_excel(tournament, filepath)`: uses
+  `pd.ExcelWriter(filepath, engine='openpyxl')` and writes per-event sheets via
+  `pd.DataFrame(...).to_excel(writer, sheet_name=..., index=False)`. Sheets:
+  Team Standings, Bull of Woods, Belle of Woods, one sheet per event, Overview.
+- [services/handicap_export.py:62](../services/handicap_export.py#L62) —
+  `export_chopping_results_to_excel(tournament, filepath)`: single sheet
+  "Chopping Results", same pattern.
+
+Both route handlers use the same `tempfile.mkstemp(..., suffix='.xlsx')` +
+`send_file(path, as_attachment=True, download_name=...)` +
+`@after_this_request` cleanup pattern ([routes/reporting.py:277-296](../routes/reporting.py#L277-L296)).
+
+### Nothing to install
+
+Both pandas+openpyxl and the tempfile/send_file download pattern are in place.
+The VJ workbook can be assembled with the same libraries and the same route
+response pattern as `export_results`. If deeper openpyxl control is needed
+(column widths, freeze panes, protected cells, header formatting) that's
+available directly on openpyxl Workbook objects — pandas to_excel writes
+through openpyxl, and the writer's `book`/`sheets` attributes expose the
+underlying openpyxl objects.
+
+---
+
+## TASK 4 — Configured events (VJ workbook tab list)
+
+Source of truth: [config.py:380-429](../config.py#L380-L429). Events are
+defined in three dicts and instantiated as `Event` rows per tournament.
+
+### COLLEGE_OPEN_EVENTS (come-and-go Friday, `is_open=True`)
+
+| Name | scoring_type | runs | partnered? | Birling/bracket? |
+|---|---|---|---|---|
+| Axe Throw | score (triple) | 3 | no | no |
+| Peavey Log Roll | time | 1 | yes (mixed) | no |
+| Caber Toss | distance (dual) | 2 | no | no |
+| Pulp Toss | time | 1 | yes (mixed) | no |
+
+### COLLEGE_CLOSED_EVENTS
+
+| Name | scoring_type | runs | partnered? | Gendered? | Birling/bracket? |
+|---|---|---|---|---|---|
+| Underhand Hard Hit | hits | 1 | no | M/F | no |
+| Underhand Speed | time | 1 | no | M/F | no |
+| Standing Block Hard Hit | hits | 1 | no | M/F | no |
+| Standing Block Speed | time | 1 | no | M/F | no |
+| Single Buck | time | 1 | no | M/F | no |
+| Double Buck | time | 1 | **yes (same)** | M/F | no |
+| Jack & Jill Sawing | time | 1 | **yes (mixed)** | no | no |
+| Stock Saw | time | 1 | no | M/F | no |
+| Speed Climb | time (dual, day-split) | 2 | no | M/F | no |
+| Obstacle Pole | time | 1 | no | M/F | no |
+| Chokerman's Race | time (dual, day-split) | 2 | no | M/F | no |
+| **Birling** | **bracket** | n/a | no | M/F | **YES** |
+| 1-Board Springboard | time | 1 | no | M/F | no |
+
+### PRO_EVENTS
+
+| Name | scoring_type | runs | partnered? | Gendered? | Birling? |
+|---|---|---|---|---|---|
+| Springboard | time | 1 | no | no | no |
+| Pro 1-Board | time | 1 | no | no | no |
+| 3-Board Jigger | time | 1 | no | no | no |
+| Underhand | time | 1 | no | M/F | no |
+| Standing Block | time | 1 | no | M/F | no |
+| Stock Saw | time | 1 | no | M/F | no |
+| Hot Saw | time | 1 | no | no | no |
+| Single Buck | time | 1 | no | M/F | no |
+| Double Buck | time | 1 | **yes** | M/F | no |
+| Jack & Jill Sawing | time | 1 | **yes (mixed)** | no | no |
+| Partnered Axe Throw | score (triple) | 3 | **yes** | no | no |
+| Obstacle Pole | time | 1 | no | no | no |
+| Pole Climb | time | 1 | no | no | no |
+| Cookie Stack | time | 1 | no | no | no |
+
+### Birling flag for VJ export
+
+**Primary skip flag: `event.scoring_type == 'bracket'`**.
+
+- Only Birling has `scoring_type='bracket'` ([config.py:407](../config.py#L407)).
+- No pro birling exists in `PRO_EVENTS` (confirmed — CLAUDE.md section 3
+  explicitly notes pro birling removed per 2026-01-25 changelog).
+- The same predicate is used in existing code:
+  [routes/scheduling/heat_sheets.py:313](../routes/scheduling/heat_sheets.py#L313)
+  branches on `event.scoring_type == 'bracket'` to render birling bracket
+  separately from heat cards; and the `birling_bp` routes gate on the same
+  check ([routes/scheduling/birling.py:23](../routes/scheduling/birling.py#L23)).
+
+**Partnered skip logic for the VJ spec**: the VJ workbook spec requires a
+row per pair (not a row per competitor) for partnered events. Partnered events
+in the list above:
+- College: Peavey Log Roll, Pulp Toss, Double Buck, Jack & Jill Sawing
+- Pro: Double Buck, Jack & Jill Sawing, Partnered Axe Throw
+
+Also note: **LIST_ONLY_EVENT_NAMES** at [config.py:464](../config.py#L464) —
+`axethrow, peaveylogroll, cabertoss, pulptoss` are tracked as sign-up lists
+only; **no heats are generated** for them. So their heats list will be empty
+and the VJ export either needs to skip them or emit a "No heats — sign-up
+only" tab. Existing `get_event_heats_for_judging()` returns an empty heats
+array for these ([line 93](../services/judge_sheet.py#L93) — "No heats"
+message flagged in template).
+
+### Event list for a specific tournament
+
+Tournaments instantiate from these lists via `_create_college_events()` and
+`_create_pro_events()` in `routes/scheduling` (CLAUDE.md section 2). Actual
+events for a given tournament come from `Event.query.filter_by(tournament_id=tid)`
+— the judge-sheets-all route already does this at
+[routes/scoring.py:1565-1570](../routes/scoring.py#L1565-L1570). Mirror that
+query for the VJ workbook.
+
+---
+
+## TASK 5 — Birling bracket: data and templates
+
+### State storage
+
+**The entire bracket lives in `Event.payouts` (JSON TEXT)** —
+[services/birling_bracket.py:20-46](../services/birling_bracket.py#L20-L46).
+This is the "repurposing payouts field for state" pattern used by ProAmRelay,
+PartneredAxeThrow, and BirlingBracket (CLAUDE.md section 2: "Service classes for
+complex state").
+
+Default shape returned by `_load_bracket_data()`:
+```python
+{
+    "bracket": {
+        "winners": [[match, ...], ...],    # list of rounds
+        "losers":  [[match, ...], ...],    # list of rounds
+        "finals": {match},
+        "true_finals": {match, "needed": bool}
+    },
+    "competitors": [{"id": int, "name": str}, ...],
+    "seeding": [comp_id, comp_id, ...],    # 1st seed first
+    "current_round": "winners_1",
+    "placements": {comp_id_str: position_int}
+}
+```
+
+Match dict shape (winners + losers):
+```python
+{
+    "match_id": "W1_1" | "L2_3" | "F1" | "F2",
+    "round": "winners_1" | "losers_2" | "finals" | "true_finals",
+    "competitor1": int | None,   # None = TBD or BYE
+    "competitor2": int | None,
+    "winner": int | None,
+    "loser": int | None,
+    "falls": [{"fall_number": int, "winner": int, "recorded_at": iso}, ...],
+    "is_bye": bool,                              # winners only
+    "eliminated_position": int | None,           # losers only
+    "needed": bool,                              # true_finals only
+}
+```
+
+### Bracket structure generation
+
+`BirlingBracket.generate_bracket(competitors, seeding=None)` at
+[services/birling_bracket.py:48](../services/birling_bracket.py#L48):
+
+1. `bracket_size = 2 ** ceil(log2(N))` — next power of 2 ≥ competitor count.
+2. Number of byes = `bracket_size - N`.
+3. **Round 1 pairings**: standard tournament bracket (1 vs N, 2 vs N-1, etc.) —
+   `seed1 = i`, `seed2 = bracket_size - 1 - i`. Missing seeds yield `None`
+   (BYE slots), which auto-advance the present competitor via lines 97-100.
+4. Subsequent winners rounds created with `None` competitors (TBD).
+5. Losers bracket via `_generate_losers_bracket()` — `2 * (log2(B) - 1)` rounds
+   alternating consolidation (odd) and drop-down (even).
+6. Finals (`F1`) and true finals (`F2`) placeholders.
+7. `_propagate_byes()` walks Round 1 BYE matches and advances the present
+   competitor into their next winners match.
+
+**Result**: after `generate_bracket()` runs, every Round-1 match has both
+`competitor1` and `competitor2` filled (or one + `is_bye=True`). All later
+rounds have `None` competitors because they await advancement.
+
+**Perfect for the blank-bracket print**: generate → save → print. No match
+results recorded, but round-1 matchups populated.
+
+### Seeding source & timing
+
+In `scheduling.birling_generate()` at
+[routes/scheduling/birling.py:85](../routes/scheduling/birling.py#L85):
+- If manual `seed_{comp_id}` form fields are filled, use those.
+- Otherwise fall back to `pre_seedings` from ability rankings
+  ([line 123-138](../routes/scheduling/birling.py#L123-L138)).
+- Unseeded competitors sort alphabetically after seeded ones.
+- `event.payouts` dict has a `pre_seedings` key populated from the
+  ability-rankings page (CLAUDE.md section 4: "Also supports College Birling
+  Seedings — per-school ordering stored as `pre_seedings` in `Event.payouts` JSON").
+
+**Seeding IS intended to happen in show-prep**. The flow is:
+`scheduling.ability_rankings` (per-school birling seedings drag-drop) →
+`scheduling.birling_manage` (confirm/override seeds and press Generate Bracket).
+Once Generate Bracket runs, the bracket has round-1 populated — that's the
+target state for the blank print.
+
+### Templates
+
+- [templates/scheduling/birling_manage.html](../templates/scheduling/birling_manage.html)
+  — the main bracket view. 512 lines. Sections:
+  - Seeding form (table with `seed_{comp.id}` input per competitor).
+  - Active matches card (playable matches with fall-tracker UI).
+  - Bracket visualization (winners / losers / finals) using `render_match` +
+    `render_slot` Jinja macros at [lines 323-379](../templates/scheduling/birling_manage.html#L323-L379).
+  - Placements table.
+  - Actions (Finalize / Reset).
+- [templates/scheduling/heat_sheets_print.html:443-](../templates/scheduling/heat_sheets_print.html#L443)
+  — already renders **live** birling brackets inline on the heat sheets print
+  page. It has its own `hs-bracket-*` CSS and `bracket_slot` / `bracket_match`
+  macros at [line 486-516](../templates/scheduling/heat_sheets_print.html#L486-L516).
+  This rendering already handles an in-progress or blank bracket, because the
+  slot macro gracefully renders `TBD` for `None` competitors
+  ([line 487-499](../templates/scheduling/heat_sheets_print.html#L487-L499)).
+- [templates/scoring/birling_bracket.html](../templates/scoring/birling_bracket.html)
+  — 133 lines. `scoring.birling_bracket` route at
+  [routes/scoring.py:1498](../routes/scoring.py#L1498) is a legacy redirect to
+  `scheduling.birling_manage`. The template may still be used elsewhere; not
+  recon-critical.
+
+### Can the bracket render with empty competitor slots?
+
+**Yes, by design.** All three bracket templates (`birling_manage.html`,
+`heat_sheets_print.html`, and the render_slot macro) already handle
+`comp_id=None` → "TBD" rendering for rounds 2+. So a freshly-generated bracket
+with only round-1 populated will render cleanly with all later slots as "TBD".
+No template changes needed for the blank-bracket scenario; only a new route +
+standalone print template.
+
+**Caveat**: the existing render assumes the bracket was generated. If the user
+hits the print-blank-bracket button before `generate_bracket()` has run, the
+page will have no structure to render. The workflow needs to either (a)
+auto-generate on first print, or (b) flash "Generate the bracket first" and
+redirect.
+
+---
+
+## TASK 6 — Print/PDF infrastructure
+
+### WeasyPrint
+
+**NOT in requirements.txt** — absent from [requirements.txt](../requirements.txt).
+Both existing PDF routes import it lazily inside a try/except:
+
+```python
+try:
+    from weasyprint import HTML as WP_HTML
+    pdf_bytes = WP_HTML(string=html).write_pdf()
+    return pdf_bytes, 200, {'Content-Type': 'application/pdf', ...}
+except ImportError:
+    return html, 200, {'Content-Type': 'text/html'}
+```
+
+See [routes/scoring.py:1527-1537](../routes/scoring.py#L1527-L1537)
+(`_judge_sheet_response`) and the heat-sheet PDF route around
+[routes/scoring.py:1490-1495](../routes/scoring.py#L1490-L1495).
+
+**Implication**: on Railway (production) WeasyPrint is probably not installed
+(system deps are heavy: cairo, pango, gdk-pixbuf). Users download HTML
+instead and press Ctrl-P to save as PDF. The blank-bracket deliverable
+should follow the same pattern — HTML is the reliable output, PDF is a
+bonus if WeasyPrint happens to be available.
+
+### Print CSS patterns in use
+
+Two distinct patterns:
+
+1. **Standalone inline-CSS templates for WeasyPrint** (preferred pattern for
+   PDF-first exports):
+   - [templates/scoring/judge_sheet.html:8](../templates/scoring/judge_sheet.html#L8) —
+     `@page { size: ...; margin: ...; @bottom-center { content: ...; } }`
+   - [templates/scoring/heat_sheet_print.html:8](../templates/scoring/heat_sheet_print.html#L8) —
+     `@page { size: letter portrait; margin: 1.5cm; }`
+   - Does NOT extend base.html. No Bootstrap, no theme.css — inline CSS only.
+   - This is the template the blank-bracket print should mimic.
+
+2. **In-app print screen with `@media print` overrides** (the heat sheets page
+   for browser Ctrl-P use):
+   - [templates/scheduling/heat_sheets_print.html:124](../templates/scheduling/heat_sheets_print.html#L124) —
+     `@media print { ... }` block; extends base.html with Bootstrap sidebar
+     hidden via `.no-print`.
+
+For the blank birling bracket, pattern #1 is the right match: a standalone
+template modeled on `judge_sheet.html` / `heat_sheet_print.html` with inline
+CSS and `@page` declarations.
+
+### Recommended reuse
+
+- **Page header / footer idiom**: mirror `judge_sheet.html` lines 26-38
+  (header) + `@page @bottom-center` page counter.
+- **Bracket slot / match macros**: copy the `hs-bracket-*` CSS and macros
+  from [templates/scheduling/heat_sheets_print.html:453-516](../templates/scheduling/heat_sheets_print.html#L453-L516) —
+  already inlined, already renders `TBD` for blank slots, already sized for
+  print.
+
+---
+
+## TASK 7 — Field-size scaling in bracket rendering
+
+### Current bracket rendering is dynamic, not fixed-layout
+
+- **Winners bracket**: `log2(bracket_size)` rounds, each with half the matches
+  of the previous. Rendered as one `.bracket-round` flex column per round.
+  ([templates/scheduling/birling_manage.html:388-398](../templates/scheduling/birling_manage.html#L388-L398))
+- **Losers bracket**: `2 * (log2(B) - 1)` rounds, same column-per-round layout.
+  ([line 410-417](../templates/scheduling/birling_manage.html#L410-L417))
+- Each `.bracket-round` is `min-width: 180px; flex-shrink: 0`, so horizontal
+  space grows with round count.
+- `.bracket-container { overflow-x: auto; }` — wide brackets scroll
+  horizontally in-browser.
+
+### Field size implications
+
+`bracket_size = 2 ** ceil(log2(N))`, so rounds scale predictably:
+
+| N competitors | bracket_size | winners rounds | losers rounds | total round columns |
+|---|---|---|---|---|
+| 2-4 | 4 | 2 | 2 | 4 |
+| 5-8 | 8 | 3 | 4 | 7 |
+| 9-16 | 16 | 4 | 6 | 10 |
+
+At N=16 with 10 round columns × 180px minimum = 1800px horizontal. This
+overflows both `Letter portrait` (~2100px at 300dpi ÷ ~200dpi actual = ~1100px)
+AND `Letter landscape` without scaling. The birling_manage page works around
+this with `overflow-x: auto` and horizontal scroll, but a **print** layout
+cannot scroll.
+
+**Options for the blank print**:
+- (a) `@page { size: A3 landscape; }` or `size: 17in 11in;` for a tabloid sheet.
+- (b) Scale down font + min-width at larger N.
+- (c) Split losers bracket onto a second page — winners + finals on page 1,
+  losers on page 2.
+- (d) For small fields (N ≤ 8, which is the typical Missoula field per
+  CLAUDE.md section 3 — "top 6 determined", implying single-digit entries),
+  Letter landscape at current CSS is roughly adequate.
+
+Field size for Missoula Pro Am birling: college birling is gender-segregated;
+each school typically sends 1-2 birlers per gender; ballpark total field per
+gender is 8-16. So N=8 is the realistic low-end, N=16 is the upper end.
+Letter landscape with minor font tweaks works up to ~8-10; beyond that, A3 or
+multi-page layout is required.
+
+### Recommendation boundary (taste call, not implementation)
+
+Anything beyond recon, but the existing `hs-bracket-*` CSS in heat_sheets_print
+([line 453-480](../templates/scheduling/heat_sheets_print.html#L453-L480))
+is already tighter than the interactive CSS — 170px columns, 0.82rem font — and
+would likely fit a 16-field bracket in A3 landscape or Letter landscape with
+one more font shrink. Clean baseline to start from.
+
+---
+
+## TASK 8 — Birling nav surfacing (current state)
+
+### Existing entry points to `scheduling.birling_manage`
+
+| Location | File | Context |
+|---|---|---|
+| Event results page "Bracket" button | [templates/scoring/event_results.html:86](../templates/scoring/event_results.html#L86) | Only shown when `event.scoring_type == 'bracket'` |
+| Ability rankings page | [templates/scheduling/ability_rankings.html:174](../templates/scheduling/ability_rankings.html#L174) | "College Birling Seedings" section; drag-drop writes `pre_seedings` into `event.payouts` but does not link to bracket page |
+| Legacy redirect | [routes/scoring.py:1498](../routes/scoring.py#L1498) | `scoring.birling_bracket` → redirects to `scheduling.birling_manage` |
+
+### What's missing
+
+- **No sidebar link** — [templates/_sidebar.html](../templates/_sidebar.html)
+  has zero matches for `birling` (grep returned nothing). The "Run Show" sidebar
+  group has `Build Schedule / Friday / Saturday Operations / Heat Sheets / Kiosk`
+  but no Birling / Brackets entry.
+- **No tournament_detail card** — [templates/tournament_detail.html](../templates/tournament_detail.html)
+  has no link to birling_manage in any of the phase panels.
+- **No events.html bracket button** — the events list at
+  [templates/scheduling/events.html:627-636](../templates/scheduling/events.html#L627-L636)
+  shows an "Always Last" badge for birling but **does not link to birling_manage**.
+  A judge sees the event in the list but has no obvious click-through.
+- **Only discoverable via Event Results screen** — which requires the judge to
+  navigate to Results → pick the birling event → see the Bracket button. That's
+  the deepest possible path and explains why judges-in-training can't find it.
+
+### Lowest-effort surfacing candidates
+
+1. **Event list row → "Bracket" action button** on the events.html event list
+   when `event.scoring_type == 'bracket'`. Mirrors the event_results.html
+   pattern. Single-template change.
+2. **Sidebar "Run Show" group → "Birling Bracket(s)"** entry. Slightly more
+   work because there are two events (men's + women's) for college; either
+   link to a landing page listing both, or surface each directly.
+3. **Tournament_detail "Ready for Game Day" action bar** → Birling Bracket
+   button next to Heat Sheets / Judge Sheets. Only visible in setup phase, but
+   that's the exact phase where show-prep happens.
+
+---
+
+## Open Questions for Alex
+
+1. **VJ workbook — partnered event row format**: confirmed requirement is
+   "one row per pair per run". Should the partner column render as
+   `"Smith / Jones"` (single cell) or as a separate second column? The
+   existing judge_sheet.html and heat sheet templates both use single-cell
+   `"{a} & {b}"` or `"{a} / {b}"` — is that the right model?
+
+2. **VJ workbook — run 2 inclusion**: `get_event_heats_for_judging()` filters
+   out run 2 for the paper judge sheet because it uses multi-column layout.
+   The VJ workbook spec says "one row per competitor per run". Should run 1
+   and run 2 appear on the same tab (stacked rows) or on separate tabs per
+   run? Chokerman's Race and Speed Climb are the day-split cases — run 1 is
+   Friday, run 2 is Saturday. Keeping them on one tab may confuse the
+   video-judging workflow.
+
+3. **VJ workbook — Birling / LIST_ONLY events**: confirmed Birling must be
+   skipped (scoring_type='bracket' is not video-timed). Should the
+   sign-up-only events (Axe Throw, Peavey Log Roll, Caber Toss, Pulp Toss —
+   `LIST_ONLY_EVENT_NAMES` at [config.py:464](../config.py#L464)) also be
+   skipped? They have no heats to populate rows from — the workbook would
+   emit empty tabs. Recommend skip; confirm.
+
+4. **VJ workbook — scoring_type='hits' / 'score' events**: Underhand Hard Hit,
+   Standing Block Hard Hit, Axe Throw (if closed), Partnered Axe Throw all
+   score by hits/points, not time. These are judged in-person, not on video.
+   Should they be excluded from the VJ workbook, or included with "VJ Score 1 /
+   VJ Score 2" columns for documentation only? Existing judge sheet includes
+   them all.
+
+5. **Birling blank bracket — multiple brackets per tournament**: men's and
+   women's college brackets are separate Event rows (both with
+   `scoring_type='bracket'`). Does the blank-bracket deliverable produce
+   (a) one PDF per event (two separate buttons on birling_manage), or
+   (b) one combined PDF (two brackets, one document) invoked from a higher
+   surface? Existing judge-sheets-all already follows pattern (b) with the
+   single tournament-wide aggregator.
+
+6. **Birling blank bracket — bracket-not-yet-generated UX**: the bracket has
+   to exist in `event.payouts` before round-1 slots are populated. If the
+   judge clicks "Print Blank Bracket" before `generate_bracket()` has been
+   run via the seeding form, what should happen? Auto-generate on the fly
+   (from `pre_seedings` or alpha order)? Or flash "seed first" error and
+   redirect?
+
+7. **Nav surfacing — scope**: which of the three surfacing options (events
+   list row button / sidebar Run-Show entry / tournament_detail action bar)
+   is in scope? All three? One? If sidebar, how should the two college
+   brackets (men's + women's) be addressed — landing page listing all
+   bracket events in the tournament, or one link per event?
+
+8. **Show-prep home for the new buttons**: should the VJ workbook and
+   blank-bracket buttons live under a new "Reports" or "Exports" section of
+   the sidebar (which does not yet exist — see Task 1), or be appended into
+   the existing scattered locations (tournament_detail + sidebar "Run Show")?
+   A dedicated Exports hub would make all ~6 existing exports discoverable
+   in one place, but is a bigger-scope change than the two deliverables need.
+
+9. **Filename convention for VJ workbook**: existing xlsx filenames use
+   `{tournament.name}_{tournament.year}_results.xlsx` (spaces → `_`). VJ
+   workbook suggested as `{tournament.name}_{year}_video_judge_sheets.xlsx`?
+
+10. **Handedness / left-handed springboard**: pro springboard heats group
+    left-handed cutters together on specific dummies. Does the VJ workbook
+    need to surface this (e.g., a flag column) or is stand assignment
+    sufficient? Current judge_sheet.html does not show stand assignments at
+    all — rows are `name / team_code / blank timers / status / reason`.

--- a/routes/import_routes.py
+++ b/routes/import_routes.py
@@ -272,6 +272,12 @@ def confirm_pro_entries(tournament_id):
             competitor.gear_sharing_details = entry.get('gear_sharing_details')
             competitor.notes          = entry.get('notes')
             competitor.springboard_slow_heat = bool(entry.get('springboard_slow_heat', False))
+            # Handedness: None sentinel from parser means the xlsx form lacked
+            # both Springboard (L) and Springboard (R) columns, so we have no
+            # signal and must preserve any existing manual value on the row.
+            lh_flag = entry.get('is_left_handed_springboard')
+            if lh_flag is not None:
+                competitor.is_left_handed_springboard = bool(lh_flag)
             competitor.total_fees     = entry.get('total_fees', 0)
             competitor.import_timestamp = now
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,6 @@
+"""Project scripts package — marker for Python package discovery.
+
+Makes scripts/ importable (e.g. ``from scripts.repair_springboard_handedness
+import repair``) so test modules can exercise script entry points without a
+sys.path hack.
+"""

--- a/scripts/repair_springboard_handedness.py
+++ b/scripts/repair_springboard_handedness.py
@@ -1,0 +1,210 @@
+"""
+Repair script for the L/R springboard importer bug (2026-04-20).
+
+Before this PR, services/pro_entry_importer.py collapsed the Google Form
+checkboxes 'Springboard (L)' and 'Springboard (R)' into canonical
+'Springboard' but never populated ProCompetitor.is_left_handed_springboard.
+Every pro competitor imported via xlsx in 2026 defaulted to False (right-
+handed), which silently broke the heat generator's LH spreading rule.
+
+This script runs ONCE after PR A deploys. It re-parses the original xlsx
+with the fixed parser, writes is_left_handed_springboard where the form
+captured a signal, and regenerates heats for pro springboard events so
+they reflect the corrected handedness.
+
+Usage:
+    flask shell
+    >>> from scripts.repair_springboard_handedness import repair
+    >>> repair(tournament_id=1, xlsx_path='uploads/<uuid>.xlsx')
+
+Or as a standalone script from the project root:
+    python -m scripts.repair_springboard_handedness <tournament_id> <xlsx_path>
+
+Skips heat regeneration for any pro springboard event with:
+  - event.is_finalized True, or
+  - any Heat with status in ('in_progress', 'completed')
+
+so live / scored events are never mutated.  For those, the script updates
+the is_left_handed_springboard flag only and logs a notice that the admin
+must rebuild manually.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def repair(tournament_id: int, xlsx_path: str, dry_run: bool = False) -> dict:
+    """
+    Re-apply is_left_handed_springboard from an xlsx to existing competitors
+    and regenerate pro springboard heats where safe.
+
+    Args:
+        tournament_id: Target tournament ID.
+        xlsx_path: Path to the original Google Forms xlsx export.
+        dry_run: If True, report what would change but commit nothing.
+
+    Returns:
+        Dict summarising the repair: flag_updates, heat_regenerations,
+        skipped_events, unmatched_emails, errors.
+    """
+    from database import db
+    from models import Event, Heat, ProCompetitor, Tournament
+    from services.pro_entry_importer import parse_pro_entries
+
+    summary = {
+        "tournament_id": tournament_id,
+        "xlsx_path": xlsx_path,
+        "dry_run": dry_run,
+        "flag_updates": [],  # list of {email, name, old, new}
+        "heat_regenerations": [],  # list of event display names regenerated
+        "skipped_events": [],  # list of {event, reason}
+        "unmatched_emails": [],  # list of xlsx emails not found in DB
+        "errors": [],
+    }
+
+    tournament = Tournament.query.get(tournament_id)
+    if tournament is None:
+        summary["errors"].append(f"Tournament {tournament_id} not found.")
+        return summary
+
+    entries = parse_pro_entries(xlsx_path)
+    logger.info("repair: parsed %d entries from %s", len(entries), xlsx_path)
+
+    # --- Phase 1: update is_left_handed_springboard from xlsx signal ---
+    for entry in entries:
+        email = (entry.get("email") or "").strip()
+        if not email:
+            continue
+        lh_flag = entry.get("is_left_handed_springboard")
+        if lh_flag is None:
+            continue  # sentinel: no signal in this xlsx, skip
+
+        competitor = ProCompetitor.query.filter_by(
+            tournament_id=tournament_id,
+            email=email,
+        ).first()
+        if competitor is None:
+            summary["unmatched_emails"].append(email)
+            continue
+
+        old_flag = bool(competitor.is_left_handed_springboard)
+        new_flag = bool(lh_flag)
+        if old_flag == new_flag:
+            continue
+
+        summary["flag_updates"].append(
+            {
+                "email": email,
+                "name": competitor.name,
+                "old": old_flag,
+                "new": new_flag,
+            }
+        )
+
+        if not dry_run:
+            competitor.is_left_handed_springboard = new_flag
+
+    if not dry_run:
+        db.session.flush()
+
+    # --- Phase 2: regenerate pro springboard heats where safe ---
+    springboard_events = Event.query.filter_by(
+        tournament_id=tournament_id,
+        event_type="pro",
+        stand_type="springboard",
+    ).all()
+
+    for event in springboard_events:
+        if event.is_finalized:
+            summary["skipped_events"].append(
+                {
+                    "event": event.display_name,
+                    "reason": "event is finalized — manual rebuild only",
+                }
+            )
+            continue
+
+        live_heat = (
+            Heat.query.filter_by(event_id=event.id)
+            .filter(Heat.status.in_(("in_progress", "completed")))
+            .first()
+        )
+        if live_heat is not None:
+            summary["skipped_events"].append(
+                {
+                    "event": event.display_name,
+                    "reason": f"heat #{live_heat.heat_number} already {live_heat.status}",
+                }
+            )
+            continue
+
+        if dry_run:
+            summary["heat_regenerations"].append(f"(dry-run) {event.display_name}")
+            continue
+
+        # Regenerate.  Uses the fixed heat generator which spreads LH cutters.
+        from services.heat_generator import generate_event_heats
+
+        try:
+            generate_event_heats(event)
+            summary["heat_regenerations"].append(event.display_name)
+        except Exception as exc:  # noqa: BLE001
+            summary["errors"].append(f"regenerate {event.display_name}: {exc!s}")
+
+    if not dry_run:
+        db.session.commit()
+
+    return summary
+
+
+def _main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    if len(sys.argv) < 3:
+        print(
+            "usage: python -m scripts.repair_springboard_handedness "
+            "<tournament_id> <xlsx_path> [--dry-run]"
+        )
+        return 2
+
+    tid = int(sys.argv[1])
+    path = sys.argv[2]
+    dry = "--dry-run" in sys.argv[3:]
+
+    from app import create_app
+
+    app = create_app()
+    with app.app_context():
+        summary = repair(tid, path, dry_run=dry)
+
+    print(
+        f'Tournament {summary["tournament_id"]}  xlsx={summary["xlsx_path"]}'
+        f'  dry_run={summary["dry_run"]}'
+    )
+    print(f'Flag updates: {len(summary["flag_updates"])}')
+    for u in summary["flag_updates"]:
+        print(f'  {u["email"]:<40} {u["name"]:<30} {u["old"]} -> {u["new"]}')
+    print(f'Heats regenerated: {len(summary["heat_regenerations"])}')
+    for name in summary["heat_regenerations"]:
+        print(f"  {name}")
+    if summary["skipped_events"]:
+        print(f'Skipped events: {len(summary["skipped_events"])}')
+        for s in summary["skipped_events"]:
+            print(f'  {s["event"]}: {s["reason"]}')
+    if summary["unmatched_emails"]:
+        print(f'Unmatched xlsx emails: {len(summary["unmatched_emails"])}')
+        for email in summary["unmatched_emails"]:
+            print(f"  {email}")
+    if summary["errors"]:
+        print("Errors:")
+        for err in summary["errors"]:
+            print(f"  {err}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -110,14 +110,41 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None) -> int:
     logger.debug('flight_builder: loaded %d non-axe heats for %d events',
                  len(batched_heats), len(non_axe_event_ids))
 
+    # Batch-load left-handed-springboard flags for all springboard-heat
+    # competitors so the optimizer can penalize >1 LH heat per flight
+    # (domain rule: only one physical LH dummy on site, so one LH cutter
+    # per flight time-slot).  Single .in_() query — no N+1.
+    lh_comp_ids: set[int] = set()
+    for heat in batched_heats:
+        event = event_by_id.get(heat.event_id)
+        if event and getattr(event, 'stand_type', None) == 'springboard':
+            lh_comp_ids.update(heat.get_competitors())
+
+    lh_flags: dict[int, bool] = {}
+    if lh_comp_ids:
+        from models.competitor import ProCompetitor
+        lh_rows = (
+            ProCompetitor.query
+            .filter(
+                ProCompetitor.id.in_(lh_comp_ids),
+                ProCompetitor.is_left_handed_springboard.is_(True),
+            )
+            .with_entities(ProCompetitor.id)
+            .all()
+        )
+        lh_flags = {row.id: True for row in lh_rows}
+
     all_heats = []
     for heat in batched_heats:
         event = event_by_id.get(heat.event_id)
         if event:
+            comps = set(heat.get_competitors())
+            contains_lh = any(lh_flags.get(cid, False) for cid in comps)
             all_heats.append({
                 'heat': heat,
                 'event': event,
-                'competitors': set(heat.get_competitors()),
+                'competitors': comps,
+                'contains_lh': contains_lh,
             })
 
     if not all_heats and not partnered_axe_heats:
@@ -154,6 +181,7 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None) -> int:
     flights_created = 0
     heat_index = 0
     created_flights: list[Flight] = []
+    lh_count_per_flight: dict[int, int] = {}  # flight_number -> LH heat count
 
     for flight_num in range(1, target_flights + 1):
         flight = Flight(
@@ -169,10 +197,24 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None) -> int:
             heat_data = ordered_heats[heat_index]
             heat_data['heat'].flight_id = flight.id
             heat_data['heat'].flight_position = heats_in_flight + 1
+            if heat_data.get('contains_lh'):
+                lh_count_per_flight[flight_num] = lh_count_per_flight.get(flight_num, 0) + 1
             heat_index += 1
             heats_in_flight += 1
 
         flights_created += 1
+
+    # Post-slice sanity check: if any flight ended up with >1 LH-containing heat,
+    # the scoring penalty was dominated by spacing constraints.  Log a warning so
+    # the admin knows the LH dummy will be over-subscribed in those flights.
+    for fnum, count in lh_count_per_flight.items():
+        if count > 1:
+            logger.warning(
+                'LH DUMMY CONTENTION: flight %d has %d LH-containing heats. '
+                'Only one physical LH springboard dummy exists. '
+                'Manual review recommended.',
+                fnum, count,
+            )
 
     # Insert partnered axe heats with deterministic flight placement.
     _insert_partnered_axe_heats(created_flights, partnered_axe_heats)
@@ -482,6 +524,21 @@ def _score_ordering(ordered: list, heats_per_flight: int,
                     overlap = partner_ids & prev_comps
                     if overlap:
                         total -= 200 * len(overlap)
+
+    # Left-handed springboard flight constraint: at most one LH-containing
+    # heat per flight block.  Only one physical LH dummy on site, so two
+    # LH heats in the same flight would need simultaneous use.  Penalty must
+    # outweigh typical spacing bonuses across a flight (~20 × 8 = 160 max)
+    # so the optimizer always prefers spreading LH heats across flights.
+    if heats_per_flight > 0:
+        lh_per_block: dict[int, int] = {}
+        for pos, hd in enumerate(ordered):
+            if hd.get('contains_lh'):
+                block = pos // heats_per_flight
+                lh_per_block[block] = lh_per_block.get(block, 0) + 1
+        for count in lh_per_block.values():
+            if count > 1:
+                total -= 1000 * (count - 1)
 
     return total
 

--- a/services/heat_generator.py
+++ b/services/heat_generator.py
@@ -21,11 +21,25 @@ logger = logging.getLogger(__name__)
 # surface a warning flash to the judge (gear audit fix G2/G3 — 2026-04-07).
 _last_gear_violations: dict[int, list[dict]] = {}
 
+# Per-event left-handed springboard overflow log, populated by
+# _generate_springboard_heats() when LH cutter count exceeds heat count.
+# Separate from gear violations because the remediation is different
+# (reconfigure field sizes vs. rebuild gear pairs).
+_last_lh_overflow_warnings: dict[int, list[dict]] = {}
+
 
 def get_last_gear_violations(event_id: int) -> list[dict]:
     """Return the gear-sharing violations recorded by the most recent
     generate_event_heats(event) call for this event_id, or an empty list."""
     return list(_last_gear_violations.get(event_id, []))
+
+
+def get_last_lh_overflow_warnings(event_id: int) -> list[dict]:
+    """Return the left-handed springboard overflow warnings recorded by the
+    most recent generate_event_heats(event) call for this event_id, or an
+    empty list.  Each entry is a dict with keys type, heat_index,
+    overflow_count, overflow_names."""
+    return list(_last_lh_overflow_warnings.get(event_id, []))
 
 
 def _sort_by_ability(competitors: list, event: Event) -> list:
@@ -133,10 +147,16 @@ def generate_event_heats(event: Event) -> int:
     gear_violations: list[dict] = []
     _last_gear_violations.pop(event.id, None)
 
+    # Per-event left-handed springboard overflow warnings recorded by
+    # _generate_springboard_heats when LH count > heat count.
+    lh_warnings: list[dict] = []
+    _last_lh_overflow_warnings.pop(event.id, None)
+
     # Apply special constraints
     if event.stand_type == 'springboard':
         heats = _generate_springboard_heats(competitors, num_heats, max_per_heat, stand_config, event=event,
-                                            gear_violations=gear_violations)
+                                            gear_violations=gear_violations,
+                                            lh_warnings=lh_warnings)
     elif event.stand_type in ['saw_hand']:
         heats = _generate_saw_heats(competitors, num_heats, max_per_heat, stand_config, event=event,
                                     gear_violations=gear_violations)
@@ -250,6 +270,29 @@ def generate_event_heats(event: Event) -> int:
                 v.get('comp_name', ''), heat_id,
             )
         _last_gear_violations[event.id] = resolved
+
+    # Promote LH overflow warnings for springboard events, same pattern.
+    if lh_warnings:
+        resolved_lh: list[dict] = []
+        for w in lh_warnings:
+            idx = w.get('heat_index')
+            heat_id = None
+            heat_number = None
+            if isinstance(idx, int) and 0 <= idx < len(created_heats):
+                heat_id = created_heats[idx].id
+                heat_number = created_heats[idx].heat_number
+            resolved_lh.append({
+                'type': w.get('type'),
+                'heat_id': heat_id,
+                'heat_number': heat_number,
+                'overflow_count': w.get('overflow_count'),
+                'overflow_names': w.get('overflow_names', []),
+            })
+            logger.warning(
+                'LH SPRINGBOARD OVERFLOW: %d cutter(s) overflowed into heat %s — LH dummy contention expected',
+                w.get('overflow_count', 0), heat_id,
+            )
+        _last_lh_overflow_warnings[event.id] = resolved_lh
 
     # Flush but do NOT commit — the calling route owns the transaction boundary and
     # will commit (or roll back) after all scheduling actions are complete.  This
@@ -565,27 +608,76 @@ def _get_partner_name_for_event(competitor, event: Event) -> str:
 
 def _generate_springboard_heats(competitors: list, num_heats: int,
                                  max_per_heat: int, stand_config: dict, event: Event = None,
-                                 gear_violations: list | None = None) -> list:
+                                 gear_violations: list | None = None,
+                                 lh_warnings: list | None = None) -> list:
     """
-    Generate springboard heats with left-handed cutter grouping.
+    Generate springboard heats with left-handed cutter spreading.
 
-    Left-handed cutters need to be grouped into the same heat.
+    Only one physical left-handed springboard dummy exists on site, so at most
+    ONE left-handed cutter can be in a single heat at a time.  Spread LH cutters
+    one per heat across heats 0..N-1.  If more LH cutters than heats exist,
+    overflow into the FINAL heat (per user rule, 2026-04-20) and log a warning
+    via lh_warnings so the admin knows there is dummy contention.
+
+    Slow-heat cutters still cluster starting at the final heat (unchanged).
     """
     heats = [[] for _ in range(num_heats)]
 
     # Dedicated springboard buckets:
-    # - Left-handed cutters must stay together in one heat.
-    # - Slow-heat cutters should be grouped into the dedicated slow heat.
+    # - LH cutters: one per heat (spread), overflow to final heat with warning.
+    # - Slow-heat cutters: cluster into the dedicated slow heat.
     left_handed = [c for c in competitors if c.get('is_left_handed', False)]
     slow_heat = [c for c in competitors if c.get('is_slow_springboard', False)]
 
-    left_heat_idx = 0 if left_handed else None
     slow_heat_idx = (num_heats - 1) if slow_heat else None
-    if left_heat_idx is not None and slow_heat_idx is not None and num_heats == 1:
-        slow_heat_idx = left_heat_idx
 
     assigned_ids = set()
 
+    # --- LH spread ---
+    # One LH cutter per heat, heats 0..N-1.  Overflow spills into the final
+    # heat (heats[num_heats-1]), mixed with RH cutters there.  If the final
+    # heat also hits max_per_heat, any further LH cutters are unplaceable —
+    # surface them via gear_violations as a hard warning so the admin reacts.
+    if left_handed and num_heats > 0:
+        spread = left_handed[:num_heats]
+        overflow = left_handed[num_heats:]
+
+        for i, lh in enumerate(spread):
+            if len(heats[i]) < max_per_heat:
+                heats[i].append(lh)
+                assigned_ids.add(lh['id'])
+
+        if overflow:
+            final_idx = num_heats - 1
+            placed_overflow: list[str] = []
+            unplaced_overflow: list[str] = []
+            for lh in overflow:
+                if lh['id'] in assigned_ids:
+                    continue
+                if len(heats[final_idx]) < max_per_heat:
+                    heats[final_idx].append(lh)
+                    assigned_ids.add(lh['id'])
+                    placed_overflow.append(lh.get('name', ''))
+                else:
+                    unplaced_overflow.append(lh.get('name', ''))
+
+            if placed_overflow and lh_warnings is not None:
+                lh_warnings.append({
+                    'type': 'lh_overflow',
+                    'heat_index': final_idx,
+                    'overflow_count': len(placed_overflow),
+                    'overflow_names': placed_overflow,
+                })
+            if unplaced_overflow and gear_violations is not None:
+                for name in unplaced_overflow:
+                    gear_violations.append({
+                        'comp_id': None,
+                        'comp_name': name,
+                        'heat_index': final_idx,
+                        'reason': 'LH cutter unplaced — all heats at capacity',
+                    })
+
+    # --- Slow-heat cluster (unchanged behavior) ---
     def _place_group(group: list, preferred_idx: int | None):
         if not group:
             return
@@ -612,7 +704,6 @@ def _generate_springboard_heats(competitors: list, num_heats: int,
             remaining = remaining[len(take):]
             idx += 1
 
-    _place_group(left_handed, left_heat_idx)
     _place_group(slow_heat, slow_heat_idx)
 
     # Fill the remaining cutters with snake draft while respecting capacity.

--- a/services/pro_entry_importer.py
+++ b/services/pro_entry_importer.py
@@ -157,13 +157,39 @@ def parse_pro_entries(filepath: str) -> list:
 
         ala_member = _yes(_get(row, hmap.get('Are you a current ALA member?')))
 
+        # --- Handedness capture (BEFORE canonical dedup — raw L/R columns).
+        # _EVENT_MAP collapses 'Springboard (L)' and 'Springboard (R)' to the
+        # canonical 'Springboard', but the L/R checkbox is the admin's only
+        # signal for which springboard dummy this cutter uses. Capture it here
+        # so compute_review_flags() can flag the "both checked" conflict.
+        has_l_col = 'Springboard (L)' in hmap
+        has_r_col = 'Springboard (R)' in hmap
+        raw_sb_l  = _yes(_get(row, hmap.get('Springboard (L)'))) if has_l_col else False
+        raw_sb_r  = _yes(_get(row, hmap.get('Springboard (R)'))) if has_r_col else False
+        if has_l_col or has_r_col:
+            # Form has at least one column → we have a signal. L wins on conflict.
+            is_left_handed_springboard = raw_sb_l
+        else:
+            # Form has neither column (legacy import or non-springboard-form).
+            # Use None sentinel so confirm_pro_entries() preserves any manual
+            # flag already set on an existing competitor instead of wiping it.
+            is_left_handed_springboard = None
+
         # --- Events and fees ---
-        events        = []
-        chopping_fees = 0
-        other_fees    = 0
+        # Dedup by canonical event name so double-checked aliases (e.g. both
+        # Springboard (L) and Springboard (R), or Jack & Jill + Jack & Jill
+        # Sawing) don't double-enter or double-charge. seen_canonical_events
+        # is reset per row.
+        events                  = []
+        chopping_fees           = 0
+        other_fees              = 0
+        seen_canonical_events: set = set()
 
         for form_header, (event_name, fee) in _EVENT_MAP.items():
             if _yes(_get(row, hmap.get(form_header))):
+                if event_name in seen_canonical_events:
+                    continue
+                seen_canonical_events.add(event_name)
                 events.append(event_name)
                 if fee == 10:
                     chopping_fees += 10
@@ -226,6 +252,12 @@ def parse_pro_entries(filepath: str) -> list:
             'waiver_signature':     waiver_signature,
             'notes':                notes,
             'springboard_slow_heat': springboard_slow_heat,
+            'is_left_handed_springboard': is_left_handed_springboard,
+            # Raw L/R signals preserved so compute_review_flags() can warn on
+            # the impossible both-checked state. Consumers should NOT write these
+            # to the DB — underscore-prefix marks them as import-internal only.
+            '_raw_springboard_l':   raw_sb_l,
+            '_raw_springboard_r':   raw_sb_r,
             'chopping_fees':        chopping_fees,
             'other_fees':           other_fees,
             'relay_fee':            relay_fee,
@@ -263,6 +295,14 @@ def compute_review_flags(entries: list, existing_names: list = None) -> list:
         if not entry['waiver_accepted']:
             flags.append('NO WAIVER')
             flag_class = 'table-danger'
+
+        # Both Springboard (L) AND Springboard (R) boxes checked — physically
+        # impossible, the admin needs to resolve which dummy this cutter uses.
+        # Reads raw pre-dedup checkbox state, not the canonicalised events list.
+        if entry.get('_raw_springboard_l') and entry.get('_raw_springboard_r'):
+            flags.append('CONFLICT: BOTH L AND R SPRINGBOARD CHECKED')
+            if not flag_class:
+                flag_class = 'table-warning'
 
         for event_name, partner_name in entry.get('partners', {}).items():
             if partner_name and partner_name.strip().lower() not in all_names:

--- a/tests/test_flight_builder_lh_constraint.py
+++ b/tests/test_flight_builder_lh_constraint.py
@@ -1,0 +1,144 @@
+"""
+Flight builder left-handed-springboard constraint tests.
+
+Domain rule (2026-04-20): only one physical left-handed springboard dummy
+exists on site, so at most one LH-containing heat can be in the same flight
+time-window.  services/flight_builder.py enforces this via a scoring penalty
+in _score_ordering plus a post-slice sanity-check warning.
+
+These tests exercise the scoring logic directly — they are pure helpers
+and require no database.
+
+Run:  pytest tests/test_flight_builder_lh_constraint.py -v
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services.flight_builder import _score_ordering
+
+
+def _event(stand_type: str = "springboard", id: int = 1, name: str = "Springboard"):
+    return SimpleNamespace(stand_type=stand_type, id=id, name=name)
+
+
+def _heat_data(event, competitors, heat_number: int = 1, contains_lh: bool = False):
+    heat = SimpleNamespace(event_id=event.id, heat_number=heat_number, run_number=1)
+    return {
+        "heat": heat,
+        "event": event,
+        "competitors": set(competitors),
+        "contains_lh": contains_lh,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scoring penalty dominates spreading LH across flights
+# ---------------------------------------------------------------------------
+
+
+class TestLhFlightScoringPenalty:
+    def test_two_lh_heats_in_same_flight_trigger_penalty(self):
+        """Two LH-tagged heats in the first flight block → 1000-point penalty."""
+        ev = _event()
+        # heats_per_flight=4.  Two LH heats in positions 0 and 1 → same block.
+        ordered = [
+            _heat_data(ev, {1}, heat_number=1, contains_lh=True),
+            _heat_data(ev, {2}, heat_number=2, contains_lh=True),
+            _heat_data(ev, {3}, heat_number=3, contains_lh=False),
+            _heat_data(ev, {4}, heat_number=4, contains_lh=False),
+        ]
+        score_same_flight = _score_ordering(ordered, heats_per_flight=4)
+
+        # Spread: LH heats in different flights.
+        spread = [
+            _heat_data(ev, {1}, heat_number=1, contains_lh=True),
+            _heat_data(ev, {3}, heat_number=3, contains_lh=False),
+            _heat_data(ev, {4}, heat_number=4, contains_lh=False),
+            _heat_data(ev, {5}, heat_number=5, contains_lh=False),
+            _heat_data(ev, {2}, heat_number=2, contains_lh=True),
+            _heat_data(ev, {6}, heat_number=6, contains_lh=False),
+            _heat_data(ev, {7}, heat_number=7, contains_lh=False),
+            _heat_data(ev, {8}, heat_number=8, contains_lh=False),
+        ]
+        score_spread = _score_ordering(spread, heats_per_flight=4)
+
+        # Spread must score higher — penalty dominates.
+        assert score_spread > score_same_flight
+        # Concretely, the penalty is -1000 per extra LH heat in a block.
+        assert (score_spread - score_same_flight) >= 1000
+
+    def test_three_lh_heats_in_same_flight_double_penalty(self):
+        """Three LH heats in one block → -1000 × 2 = -2000 extra penalty vs one."""
+        ev = _event()
+        three_in_one = [
+            _heat_data(ev, {1}, heat_number=1, contains_lh=True),
+            _heat_data(ev, {2}, heat_number=2, contains_lh=True),
+            _heat_data(ev, {3}, heat_number=3, contains_lh=True),
+            _heat_data(ev, {4}, heat_number=4, contains_lh=False),
+        ]
+        one_lh = [
+            _heat_data(ev, {1}, heat_number=1, contains_lh=True),
+            _heat_data(ev, {2}, heat_number=2, contains_lh=False),
+            _heat_data(ev, {3}, heat_number=3, contains_lh=False),
+            _heat_data(ev, {4}, heat_number=4, contains_lh=False),
+        ]
+        score_three = _score_ordering(three_in_one, heats_per_flight=4)
+        score_one = _score_ordering(one_lh, heats_per_flight=4)
+        # Three LH in one block pays two extra -1000 penalties vs a single LH.
+        assert (score_one - score_three) >= 2000
+
+    def test_lh_heats_across_different_flights_no_penalty(self):
+        """One LH heat per flight → no penalty beyond the usual scoring."""
+        ev = _event()
+        ordered = [
+            _heat_data(ev, {1}, heat_number=1, contains_lh=True),
+            _heat_data(ev, {3}, heat_number=3, contains_lh=False),
+            _heat_data(ev, {4}, heat_number=4, contains_lh=False),
+            _heat_data(ev, {5}, heat_number=5, contains_lh=False),
+            # Flight 2 boundary
+            _heat_data(ev, {2}, heat_number=2, contains_lh=True),
+            _heat_data(ev, {6}, heat_number=6, contains_lh=False),
+            _heat_data(ev, {7}, heat_number=7, contains_lh=False),
+            _heat_data(ev, {8}, heat_number=8, contains_lh=False),
+        ]
+        no_lh = [
+            _heat_data(ev, {1}, heat_number=1, contains_lh=False),
+            _heat_data(ev, {3}, heat_number=3, contains_lh=False),
+            _heat_data(ev, {4}, heat_number=4, contains_lh=False),
+            _heat_data(ev, {5}, heat_number=5, contains_lh=False),
+            _heat_data(ev, {2}, heat_number=2, contains_lh=False),
+            _heat_data(ev, {6}, heat_number=6, contains_lh=False),
+            _heat_data(ev, {7}, heat_number=7, contains_lh=False),
+            _heat_data(ev, {8}, heat_number=8, contains_lh=False),
+        ]
+        score_spread = _score_ordering(ordered, heats_per_flight=4)
+        score_no_lh = _score_ordering(no_lh, heats_per_flight=4)
+        # Scores should be effectively equal — no LH penalty.
+        assert score_spread == score_no_lh
+
+    def test_heats_without_contains_lh_key_default_to_false(self):
+        """Old-shape heat dicts (no contains_lh key) must not crash the scorer."""
+        ev = _event()
+        ordered = [
+            # Explicitly drop the contains_lh key to simulate old data.
+            {
+                "heat": SimpleNamespace(event_id=ev.id, heat_number=1, run_number=1),
+                "event": ev,
+                "competitors": {1},
+            },
+            {
+                "heat": SimpleNamespace(event_id=ev.id, heat_number=2, run_number=1),
+                "event": ev,
+                "competitors": {2},
+            },
+        ]
+        # Must not raise.
+        score = _score_ordering(ordered, heats_per_flight=4)
+        assert isinstance(score, float)
+
+    def test_empty_ordering_returns_zero(self):
+        assert _score_ordering([], heats_per_flight=4) == 0.0

--- a/tests/test_heat_gen_integration.py
+++ b/tests/test_heat_gen_integration.py
@@ -352,9 +352,14 @@ class TestGeneratePartneredEvent:
 # ---------------------------------------------------------------------------
 
 class TestGenerateSpringboardHeats:
-    """Springboard: 4 dummies, left-handed cutters grouped together."""
+    """Springboard: 4 dummies, left-handed cutters spread ONE per heat.
 
-    def test_left_handed_grouped_together(self, db_session):
+    Rule (2026-04-20): only one physical LH springboard dummy on site, so at
+    most one LH cutter per heat.  Spread LH cutters one per heat 0..N-1.
+    Overflow (more LH than heats) goes into the final heat with a warning.
+    """
+
+    def test_left_handed_spread_one_per_heat(self, db_session):
         t = _make_tournament(db_session)
         ev = _make_event(db_session, t, name='Springboard', stand_type='springboard',
                          max_stands=4, gender=None)
@@ -373,7 +378,7 @@ class TestGenerateSpringboardHeats:
         generate_event_heats(ev)
 
         heats = _all_heats_for_event(ev.id, run_number=1)
-        # Both lefties should be in the same heat
+        # Each lefty should land in a DIFFERENT heat (spread, not clustered).
         lefty_heats = set()
         for h in heats:
             comps = set(h.get_competitors())
@@ -381,8 +386,10 @@ class TestGenerateSpringboardHeats:
                 if lid in comps:
                     lefty_heats.add(h.heat_number)
 
-        assert len(lefty_heats) == 1, \
-            f'Left-handed cutters spread across heats {lefty_heats}, expected 1'
+        assert len(lefty_heats) == 2, (
+            f'Left-handed cutters clustered in heats {lefty_heats}; '
+            'each LH cutter should land in its own heat.'
+        )
 
     def test_stand_assignments_within_4_dummies(self, db_session):
         t = _make_tournament(db_session)

--- a/tests/test_heat_generator.py
+++ b/tests/test_heat_generator.py
@@ -368,7 +368,33 @@ class TestGenerateStandardHeats:
 # ---------------------------------------------------------------------------
 
 class TestGenerateSpringboardHeats:
-    def test_left_handed_grouped_in_first_heat(self):
+    """
+    LH cutter placement rule (2026-04-20):
+      - Only one physical LH springboard dummy on site.
+      - At most one LH cutter per heat.
+      - Spread LH cutters one per heat 0..N-1.
+      - If more LH cutters than heats, overflow goes to the FINAL heat with
+        a warning (emitted via lh_warnings list).
+      - Slow-heat cutters still cluster into the final heat (unchanged).
+    """
+
+    def test_one_lh_cutter_placed_in_heat_0(self):
+        ev = _event(event_type='college', stand_type='springboard')
+        comps = [
+            _comp(1, name='A', is_left_handed=True),
+            _comp(2, name='B'),
+            _comp(3, name='C'),
+            _comp(4, name='D'),
+            _comp(5, name='E'),
+            _comp(6, name='F'),
+        ]
+        heats = _generate_springboard_heats(comps, 2, 4, {}, event=ev)
+        heat0_ids = {c['id'] for c in heats[0]}
+        heat1_ids = {c['id'] for c in heats[1]}
+        assert 1 in heat0_ids
+        assert 1 not in heat1_ids
+
+    def test_two_lh_cutters_spread_not_clustered(self):
         ev = _event(event_type='college', stand_type='springboard')
         comps = [
             _comp(1, name='A', is_left_handed=True),
@@ -379,10 +405,139 @@ class TestGenerateSpringboardHeats:
             _comp(6, name='F'),
         ]
         heats = _generate_springboard_heats(comps, 2, 4, {}, event=ev)
-        lh_ids = {1, 2}
-        # Both left-handers should be in heat 0 (left_heat_idx=0)
         heat0_ids = {c['id'] for c in heats[0]}
-        assert lh_ids.issubset(heat0_ids)
+        heat1_ids = {c['id'] for c in heats[1]}
+        # LH 1 should be in heat 0, LH 2 in heat 1 — NOT both in heat 0.
+        assert 1 in heat0_ids and 2 in heat1_ids
+        # Defensive: if both were clustered, the test would have caught the old bug.
+        assert not ({1, 2}.issubset(heat0_ids))
+
+    def test_four_lh_cutters_four_heats_one_per_heat(self):
+        ev = _event(event_type='college', stand_type='springboard')
+        comps = [
+            _comp(1, name='A', is_left_handed=True),
+            _comp(2, name='B', is_left_handed=True),
+            _comp(3, name='C', is_left_handed=True),
+            _comp(4, name='D', is_left_handed=True),
+            _comp(5, name='E'),
+            _comp(6, name='F'),
+            _comp(7, name='G'),
+            _comp(8, name='H'),
+            _comp(9, name='I'),
+            _comp(10, name='J'),
+            _comp(11, name='K'),
+            _comp(12, name='L'),
+        ]
+        heats = _generate_springboard_heats(comps, 4, 3, {}, event=ev)
+        lh_per_heat = [
+            sum(1 for c in heat if c['id'] in {1, 2, 3, 4})
+            for heat in heats
+        ]
+        assert lh_per_heat == [1, 1, 1, 1]
+
+    def test_overflow_lh_goes_to_final_heat_with_warning(self):
+        """5 LH cutters across 4 heats: 4 spread, 1 overflows to final heat."""
+        ev = _event(event_type='college', stand_type='springboard')
+        comps = [
+            _comp(1, name='A', is_left_handed=True),
+            _comp(2, name='B', is_left_handed=True),
+            _comp(3, name='C', is_left_handed=True),
+            _comp(4, name='D', is_left_handed=True),
+            _comp(5, name='E', is_left_handed=True),
+            _comp(6, name='F'),
+            _comp(7, name='G'),
+            _comp(8, name='H'),
+        ]
+        lh_warnings: list = []
+        heats = _generate_springboard_heats(
+            comps, 4, 4, {}, event=ev, lh_warnings=lh_warnings,
+        )
+        # Heat 0..2 each have exactly 1 LH; final heat has 2 LH.
+        lh_per_heat = [
+            sum(1 for c in heat if c['id'] in {1, 2, 3, 4, 5})
+            for heat in heats
+        ]
+        assert lh_per_heat == [1, 1, 1, 2]
+        # Overflow warning emitted for heat 3.
+        assert len(lh_warnings) == 1
+        assert lh_warnings[0]['type'] == 'lh_overflow'
+        assert lh_warnings[0]['heat_index'] == 3
+        assert lh_warnings[0]['overflow_count'] == 1
+
+    def test_overflow_unplaceable_when_final_heat_full(self):
+        """LH overflow exceeds max_per_heat of final heat — gear_violations records it."""
+        ev = _event(event_type='college', stand_type='springboard')
+        # 3 heats of max 2 cutters each = 6 slots.
+        # 4 LH cutters: 3 spread to heats 0/1/2 (one each), 4th overflow to final
+        # heat 2.  Final heat now has 1 LH from spread + 1 LH overflow = 2/2 capacity.
+        # Add a 5th LH: overflow unplaceable.
+        comps = [
+            _comp(1, name='A', is_left_handed=True),
+            _comp(2, name='B', is_left_handed=True),
+            _comp(3, name='C', is_left_handed=True),
+            _comp(4, name='D', is_left_handed=True),
+            _comp(5, name='E', is_left_handed=True),
+        ]
+        lh_warnings: list = []
+        gear_violations: list = []
+        _generate_springboard_heats(
+            comps, 3, 2, {}, event=ev,
+            gear_violations=gear_violations, lh_warnings=lh_warnings,
+        )
+        # E (id=5) can't fit anywhere — all heats at max 2 after spread + 1 overflow.
+        unplaceable = [v for v in gear_violations if 'unplaced' in v.get('reason', '').lower()]
+        assert len(unplaceable) == 1
+        assert unplaceable[0]['comp_name'] == 'E'
+
+    def test_no_left_handers_no_warning_and_no_grouping(self):
+        ev = _event(event_type='college', stand_type='springboard')
+        comps = [_comp(i, name=f'C{i}') for i in range(1, 9)]
+        lh_warnings: list = []
+        heats = _generate_springboard_heats(
+            comps, 2, 4, {}, event=ev, lh_warnings=lh_warnings,
+        )
+        assert sum(len(h) for h in heats) == 8
+        assert lh_warnings == []
+
+    def test_slow_heat_clusters_into_final_heat_unchanged(self):
+        """Slow-heat behavior preserved: cluster into final heat."""
+        ev = _event(event_type='college', stand_type='springboard')
+        comps = [
+            _comp(1, name='A', is_slow_springboard=True),
+            _comp(2, name='B', is_slow_springboard=True),
+            _comp(3, name='C'),
+            _comp(4, name='D'),
+            _comp(5, name='E'),
+            _comp(6, name='F'),
+            _comp(7, name='G'),
+            _comp(8, name='H'),
+        ]
+        heats = _generate_springboard_heats(comps, 2, 4, {}, event=ev)
+        # Slow cutters should both be in the final heat (idx 1).
+        final_ids = {c['id'] for c in heats[1]}
+        assert {1, 2}.issubset(final_ids)
+
+    def test_lh_and_slow_heat_both_land_in_final_heat(self):
+        """Interaction: 1 LH cutter alone fits heat 0; 1 slow-heat cutter in final.
+        With only 2 heats, final heat hosts the slow cutter AND (eventually) overflow
+        LH would go there too.  Smoke test that both mechanisms coexist without crash.
+        """
+        ev = _event(event_type='college', stand_type='springboard')
+        comps = [
+            _comp(1, name='A', is_left_handed=True),
+            _comp(2, name='B', is_slow_springboard=True),
+            _comp(3, name='C'),
+            _comp(4, name='D'),
+            _comp(5, name='E'),
+            _comp(6, name='F'),
+        ]
+        heats = _generate_springboard_heats(comps, 2, 4, {}, event=ev)
+        heat0_ids = {c['id'] for c in heats[0]}
+        heat1_ids = {c['id'] for c in heats[1]}
+        assert 1 in heat0_ids      # LH spread to heat 0
+        assert 2 in heat1_ids      # slow in final
+        # All six placed.
+        assert len(heat0_ids | heat1_ids) == 6
 
     def test_all_placed(self):
         ev = _event(event_type='college', stand_type='springboard')
@@ -390,12 +545,6 @@ class TestGenerateSpringboardHeats:
         heats = _generate_springboard_heats(comps, 2, 4, {}, event=ev)
         placed = [c for heat in heats for c in heat]
         assert len(placed) == 8
-
-    def test_no_left_handers_no_grouping(self):
-        ev = _event(event_type='college', stand_type='springboard')
-        comps = [_comp(i, name=f'C{i}') for i in range(1, 9)]
-        heats = _generate_springboard_heats(comps, 2, 4, {}, event=ev)
-        assert sum(len(h) for h in heats) == 8
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pro_entry_importer_handedness.py
+++ b/tests/test_pro_entry_importer_handedness.py
@@ -1,0 +1,288 @@
+"""
+Handedness + canonical-dedup tests for services/pro_entry_importer.py.
+
+Covers the L/R springboard bug fix (2026-04-20):
+- is_left_handed_springboard is correctly captured from the 'Springboard (L)'
+  column (and NOT lost in canonical dedup).
+- Canonical dedup prevents double-entry and double-fee-charging when the form
+  has multiple aliased columns mapping to the same canonical event.
+- Sentinel None is used when neither L nor R column exists in the xlsx so
+  re-imports do not wipe manually corrected flags.
+- compute_review_flags warns when both L and R boxes are checked on the
+  same row.
+
+Run:  pytest tests/test_pro_entry_importer_handedness.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from services.pro_entry_importer import compute_review_flags, parse_pro_entries
+
+# Waiver column header (full text is long; starts-with matching is done in parser)
+_WAIVER_HEADER = (
+    "I know that logging events bear inherent risks. "
+    "I consent to participate at my own risk."
+)
+
+
+def _write_form_xlsx(tmp_path: Path, columns: list[str], rows: list[list]) -> str:
+    """Write a minimal Google-Forms-style xlsx and return its path as string."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(columns)
+    for row in rows:
+        ws.append(row)
+    fp = tmp_path / "form.xlsx"
+    wb.save(fp)
+    return str(fp)
+
+
+def _base_columns(event_columns: list[str]) -> list[str]:
+    """
+    Return the minimum set of Google Forms columns + the event columns under test.
+
+    Columns match the strings parse_pro_entries looks up via hmap.
+    """
+    return [
+        "Timestamp",
+        "Email Address",
+        "Full Name",
+        "Gender",
+        "Mailing Address",
+        "Phone Number",
+        "Are you a current ALA member?",
+        *event_columns,
+        "I would like to enter into the Pro-Am lottery",
+        "Are you sharing gear?",
+        _WAIVER_HEADER,
+        "Signature",
+    ]
+
+
+def _row_template(
+    name: str = "Alex Kaper",
+    email: str = "alex@example.com",
+    gender: str = "Male",
+    event_answers: list = None,
+) -> list:
+    """Return a row with base columns filled in and event answers interleaved."""
+    return [
+        "2026-04-20T10:00:00",  # Timestamp
+        email,  # Email Address
+        name,  # Full Name
+        gender,  # Gender
+        "123 Log St",  # Mailing Address
+        "5551234567",  # Phone Number
+        "Yes",  # ALA member?
+        *(event_answers or []),
+        "No",  # Pro-Am lottery
+        "No",  # gear sharing
+        "Yes",  # waiver
+        "Alex Kaper",  # signature
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Handedness capture
+# ---------------------------------------------------------------------------
+
+
+class TestHandednessCapture:
+    def test_springboard_l_only_sets_true(self, tmp_path):
+        cols = _base_columns(["Springboard (L)", "Springboard (R)"])
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["Yes", "No"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        assert entries[0]["is_left_handed_springboard"] is True
+        assert entries[0]["events"] == ["Springboard"]
+
+    def test_springboard_r_only_keeps_false(self, tmp_path):
+        cols = _base_columns(["Springboard (L)", "Springboard (R)"])
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["No", "Yes"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        assert entries[0]["is_left_handed_springboard"] is False
+        assert entries[0]["events"] == ["Springboard"]
+
+    def test_both_checked_sets_true_and_dedupes_event(self, tmp_path):
+        """Both L and R checked → prefer L (True); event + fee dedup to 1."""
+        cols = _base_columns(["Springboard (L)", "Springboard (R)"])
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["Yes", "Yes"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        assert entries[0]["is_left_handed_springboard"] is True
+        # Canonical dedup: should NOT be ['Springboard', 'Springboard'].
+        assert entries[0]["events"] == ["Springboard"]
+        # Fee dedup: $10 chopping, not $20.
+        assert entries[0]["chopping_fees"] == 10
+        # Raw flags preserved for review-flag detection.
+        assert entries[0]["_raw_springboard_l"] is True
+        assert entries[0]["_raw_springboard_r"] is True
+
+    def test_neither_checked_defaults_false(self, tmp_path):
+        """Form has L/R columns, row checks neither → False (explicit signal)."""
+        cols = _base_columns(["Springboard (L)", "Springboard (R)"])
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["No", "No"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        # Form has the columns, so we have a signal: False (right-handed).
+        assert entries[0]["is_left_handed_springboard"] is False
+        assert entries[0]["events"] == []
+
+    def test_columns_absent_sets_none_sentinel(self, tmp_path):
+        """Form lacks both L and R columns → None sentinel (preserve manual)."""
+        # Minimal form with ONLY non-springboard events.
+        cols = _base_columns(["Hot Saw"])
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["Yes"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        # No L/R columns at all → None so confirmer preserves any DB value.
+        assert entries[0]["is_left_handed_springboard"] is None
+
+
+# ---------------------------------------------------------------------------
+# Canonical dedup across other event aliases
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalDedup:
+    def test_pro_1board_three_headers_dedup_to_one_entry_one_fee(self, tmp_path):
+        """
+        _EVENT_MAP has three keys mapping to canonical 'Pro 1-Board':
+        'Intermediate 1-Board Springboard', '1-Board Springboard', 'Pro 1-Board'.
+        Row with 'Yes' on ALL THREE should produce a single entry + single $10 fee.
+        """
+        cols = _base_columns(
+            [
+                "Intermediate 1-Board Springboard",
+                "1-Board Springboard",
+                "Pro 1-Board",
+            ]
+        )
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["Yes", "Yes", "Yes"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        assert entries[0]["events"] == ["Pro 1-Board"]
+        assert entries[0]["chopping_fees"] == 10
+        assert entries[0]["total_fees"] == 10
+
+    def test_jack_jill_three_headers_dedup_to_one_entry_one_fee(self, tmp_path):
+        """
+        _EVENT_MAP has 'Jack & Jill', 'Jack & Jill Sawing', 'Jack Jill' → one canonical.
+        Row with 'Yes' on all three should produce a single entry + single $5 fee.
+        """
+        cols = _base_columns(
+            [
+                "Jack & Jill",
+                "Jack & Jill Sawing",
+                "Jack Jill",
+            ]
+        )
+        path = _write_form_xlsx(
+            tmp_path,
+            cols,
+            [
+                _row_template(
+                    event_answers=["Yes", "Yes", "Yes"],
+                )
+            ],
+        )
+        entries = parse_pro_entries(path)
+        assert len(entries) == 1
+        assert entries[0]["events"] == ["Jack & Jill Sawing"]
+        assert entries[0]["other_fees"] == 5
+        assert entries[0]["total_fees"] == 5
+
+
+# ---------------------------------------------------------------------------
+# compute_review_flags: both-checked conflict
+# ---------------------------------------------------------------------------
+
+
+class TestReviewFlagsConflict:
+    def _entry(self, l: bool, r: bool) -> dict:
+        """Minimal entry dict with the raw L/R flags required by the flag logic."""
+        return {
+            "name": "Alex",
+            "waiver_accepted": True,
+            "partners": {},
+            "gear_sharing": False,
+            "gear_sharing_details": None,
+            "_raw_springboard_l": l,
+            "_raw_springboard_r": r,
+        }
+
+    def test_both_l_and_r_flags_conflict(self):
+        entries = [self._entry(True, True)]
+        compute_review_flags(entries)
+        assert "CONFLICT: BOTH L AND R SPRINGBOARD CHECKED" in entries[0]["flags"]
+        # Should be a warning-level class (not error red, since waiver OK).
+        assert entries[0]["flag_class"] == "table-warning"
+
+    def test_only_l_no_conflict(self):
+        entries = [self._entry(True, False)]
+        compute_review_flags(entries)
+        assert "CONFLICT: BOTH L AND R SPRINGBOARD CHECKED" not in entries[0]["flags"]
+
+    def test_only_r_no_conflict(self):
+        entries = [self._entry(False, True)]
+        compute_review_flags(entries)
+        assert "CONFLICT: BOTH L AND R SPRINGBOARD CHECKED" not in entries[0]["flags"]
+
+    def test_neither_no_conflict(self):
+        entries = [self._entry(False, False)]
+        compute_review_flags(entries)
+        assert "CONFLICT: BOTH L AND R SPRINGBOARD CHECKED" not in entries[0]["flags"]

--- a/tests/test_repair_springboard_handedness.py
+++ b/tests/test_repair_springboard_handedness.py
@@ -1,0 +1,235 @@
+"""
+Tests for scripts/repair_springboard_handedness.py.
+
+Covers the one-time repair workflow that retroactively applies the L/R
+springboard importer fix to competitors that were imported under the broken
+parser.  The repair script re-parses a given xlsx with the fixed parser and:
+  1. Updates ProCompetitor.is_left_handed_springboard from the form signal.
+  2. Regenerates pro springboard heats where safe (skipping finalized events
+     and events with heats already in_progress / completed).
+
+These tests use the same xlsx-fixture pattern as test_pro_entry_importer_handedness.
+
+Run:  pytest tests/test_repair_springboard_handedness.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from scripts.repair_springboard_handedness import repair
+from tests.conftest import (
+    make_event,
+    make_pro_competitor,
+    make_tournament,
+)
+
+_WAIVER_HEADER = (
+    "I know that logging events bear inherent risks. "
+    "I consent to participate at my own risk."
+)
+
+
+def _write_form_xlsx(tmp_path: Path, rows: list[dict]) -> str:
+    """
+    Write a minimal Google-Forms-style xlsx with Springboard L/R columns.
+    Each row dict provides: name, email, l ('Yes'/'No'), r ('Yes'/'No').
+    """
+    cols = [
+        "Timestamp",
+        "Email Address",
+        "Full Name",
+        "Gender",
+        "Mailing Address",
+        "Phone Number",
+        "Are you a current ALA member?",
+        "Springboard (L)",
+        "Springboard (R)",
+        "I would like to enter into the Pro-Am lottery",
+        "Are you sharing gear?",
+        _WAIVER_HEADER,
+        "Signature",
+    ]
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.append(cols)
+    for row in rows:
+        ws.append(
+            [
+                "2026-04-20T10:00:00",
+                row["email"],
+                row["name"],
+                row.get("gender", "Male"),
+                "123 Log St",
+                "5551234567",
+                "Yes",
+                row.get("l", "No"),
+                row.get("r", "No"),
+                "No",
+                "No",
+                "Yes",
+                row["name"],
+            ]
+        )
+    fp = tmp_path / "repair.xlsx"
+    wb.save(fp)
+    return str(fp)
+
+
+class TestRepairFlagUpdate:
+    def test_repair_sets_true_when_xlsx_has_l_checked(self, db_session, tmp_path):
+        tournament = make_tournament(db_session)
+        # Pre-existing competitor imported under the broken parser: LH = False.
+        comp = make_pro_competitor(
+            db_session,
+            tournament,
+            name="Alex Kaper",
+            is_left_handed_springboard=False,
+        )
+        comp.email = "alex@example.com"
+        db_session.flush()
+
+        xlsx = _write_form_xlsx(
+            tmp_path,
+            [
+                {
+                    "name": "Alex Kaper",
+                    "email": "alex@example.com",
+                    "l": "Yes",
+                    "r": "No",
+                },
+            ],
+        )
+
+        summary = repair(tournament.id, xlsx, dry_run=False)
+
+        # The repair reports one flag flip from False -> True.
+        assert len(summary["flag_updates"]) == 1
+        assert summary["flag_updates"][0]["email"] == "alex@example.com"
+        assert summary["flag_updates"][0]["old"] is False
+        assert summary["flag_updates"][0]["new"] is True
+
+        # DB reflects the update.
+        db_session.refresh(comp)
+        assert comp.is_left_handed_springboard is True
+
+    def test_repair_no_change_when_already_correct(self, db_session, tmp_path):
+        tournament = make_tournament(db_session)
+        comp = make_pro_competitor(
+            db_session,
+            tournament,
+            name="Alex Kaper",
+            is_left_handed_springboard=True,
+        )
+        comp.email = "alex@example.com"
+        db_session.flush()
+
+        xlsx = _write_form_xlsx(
+            tmp_path,
+            [
+                {
+                    "name": "Alex Kaper",
+                    "email": "alex@example.com",
+                    "l": "Yes",
+                    "r": "No",
+                },
+            ],
+        )
+
+        summary = repair(tournament.id, xlsx, dry_run=False)
+
+        # Already True, so no flag update reported.
+        assert summary["flag_updates"] == []
+
+    def test_repair_dry_run_reports_changes_but_commits_nothing(
+        self, db_session, tmp_path
+    ):
+        tournament = make_tournament(db_session)
+        comp = make_pro_competitor(
+            db_session,
+            tournament,
+            name="Alex Kaper",
+            is_left_handed_springboard=False,
+        )
+        comp.email = "alex@example.com"
+        db_session.flush()
+
+        xlsx = _write_form_xlsx(
+            tmp_path,
+            [
+                {
+                    "name": "Alex Kaper",
+                    "email": "alex@example.com",
+                    "l": "Yes",
+                    "r": "No",
+                },
+            ],
+        )
+
+        summary = repair(tournament.id, xlsx, dry_run=True)
+
+        # Reports the change...
+        assert len(summary["flag_updates"]) == 1
+        # ...but does NOT mutate the DB.
+        db_session.refresh(comp)
+        assert comp.is_left_handed_springboard is False
+
+    def test_repair_skips_unmatched_emails(self, db_session, tmp_path):
+        tournament = make_tournament(db_session)
+
+        xlsx = _write_form_xlsx(
+            tmp_path,
+            [
+                {"name": "Ghost", "email": "ghost@example.com", "l": "Yes", "r": "No"},
+            ],
+        )
+
+        summary = repair(tournament.id, xlsx, dry_run=False)
+
+        assert "ghost@example.com" in summary["unmatched_emails"]
+        assert summary["flag_updates"] == []
+
+    def test_repair_skips_finalized_springboard_event(self, db_session, tmp_path):
+        tournament = make_tournament(db_session)
+        comp = make_pro_competitor(
+            db_session,
+            tournament,
+            name="Alex Kaper",
+            is_left_handed_springboard=False,
+        )
+        comp.email = "alex@example.com"
+
+        # Finalized pro springboard event — must NOT be regenerated.
+        event = make_event(
+            db_session,
+            tournament,
+            name="Springboard",
+            event_type="pro",
+            stand_type="springboard",
+        )
+        event.is_finalized = True
+        db_session.flush()
+
+        xlsx = _write_form_xlsx(
+            tmp_path,
+            [
+                {
+                    "name": "Alex Kaper",
+                    "email": "alex@example.com",
+                    "l": "Yes",
+                    "r": "No",
+                },
+            ],
+        )
+
+        summary = repair(tournament.id, xlsx, dry_run=False)
+
+        # Flag still updated, but heat regeneration skipped with a clear reason.
+        assert len(summary["flag_updates"]) == 1
+        skipped = {s["event"]: s["reason"] for s in summary["skipped_events"]}
+        assert "Springboard" in skipped
+        assert "finalized" in skipped["Springboard"].lower()


### PR DESCRIPTION
## Summary

Three active production bugs discovered during show-prep recon for April 24-25. Must ship as one atomic PR, because fixing the importer alone would actively make the show worse (heat gen would then correctly see multiple LH cutters and cluster them on the one physical LH dummy).

- `services/pro_entry_importer.py`: capture \`is_left_handed_springboard\` from the Springboard (L) form checkbox before the canonical dedup collapses L/R into one event. Preserve raw L/R flags so \`compute_review_flags()\` can warn on the physically-impossible both-boxes-checked case. Dedup canonical event names via a seen set — fixes silent double-entry + double-fee for L+R, Pro 1-Board (3 aliases), Jack & Jill (3 aliases), etc.
- `routes/import_routes.py`: skip the handedness write when the entry sentinel is None, protecting manually-corrected flags from being wiped by a re-import where the xlsx has no L/R columns at all.
- `services/heat_generator.py::_generate_springboard_heats`: SPREAD LH cutters 1 per heat across heats 0..N-1 (old code grouped them all in heat 0). Overflow rule: extras go into the final heat with a warning surfaced via a new \`_last_lh_overflow_warnings\` lookup.
- `services/flight_builder.py`: batch-load \`is_left_handed_springboard\` for springboard competitors, add a 1000-point scoring penalty in \`_score_ordering\` for any flight block with >1 LH-containing heat, plus a post-slice sanity warning.
- `scripts/repair_springboard_handedness.py` (new): one-time re-parse of the last uploaded xlsx; updates \`is_left_handed_springboard\` on existing competitors and regenerates pro springboard heats where safe (skips finalized events and live/in-progress heats). Supports \`--dry-run\`.

Full context: \`docs/VIDEO_JUDGE_BRACKET_PLAN.md\` (plan v2 after /plan-eng-review + Codex outside-voice review).

## Test plan

- [x] \`tests/test_pro_entry_importer_handedness.py\` — 11 tests (L-only, R-only, both, neither, column-absent sentinel, 3-alias dedup for Pro 1-Board + Jack & Jill, 4 conflict-flag cases)
- [x] \`tests/test_heat_generator.py::TestGenerateSpringboardHeats\` — 9 tests (spread, overflow-to-final, unplaceable, slow-heat interaction, no-LH)
- [x] \`tests/test_flight_builder_lh_constraint.py\` — 5 tests (penalty dominates, cross-flight no-penalty, missing-contains_lh-key safe)
- [x] \`tests/test_heat_gen_integration.py\` — old "grouped together" integration test updated to assert spread
- [x] \`tests/test_repair_springboard_handedness.py\` — 5 tests (flag flip, no-change-when-correct, dry-run, unmatched email, finalized event skip)
- [x] Full regression: 285 tests green across affected modules. 4 pre-existing route_smoke failures on clean main baseline (SQLite-async-lock, unrelated).

## After merge

Run the repair script once in production:
\`\`\`
python -m scripts.repair_springboard_handedness <tournament_id> uploads/<latest>.xlsx --dry-run
# verify the summary, then run without --dry-run
\`\`\`