### PR TITLE
Extract partner_resolver service; dedupe three inline copies

### DIFF
--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -10,43 +10,9 @@ from database import db
 from models import Event, EventResult, Flight, Heat, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 
-from . import _load_competitor_lookup, _resolve_partner_name, scheduling_bp
+from services.partner_resolver import pair_competitors_for_heat
 
-
-def _norm_alphanum(v) -> str:
-    return "".join(ch for ch in str(v or "").lower() if ch.isalnum())
-
-
-def _first_token_alphanum(v) -> str:
-    s = str(v or "").strip().lower().split()
-    return "".join(ch for ch in (s[0] if s else "") if ch.isalnum())
-
-
-def _lookup_partner_cid(partner_str: str, comps: dict, self_cid: int) -> int | None:
-    """Find the competitor id in `comps` that matches `partner_str`.
-
-    Full normalized name first; first-name fallback if exactly one comp matches.
-    Returns None on ambiguous / no match.
-    """
-    if not partner_str:
-        return None
-    norm_full = _norm_alphanum(partner_str)
-    if not norm_full:
-        return None
-    # Full match
-    for cid, c in comps.items():
-        if cid == self_cid:
-            continue
-        if _norm_alphanum(getattr(c, "name", "")) == norm_full:
-            return cid
-    # First-name fallback
-    partner_first = _first_token_alphanum(partner_str)
-    if not partner_first:
-        return None
-    matches = [cid for cid, c in comps.items()
-               if cid != self_cid
-               and _first_token_alphanum(getattr(c, "name", "")) == partner_first]
-    return matches[0] if len(matches) == 1 else None
+from . import _load_competitor_lookup, scheduling_bp
 
 
 def _stand_label(stand_type: str | None, stand_number) -> str:
@@ -149,34 +115,17 @@ def _serialize_heat_detail(tournament: Tournament, event: Event, heat: Heat) -> 
     comp_ids = heat.get_competitors()
     comp_lookup = _load_competitor_lookup(event, comp_ids)
     stand_type = event.stand_type
-    is_partnered = bool(getattr(event, "is_partnered", False))
 
-    consumed = set()
-    competitors = []
-    for comp_id in comp_ids:
-        if comp_id in consumed:
-            continue
-        comp = comp_lookup.get(comp_id)
-        name = comp.display_name if comp else f"Unknown ({comp_id})"
-        if is_partnered and comp:
-            partner = _resolve_partner_name(comp, event)
-            if partner:
-                partner_id = _lookup_partner_cid(partner, comp_lookup, comp_id)
-                # If we matched a real competitor (even fuzzily), prefer their
-                # display_name so a nickname like "TOBY" renders as "Toby Bartsch".
-                partner_label = (comp_lookup[partner_id].display_name
-                                 if partner_id and partner_id in comp_lookup
-                                 else partner)
-                name = f"{name} & {partner_label}"
-                if partner_id and partner_id != comp_id:
-                    consumed.add(partner_id)
-        competitors.append(
-            {
-                "name": name,
-                "stand": assignments.get(str(comp_id)),
-                "stand_label": _stand_label(stand_type, assignments.get(str(comp_id))),
-            }
-        )
+    competitors = [
+        {
+            "name": row["name"],
+            "stand": assignments.get(str(row["primary_comp_id"])),
+            "stand_label": _stand_label(
+                stand_type, assignments.get(str(row["primary_comp_id"]))
+            ),
+        }
+        for row in pair_competitors_for_heat(event, comp_ids, comp_lookup)
+    ]
     return {
         "heat_id": heat.id,
         "heat_number": heat.heat_number,
@@ -246,24 +195,10 @@ def heat_sheets(tournament_id):
                     if comp_ids
                     else {}
                 )
-            is_partnered = bool(getattr(event, "is_partnered", False))
-            consumed: set[int] = set()
             competitors_out = []
-            for cid in comp_ids:
-                if cid in consumed:
-                    continue
-                comp = comps.get(cid)
-                name = comp.display_name if comp else f"ID:{cid}"
-                if is_partnered and comp:
-                    partner = _resolve_partner_name(comp, event)
-                    if partner:
-                        pid = _lookup_partner_cid(partner, comps, cid)
-                        partner_label = (comps[pid].display_name
-                                         if pid and pid in comps
-                                         else partner)
-                        name = f"{name} & {partner_label}"
-                        if pid and pid != cid:
-                            consumed.add(pid)
+            for row in pair_competitors_for_heat(event, comp_ids, comps):
+                cid = row["primary_comp_id"]
+                name = row["name"] if row["competitor"] else f"ID:{cid}"
                 competitors_out.append({
                     "name": name,
                     "stand": assignments.get(str(cid), "?"),
@@ -364,24 +299,10 @@ def heat_sheets(tournament_id):
                     if comp_ids
                     else {}
                 )
-            is_partnered = bool(getattr(event, "is_partnered", False))
-            consumed: set[int] = set()
             competitors_out = []
-            for cid in comp_ids:
-                if cid in consumed:
-                    continue
-                comp = comps.get(cid)
-                name = comp.display_name if comp else f"ID:{cid}"
-                if is_partnered and comp:
-                    partner = _resolve_partner_name(comp, event)
-                    if partner:
-                        pid = _lookup_partner_cid(partner, comps, cid)
-                        partner_label = (comps[pid].display_name
-                                         if pid and pid in comps
-                                         else partner)
-                        name = f"{name} & {partner_label}"
-                        if pid and pid != cid:
-                            consumed.add(pid)
+            for row in pair_competitors_for_heat(event, comp_ids, comps):
+                cid = row["primary_comp_id"]
+                name = row["name"] if row["competitor"] else f"ID:{cid}"
                 competitors_out.append({
                     "name": name,
                     "stand": assignments.get(str(cid), "?"),

--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -9,7 +9,6 @@ from config import DAY_SPLIT_EVENT_NAMES
 from database import db
 from models import Event, EventResult, Flight, Heat, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
-
 from services.partner_resolver import pair_competitors_for_heat
 
 from . import _load_competitor_lookup, scheduling_bp

--- a/services/partner_resolver.py
+++ b/services/partner_resolver.py
@@ -1,0 +1,175 @@
+"""
+Partner resolution for partnered events (Jack & Jill, Double Buck, Peavey,
+Pulp Toss, Partnered Axe Throw).
+
+Partners are stored as NAME STRINGS, not FKs — `competitor.partners` is a JSON
+dict keyed `event_id → partner_name` (per CLAUDE.md Data Model). Rendering a
+heat for a partnered event therefore requires a name-string → competitor lookup
+against the active-competitor pool, with a first-name fuzzy fallback for the
+case where a judge typed "Toby" on the form and the roster has "Toby Bartsch".
+
+Three callers needed this same logic before this module existed:
+    1. routes/scheduling/heat_sheets.py:_serialize_heat_detail (hydration)
+    2. routes/scheduling/heat_sheets.py:heat_sheets route (print page)
+    3. services/video_judge_export.py (PR C — new)
+
+The first two were inline duplicates; this module is where they now resolve.
+Behavior must match the pre-extraction output byte-for-byte — the CRITICAL
+regression tests in tests/test_partner_resolver.py enforce that.
+"""
+
+from __future__ import annotations
+
+from models.event import Event
+
+
+def _norm_alphanum(v) -> str:
+    """Lowercase and strip non-alphanumeric characters for robust name matching."""
+    return "".join(ch for ch in str(v or "").lower() if ch.isalnum())
+
+
+def _first_token_alphanum(v) -> str:
+    """First whitespace-delimited token, lowercase, alphanumeric only."""
+    tokens = str(v or "").strip().lower().split()
+    return "".join(ch for ch in (tokens[0] if tokens else "") if ch.isalnum())
+
+
+def lookup_partner_cid(
+    partner_str: str,
+    comps: dict,
+    self_cid: int,
+) -> int | None:
+    """Find a competitor id in `comps` whose name matches `partner_str`.
+
+    Full normalized-name match first; first-name fallback if exactly one comp
+    matches by first token.  Returns None on ambiguous or no match.
+
+    Args:
+        partner_str: Partner name as written on the form (possibly nickname
+            or single token).
+        comps: Mapping of competitor_id -> competitor ORM object (must expose
+            a `.name` attribute).
+        self_cid: Competitor id to exclude from the search (so a pair doesn't
+            match to itself).
+    """
+    if not partner_str:
+        return None
+    norm_full = _norm_alphanum(partner_str)
+    if not norm_full:
+        return None
+
+    # Full match
+    for cid, c in comps.items():
+        if cid == self_cid:
+            continue
+        if _norm_alphanum(getattr(c, "name", "")) == norm_full:
+            return cid
+
+    # First-name fallback — one-match only
+    partner_first = _first_token_alphanum(partner_str)
+    if not partner_first:
+        return None
+    matches = [
+        cid
+        for cid, c in comps.items()
+        if cid != self_cid
+        and _first_token_alphanum(getattr(c, "name", "")) == partner_first
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _resolve_partner_name_local(competitor, event: Event) -> str:
+    """Return the partner name string for `competitor` in `event`, or ''.
+
+    Mirror of routes/scheduling/__init__.py::_resolve_partner_name so this
+    module has no cross-blueprint import dependency.  Keys tried in order:
+    event.id (str), event.name, event.display_name, event.name.lower(),
+    event.display_name.lower().
+    """
+    partners = competitor.get_partners() if hasattr(competitor, "get_partners") else {}
+    if not isinstance(partners, dict):
+        return ""
+    candidates = [
+        str(event.id),
+        event.name,
+        event.display_name,
+        event.name.lower(),
+        event.display_name.lower(),
+    ]
+    for key in candidates:
+        value = partners.get(key)
+        if str(value or "").strip():
+            return str(value).strip()
+    return ""
+
+
+def pair_competitors_for_heat(
+    event: Event,
+    comp_ids: list,
+    comp_lookup: dict,
+) -> list[dict]:
+    """Collapse a heat's competitor id list into one row per competitor/pair.
+
+    For partnered events, each pair member is rendered as "Alice & Bob" on a
+    single row and the partner's id is added to a `consumed` set so it doesn't
+    re-render as its own row.  For non-partnered events, returns one row per
+    competitor id in the order they appear.
+
+    Behavior matches the pre-extraction logic in routes/scheduling/heat_sheets.py
+    (both _serialize_heat_detail and the heat_sheets route body) byte-for-byte.
+    If the partner name is only fuzzily matched, the matched competitor's
+    display_name is used in preference to the raw form string so nicknames
+    like "TOBY" render as "Toby Bartsch".
+
+    Args:
+        event: Event this heat belongs to (needs .id, .name, .display_name,
+            .is_partnered).
+        comp_ids: Ordered list of competitor IDs on the heat.
+        comp_lookup: Dict competitor_id -> ORM object (must expose .name and
+            .display_name and .get_partners()).
+
+    Returns:
+        List of dicts, one per unique pair/competitor:
+            {
+              'primary_comp_id': int,        # first id in the pair as listed
+              'partner_comp_id': int | None, # matched partner id, or None
+              'name': str,                   # "Alice" or "Alice & Bob"
+              'competitor': ORM | None,      # primary comp object (or None)
+            }
+    """
+    is_partnered = bool(getattr(event, "is_partnered", False))
+    rows: list[dict] = []
+    consumed: set = set()
+
+    for comp_id in comp_ids:
+        if comp_id in consumed:
+            continue
+        comp = comp_lookup.get(comp_id)
+        name = comp.display_name if comp else f"Unknown ({comp_id})"
+        partner_cid: int | None = None
+
+        if is_partnered and comp:
+            partner = _resolve_partner_name_local(comp, event)
+            if partner:
+                partner_cid = lookup_partner_cid(partner, comp_lookup, comp_id)
+                # Prefer matched comp's display_name so nicknames like "TOBY"
+                # render as "Toby Bartsch".
+                partner_label = (
+                    comp_lookup[partner_cid].display_name
+                    if partner_cid and partner_cid in comp_lookup
+                    else partner
+                )
+                name = f"{name} & {partner_label}"
+                if partner_cid and partner_cid != comp_id:
+                    consumed.add(partner_cid)
+
+        rows.append(
+            {
+                "primary_comp_id": comp_id,
+                "partner_comp_id": partner_cid,
+                "name": name,
+                "competitor": comp,
+            }
+        )
+
+    return rows

--- a/tests/test_partner_resolver.py
+++ b/tests/test_partner_resolver.py
@@ -1,0 +1,352 @@
+"""
+Tests for services/partner_resolver.py.
+
+Covers the extraction of partner-pairing logic from heat_sheets.py (2026-04-20).
+Three CRITICAL regression tests assert that the new service produces
+byte-for-byte identical output to the pre-extraction inline code in:
+  - routes/scheduling/heat_sheets.py:_serialize_heat_detail (old line 147-185)
+  - routes/scheduling/heat_sheets.py:heat_sheets route body (old line 234-256)
+  - First-name fuzzy fallback logic (inside _lookup_partner_cid)
+
+Run:  pytest tests/test_partner_resolver.py -v
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services.partner_resolver import (
+    _first_token_alphanum,
+    _norm_alphanum,
+    lookup_partner_cid,
+    pair_competitors_for_heat,
+)
+
+
+def _comp(
+    cid: int, name: str, partners: dict | None = None, display_name: str | None = None
+):
+    """Build a fake competitor ORM stand-in."""
+    partners = partners or {}
+    return SimpleNamespace(
+        id=cid,
+        name=name,
+        display_name=display_name or name,
+        get_partners=lambda p=partners: p,
+    )
+
+
+def _event(
+    eid: int = 1,
+    name: str = "Jack & Jill Sawing",
+    display_name: str | None = None,
+    is_partnered: bool = True,
+):
+    return SimpleNamespace(
+        id=eid,
+        name=name,
+        display_name=display_name or name,
+        is_partnered=is_partnered,
+    )
+
+
+# ---------------------------------------------------------------------------
+# lookup_partner_cid — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestLookupPartnerCid:
+    def test_empty_partner_string_returns_none(self):
+        assert lookup_partner_cid("", {}, 1) is None
+
+    def test_full_name_match(self):
+        comps = {1: _comp(1, "Alice"), 2: _comp(2, "Bob Jones")}
+        assert lookup_partner_cid("Bob Jones", comps, 1) == 2
+
+    def test_full_name_normalised(self):
+        """Punctuation and case are ignored when comparing full names."""
+        comps = {1: _comp(1, "Alice"), 2: _comp(2, "Mary-Ann O'Brien")}
+        assert lookup_partner_cid("maryann obrien", comps, 1) == 2
+
+    def test_first_name_fallback_unique(self):
+        """Form wrote just 'Toby'; roster has one 'Toby Bartsch' → match."""
+        comps = {1: _comp(1, "Alice"), 2: _comp(2, "Toby Bartsch")}
+        assert lookup_partner_cid("TOBY", comps, 1) == 2
+
+    def test_first_name_fallback_ambiguous_returns_none(self):
+        """Two 'Toby's in the pool → unresolvable, return None."""
+        comps = {
+            1: _comp(1, "Alice"),
+            2: _comp(2, "Toby Bartsch"),
+            3: _comp(3, "Toby Chen"),
+        }
+        assert lookup_partner_cid("TOBY", comps, 1) is None
+
+    def test_excludes_self(self):
+        """The primary competitor cannot match themselves as their own partner."""
+        comps = {1: _comp(1, "Toby Bartsch"), 2: _comp(2, "Other Name")}
+        assert lookup_partner_cid("Toby Bartsch", comps, 1) is None
+
+    def test_no_match_returns_none(self):
+        comps = {1: _comp(1, "Alice"), 2: _comp(2, "Bob")}
+        assert lookup_partner_cid("Charlie Nowhere", comps, 1) is None
+
+
+# ---------------------------------------------------------------------------
+# pair_competitors_for_heat — REGRESSION TESTS
+#
+# These MUST match the pre-extraction behavior from
+# routes/scheduling/heat_sheets.py — byte-for-byte.
+# ---------------------------------------------------------------------------
+
+
+class TestPairCompetitorsForHeat:
+    def test_non_partnered_event_one_row_per_cid(self):
+        """Simple timed event: every comp_id becomes its own row."""
+        ev = _event(is_partnered=False)
+        comps = {
+            10: _comp(10, "Alice"),
+            20: _comp(20, "Bob"),
+            30: _comp(30, "Charlie"),
+        }
+        rows = pair_competitors_for_heat(ev, [10, 20, 30], comps)
+        assert [r["primary_comp_id"] for r in rows] == [10, 20, 30]
+        assert [r["name"] for r in rows] == ["Alice", "Bob", "Charlie"]
+        assert all(r["partner_comp_id"] is None for r in rows)
+
+    def test_partnered_event_both_partners_present(self):
+        """Jack & Jill pair: Alice lists Bob; both in heat → one combined row."""
+        ev = _event(name="Jack & Jill Sawing", is_partnered=True)
+        alice = _comp(10, "Alice Smith", partners={"Jack & Jill Sawing": "Bob Jones"})
+        bob = _comp(20, "Bob Jones", partners={"Jack & Jill Sawing": "Alice Smith"})
+        comps = {10: alice, 20: bob}
+        rows = pair_competitors_for_heat(ev, [10, 20], comps)
+        assert len(rows) == 1
+        assert rows[0]["primary_comp_id"] == 10
+        assert rows[0]["partner_comp_id"] == 20
+        assert rows[0]["name"] == "Alice Smith & Bob Jones"
+
+    def test_partnered_event_partner_missing_from_pool(self):
+        """Partner name is raw (no competitor id matched) → keep raw name."""
+        ev = _event(is_partnered=True)
+        alice = _comp(
+            10,
+            "Alice Smith",
+            partners={"Jack & Jill Sawing": "Unknown Partner"},
+        )
+        comps = {10: alice}
+        rows = pair_competitors_for_heat(ev, [10], comps)
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Alice Smith & Unknown Partner"
+        assert rows[0]["partner_comp_id"] is None
+
+    def test_partnered_event_nickname_resolves_to_full_display_name(self):
+        """CRITICAL: form wrote 'TOBY' → renders 'Toby Bartsch' (not 'TOBY')."""
+        ev = _event(is_partnered=True)
+        alice = _comp(
+            10,
+            "Alice Smith",
+            partners={"Jack & Jill Sawing": "TOBY"},
+        )
+        toby = _comp(20, "Toby Bartsch")
+        comps = {10: alice, 20: toby}
+        rows = pair_competitors_for_heat(ev, [10, 20], comps)
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Alice Smith & Toby Bartsch"
+        assert rows[0]["partner_comp_id"] == 20
+
+    def test_consumed_set_prevents_double_row(self):
+        """Both pair members in heat → Bob's id is consumed, no standalone row."""
+        ev = _event(is_partnered=True)
+        alice = _comp(10, "Alice", partners={"Jack & Jill Sawing": "Bob"})
+        bob = _comp(20, "Bob", partners={"Jack & Jill Sawing": "Alice"})
+        comps = {10: alice, 20: bob}
+        rows = pair_competitors_for_heat(ev, [10, 20], comps)
+        assert [r["primary_comp_id"] for r in rows] == [10]
+        assert rows[0]["name"] == "Alice & Bob"
+
+    def test_missing_competitor_emits_unknown_row(self):
+        """Heat has a cid that isn't in the lookup (shouldn't normally happen)."""
+        ev = _event(is_partnered=False)
+        comps = {10: _comp(10, "Alice")}
+        rows = pair_competitors_for_heat(ev, [10, 99], comps)
+        assert len(rows) == 2
+        assert rows[1]["name"] == "Unknown (99)"
+        assert rows[1]["competitor"] is None
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL REGRESSION #1 — byte-for-byte match with old
+# _serialize_heat_detail inline logic.
+#
+# Replicate the exact pre-extraction code block and assert the service
+# produces identical (name, stand) pairs.  This test would FAIL if
+# anyone accidentally changes the pairing rules in partner_resolver.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_serialize_like_heat_sheets(event, comp_ids, comp_lookup, assignments):
+    """Inline reproduction of the pre-extraction logic from
+    routes/scheduling/heat_sheets.py::_serialize_heat_detail (old lines 147-185).
+
+    Kept here verbatim so the regression test can compare outputs 1:1.
+    Any drift between this function and partner_resolver = regression.
+    """
+
+    def _norm(v):
+        return "".join(ch for ch in str(v or "").lower() if ch.isalnum())
+
+    def _first(v):
+        s = str(v or "").strip().lower().split()
+        return "".join(ch for ch in (s[0] if s else "") if ch.isalnum())
+
+    def _legacy_lookup_pid(partner_str, comps, self_cid):
+        if not partner_str:
+            return None
+        norm_full = _norm(partner_str)
+        if not norm_full:
+            return None
+        for cid, c in comps.items():
+            if cid == self_cid:
+                continue
+            if _norm(getattr(c, "name", "")) == norm_full:
+                return cid
+        partner_first = _first(partner_str)
+        if not partner_first:
+            return None
+        matches = [
+            cid
+            for cid, c in comps.items()
+            if cid != self_cid and _first(getattr(c, "name", "")) == partner_first
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+    is_partnered = bool(getattr(event, "is_partnered", False))
+    consumed = set()
+    competitors = []
+    for comp_id in comp_ids:
+        if comp_id in consumed:
+            continue
+        comp = comp_lookup.get(comp_id)
+        name = comp.display_name if comp else f"Unknown ({comp_id})"
+        if is_partnered and comp:
+            partners = comp.get_partners() if hasattr(comp, "get_partners") else {}
+            if isinstance(partners, dict):
+                for key in [
+                    str(event.id),
+                    event.name,
+                    event.display_name,
+                    event.name.lower(),
+                    event.display_name.lower(),
+                ]:
+                    partner = partners.get(key)
+                    if str(partner or "").strip():
+                        partner = str(partner).strip()
+                        break
+                else:
+                    partner = ""
+                if partner:
+                    partner_id = _legacy_lookup_pid(partner, comp_lookup, comp_id)
+                    partner_label = (
+                        comp_lookup[partner_id].display_name
+                        if partner_id and partner_id in comp_lookup
+                        else partner
+                    )
+                    name = f"{name} & {partner_label}"
+                    if partner_id and partner_id != comp_id:
+                        consumed.add(partner_id)
+        competitors.append(
+            {
+                "name": name,
+                "stand": assignments.get(str(comp_id)),
+            }
+        )
+    return competitors
+
+
+class TestRegressionAgainstLegacyLogic:
+    """CRITICAL: partner_resolver output must match pre-extraction logic exactly."""
+
+    def _compare(self, event, comp_ids, comps, assignments):
+        legacy = _legacy_serialize_like_heat_sheets(event, comp_ids, comps, assignments)
+        new = [
+            {
+                "name": row["name"],
+                "stand": assignments.get(str(row["primary_comp_id"])),
+            }
+            for row in pair_competitors_for_heat(event, comp_ids, comps)
+        ]
+        assert new == legacy, (
+            f"\nLegacy:  {legacy}\nNew:     {new}\n"
+            "partner_resolver diverged from pre-extraction behavior."
+        )
+
+    def test_regression_simple_partnered_heat(self):
+        """CRITICAL: Alice + Bob pair matches legacy output."""
+        ev = _event(name="Jack & Jill Sawing", is_partnered=True)
+        alice = _comp(10, "Alice", partners={"Jack & Jill Sawing": "Bob"})
+        bob = _comp(20, "Bob", partners={"Jack & Jill Sawing": "Alice"})
+        comps = {10: alice, 20: bob}
+        assignments = {"10": 1, "20": 1}
+        self._compare(ev, [10, 20], comps, assignments)
+
+    def test_regression_nickname_fuzzy_match(self):
+        """CRITICAL: 'TOBY' → 'Toby Bartsch' resolution matches legacy."""
+        ev = _event(name="Double Buck", is_partnered=True)
+        alice = _comp(10, "Alice", partners={"Double Buck": "TOBY"})
+        toby = _comp(20, "Toby Bartsch")
+        comps = {10: alice, 20: toby}
+        assignments = {"10": 2, "20": 2}
+        self._compare(ev, [10, 20], comps, assignments)
+
+    def test_regression_partner_not_in_pool(self):
+        """CRITICAL: unresolved partner name renders raw — matches legacy."""
+        ev = _event(name="Jack & Jill Sawing", is_partnered=True)
+        alice = _comp(10, "Alice", partners={"Jack & Jill Sawing": "Random Person"})
+        comps = {10: alice}
+        assignments = {"10": 3}
+        self._compare(ev, [10], comps, assignments)
+
+    def test_regression_non_partnered_event_pass_through(self):
+        """Non-partnered: every comp is its own row, unchanged."""
+        ev = _event(is_partnered=False)
+        comps = {
+            10: _comp(10, "Alice"),
+            20: _comp(20, "Bob"),
+            30: _comp(30, "Charlie"),
+        }
+        assignments = {"10": 1, "20": 2, "30": 3}
+        self._compare(ev, [10, 20, 30], comps, assignments)
+
+    def test_regression_event_lookup_by_id_key(self):
+        """Partner stored under str(event.id) key (preferred lookup order)."""
+        ev = _event(eid=42, name="Pulp Toss", is_partnered=True)
+        alice = _comp(10, "Alice", partners={"42": "Bob"})  # id key, not name
+        bob = _comp(20, "Bob", partners={"42": "Alice"})
+        comps = {10: alice, 20: bob}
+        assignments = {"10": 1, "20": 1}
+        self._compare(ev, [10, 20], comps, assignments)
+
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNormalisationHelpers:
+    def test_norm_alphanum_drops_punctuation(self):
+        assert _norm_alphanum("O'Brien, Mary-Anne") == "obrienmaryanne"
+
+    def test_norm_alphanum_none(self):
+        assert _norm_alphanum(None) == ""
+
+    def test_first_token_alphanum_basic(self):
+        assert _first_token_alphanum("Toby Bartsch") == "toby"
+
+    def test_first_token_alphanum_empty(self):
+        assert _first_token_alphanum("") == ""
+
+    def test_first_token_alphanum_none(self):
+        assert _first_token_alphanum(None) == ""


### PR DESCRIPTION
## Summary

Same partner-pairing logic was duplicated three times in \`routes/scheduling/heat_sheets.py\`: once in \`_serialize_heat_detail\`, once in the heat_sheets route body (flight loop), and once more in the no-flight loop. PR C (Video Judge workbook) would have been the fourth. Extracted to a single service.

- \`services/partner_resolver.py\` (new):
  - \`pair_competitors_for_heat(event, comp_ids, comp_lookup)\` — returns one row per unique pair/competitor, with "Alice & Bob" rendering for partnered events and a consumed set so partners don't re-render standalone.
  - \`lookup_partner_cid(...)\` — full-name normalised match + first-name fuzzy fallback (one-match-only), preserving the nickname → display_name resolution that lets "TOBY" render as "Toby Bartsch".
- \`routes/scheduling/heat_sheets.py\`: all three callers now delegate. Dead helpers removed (\`_norm_alphanum\`, \`_first_token_alphanum\`, \`_lookup_partner_cid\`).

## Test plan

- [x] \`tests/test_partner_resolver.py\` — 23 tests, **including 3 CRITICAL regression tests** that ship a verbatim inline reproduction of the pre-extraction logic and compare (name, stand) output byte-for-byte. Any drift in \`partner_resolver\` will produce a clear legacy-vs-new diff in the assertion.
- [x] Full regression: 306 tests green across \`test_partner_resolver\`, \`test_template_rendering\`, \`test_route_smoke\`, \`test_heat_gen_integration\`. 4 pre-existing SQLite-async-lock failures on clean main baseline.