### PR TITLE
Add Video Judge Excel workbook export

### DIFF
--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -38,9 +38,11 @@ from services.reporting_export import (
     build_chopping_export,
     build_chopping_json_payload,
     build_results_export,
+    build_video_judge_export,
     resolve_completed_export_path,
     safe_download_name,
     submit_results_export_job,
+    submit_video_judge_export_job,
 )
 from services.restore_workflow import prepare_sqlite_restore
 from services.restore_workflow import sqlite_schema_info as _restore_schema_info
@@ -380,8 +382,63 @@ def export_results_job_status(tournament_id, job_id):
             pass
         return response
 
-    download_name = safe_download_name(tournament, 'results.xlsx')
+    # Download-name suffix depends on the kind of export the job produced.
+    # Defaults to 'results.xlsx' for the original all-results job; other
+    # kinds (video_judge_sheets) pick their own suffix here.
+    suffix_by_kind = {
+        'video_judge_sheets': 'video_judge_sheets.xlsx',
+    }
+    download_name = safe_download_name(
+        tournament, suffix_by_kind.get(job_kind, 'results.xlsx')
+    )
     return send_file(path, as_attachment=True, download_name=download_name)
+
+
+@reporting_bp.route('/<int:tournament_id>/export-video-judge')
+def export_video_judge_workbook(tournament_id):
+    """Synchronous Video Judge Excel workbook download.
+
+    Builds immediately and returns the xlsx as an attachment.  For bigger
+    tournaments use the /async variant to offload via background_jobs.
+    """
+    from services.video_judge_export import VideoJudgeWorkbookError
+    tournament = Tournament.query.get_or_404(tournament_id)
+    try:
+        export = build_video_judge_export(tournament)
+    except VideoJudgeWorkbookError as exc:
+        flash(f'Could not build Video Judge workbook: {exc}', 'error')
+        return redirect(url_for('main.tournament_detail', tournament_id=tournament_id))
+
+    log_action('report_export_downloaded', 'tournament', tournament.id, {
+        'tournament_id': tournament.id,
+        'format': export['format'],
+        'kind': export['kind'],
+    })
+    db.session.commit()
+
+    @after_this_request
+    def cleanup_file(response):
+        try:
+            os.remove(export['path'])
+        except OSError:
+            pass
+        return response
+
+    return send_file(export['path'], as_attachment=True, download_name=export['download_name'])
+
+
+@reporting_bp.route('/<int:tournament_id>/export-video-judge/async', methods=['POST'])
+def export_video_judge_workbook_async(tournament_id):
+    """Start Video Judge workbook generation as a background job."""
+    tournament = Tournament.query.get_or_404(tournament_id)
+    job_id = submit_video_judge_export_job(tournament_id)
+    log_action('report_export_job_started', 'tournament', tournament.id, {
+        'job_id': job_id,
+        'kind': 'video_judge_sheets',
+    })
+    db.session.commit()
+    return redirect(url_for('reporting.export_results_job_status',
+                            tournament_id=tournament_id, job_id=job_id))
 
 
 @reporting_bp.route('/<int:tournament_id>/backup')

--- a/services/reporting_export.py
+++ b/services/reporting_export.py
@@ -83,6 +83,39 @@ def submit_results_export_job(tournament_id: int) -> str:
     )
 
 
+def build_video_judge_export(tournament: Tournament) -> dict:
+    """Create a Video Judge Excel workbook for the tournament."""
+    from services.video_judge_export import build_video_judge_rows, write_workbook
+
+    path = _reserve_export_path(tournament.id, suffix='.xlsx', label='video_judge')
+    sheets = build_video_judge_rows(tournament)
+    write_workbook(sheets, path)
+    return {
+        'path': path,
+        'download_name': safe_download_name(tournament, 'video_judge_sheets.xlsx'),
+        'format': 'xlsx',
+        'kind': 'video_judge_sheets',
+    }
+
+
+def build_video_judge_export_for_job(tournament_id: int) -> str:
+    """Background-job entry point for the Video Judge workbook."""
+    tournament = db.session.get(Tournament, tournament_id)
+    if not tournament:
+        raise RuntimeError(f'Tournament {tournament_id} not found.')
+    return build_video_judge_export(tournament)['path']
+
+
+def submit_video_judge_export_job(tournament_id: int) -> str:
+    """Submit a tournament-bound background Video Judge workbook export."""
+    return submit_job(
+        f'export_video_judge_{tournament_id}',
+        build_video_judge_export_for_job,
+        tournament_id,
+        metadata={'tournament_id': tournament_id, 'kind': 'video_judge_sheets'},
+    )
+
+
 def resolve_completed_export_path(tournament_id: int, job_id: str, job_getter) -> dict | None:
     """Return a validated export job snapshot or ``None`` for wrong tournament/missing jobs."""
     job = job_getter(job_id)

--- a/services/video_judge_export.py
+++ b/services/video_judge_export.py
@@ -1,0 +1,352 @@
+"""
+Video Judge Excel workbook builder (2026-04-20).
+
+Produces one .xlsx workbook with a sheet per event, long-format rows
+(row per competitor per run; row per partnered pair per run) with two
+video-judge timer/score columns per row. Used during show-prep so a
+video-judging team can record independent times off recorded heats.
+
+Rules agreed in plan-eng-review (see docs/VIDEO_JUDGE_BRACKET_PLAN.md):
+  - Skip events where scoring_type == 'bracket' (Birling).
+  - Skip events whose normalised name is in config.LIST_ONLY_EVENT_NAMES
+    (Axe Throw, Peavey Log Roll, Caber Toss, Pulp Toss — sign-up events
+    with no heats).
+  - Dual-run day-split events (Chokerman's Race, Speed Climb) emit TWO
+    sheets: "Event Name - Run 1" and "Event Name - Run 2".
+  - Triple-run events (Axe Throw via requires_triple_runs) emit one
+    sheet with three stacked rows per competitor (Run 1 / 2 / 3).
+  - Partnered events emit one row per pair per run ("Alice & Bob").
+  - Hits/score events use "VJ Score 1 / VJ Score 2" column headers;
+    timed events use "VJ Timer 1 / VJ Timer 2".
+  - Sheet names: truncate to 31 chars (openpyxl limit), strip Excel-
+    invalid characters [ ] : * ? / \\, and dedupe collisions by
+    appending " (2)", " (3)", etc.
+  - Stable row order per sheet: heat_number ASC, run_number ASC,
+    stand_number ASC, competitor_name ASC.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+from config import LIST_ONLY_EVENT_NAMES
+from models import Event, Heat, Tournament
+from models.competitor import CollegeCompetitor, ProCompetitor
+from services.partner_resolver import pair_competitors_for_heat
+
+# Events whose run 1 and run 2 live on different days — emit as two sheets so
+# the Friday video-judge crew and the Saturday crew each get a clean tab.
+from config import DAY_SPLIT_EVENT_NAMES
+
+# Excel sheet name constraints (openpyxl)
+_SHEET_NAME_INVALID = re.compile(r"[\[\]\:\*\?/\\]")
+_SHEET_NAME_MAX = 31
+
+
+class VideoJudgeWorkbookError(RuntimeError):
+    """Raised when openpyxl cannot write the workbook (invalid sheet name,
+    filesystem issue, etc.). The route catches this and flashes a user-
+    friendly message instead of a 500."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalise_event_name(name: str) -> str:
+    return "".join(ch for ch in (name or "").lower() if ch.isalnum())
+
+
+def _is_list_only(event: Event) -> bool:
+    return _normalise_event_name(event.name) in LIST_ONLY_EVENT_NAMES
+
+
+def _num_runs(event: Event) -> int:
+    if getattr(event, "requires_triple_runs", False):
+        return 3
+    if getattr(event, "requires_dual_runs", False):
+        return 2
+    return 1
+
+
+def _column_labels(event: Event) -> tuple[str, str]:
+    """Return (col1, col2) labels for the two VJ columns on this event."""
+    if event.scoring_type in ("time", "distance"):
+        return "VJ Timer 1", "VJ Timer 2"
+    return "VJ Score 1", "VJ Score 2"
+
+
+def _sanitize_sheet_name(name: str) -> str:
+    """Strip Excel-invalid chars and truncate to 31 chars."""
+    clean = _SHEET_NAME_INVALID.sub("", name or "").strip()
+    if not clean:
+        clean = "Sheet"
+    return clean[:_SHEET_NAME_MAX]
+
+
+def _dedupe_sheet_names(names: list[str]) -> list[str]:
+    """Given a list of sanitised sheet names that may collide after truncation,
+    append ' (2)', ' (3)', etc. to duplicates. Preserves input order."""
+    seen: dict[str, int] = {}
+    out: list[str] = []
+    for n in names:
+        if n not in seen:
+            seen[n] = 1
+            out.append(n)
+            continue
+        seen[n] += 1
+        suffix = f" ({seen[n]})"
+        base_max = _SHEET_NAME_MAX - len(suffix)
+        new_name = f"{n[:base_max]}{suffix}"
+        # Very defensively, re-check for recursion if the truncated new_name
+        # itself collides (e.g. ultra-long events).  Bump counter again.
+        while new_name in out:
+            seen[n] += 1
+            suffix = f" ({seen[n]})"
+            base_max = _SHEET_NAME_MAX - len(suffix)
+            new_name = f"{n[:base_max]}{suffix}"
+        out.append(new_name)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Row building
+# ---------------------------------------------------------------------------
+
+
+def _load_competitor_lookup(event: Event, comp_ids: list) -> dict:
+    ids = sorted({int(cid) for cid in comp_ids if cid is not None})
+    if not ids:
+        return {}
+    model = CollegeCompetitor if event.event_type == "college" else ProCompetitor
+    rows = model.query.filter(model.id.in_(ids)).all()
+    return {c.id: c for c in rows}
+
+
+def _team_code(event: Event, comp) -> str | None:
+    if event.event_type != "college":
+        return None
+    team = getattr(comp, "team", None)
+    return team.team_code if team else None
+
+
+def _rows_for_heat(event: Event, heat: Heat, comp_lookup: dict) -> list[dict]:
+    """Build row dicts for one heat. Each row becomes one Excel line per run."""
+    assignments = heat.get_stand_assignments()
+    pairs = pair_competitors_for_heat(event, heat.get_competitors(), comp_lookup)
+
+    out: list[dict] = []
+    for pair in pairs:
+        primary_id = pair["primary_comp_id"]
+        comp = pair["competitor"]
+        stand = assignments.get(str(primary_id))
+        try:
+            stand_int = int(stand) if stand is not None else 999
+        except (TypeError, ValueError):
+            stand_int = 999
+        out.append(
+            {
+                "heat_number": heat.heat_number,
+                "run_number": heat.run_number,
+                "stand_number": stand_int,
+                "stand_display": stand if stand is not None else "?",
+                "competitor_name": pair["name"],
+                "team_code": _team_code(event, comp) if comp else None,
+            }
+        )
+    return out
+
+
+def _sheet_key_for_heat(event: Event, heat: Heat) -> str:
+    """Return the sheet title this heat should land on.
+
+    Dual-run day-split events (Chokerman, Speed Climb) get separate sheets
+    per run.  Everything else uses the event display name once and stacks
+    runs as extra rows.
+    """
+    base = event.display_name
+    is_day_split_dual = event.name in DAY_SPLIT_EVENT_NAMES and getattr(
+        event, "requires_dual_runs", False
+    )
+    if is_day_split_dual:
+        return f"{base} - Run {heat.run_number}"
+    return base
+
+
+def build_video_judge_rows(tournament: Tournament) -> "OrderedDict[str, dict]":
+    """Walk every pro and college event for the tournament and return an
+    ordered dict keyed by raw sheet title → {'event': Event, 'rows': [...]}.
+
+    Sheet sanitisation and dedup happen at write-time so tests can assert
+    on the un-truncated title too.
+    """
+    events = (
+        Event.query.filter_by(tournament_id=tournament.id)
+        .order_by(Event.event_type.asc(), Event.id.asc())
+        .all()
+    )
+
+    sheets: "OrderedDict[str, dict]" = OrderedDict()
+
+    for event in events:
+        if event.scoring_type == "bracket":
+            continue  # Birling — no video timing
+        if _is_list_only(event):
+            continue  # sign-up events have no heats
+
+        heats = (
+            Heat.query.filter_by(event_id=event.id)
+            .order_by(Heat.heat_number.asc(), Heat.run_number.asc())
+            .all()
+        )
+        if not heats:
+            continue
+
+        # Batch-load all competitors across the event's heats — avoids N+1
+        # when walking heat-by-heat.
+        all_comp_ids: list = []
+        for heat in heats:
+            all_comp_ids.extend(heat.get_competitors())
+        comp_lookup = _load_competitor_lookup(event, all_comp_ids)
+
+        for heat in heats:
+            sheet_title = _sheet_key_for_heat(event, heat)
+            entry = sheets.setdefault(sheet_title, {"event": event, "rows": []})
+            entry["rows"].extend(_rows_for_heat(event, heat, comp_lookup))
+
+    # Stable sort per sheet.  Row order: heat_number, run_number, stand, name.
+    for entry in sheets.values():
+        entry["rows"].sort(
+            key=lambda r: (
+                r["heat_number"],
+                r["run_number"],
+                r["stand_number"],
+                r["competitor_name"].lower(),
+            )
+        )
+
+    return sheets
+
+
+# ---------------------------------------------------------------------------
+# Workbook writer
+# ---------------------------------------------------------------------------
+
+
+def write_workbook(sheets: "OrderedDict[str, dict]", path: str) -> None:
+    """Write the sheets dict to an xlsx file.
+
+    Raises VideoJudgeWorkbookError on any openpyxl / filesystem failure so
+    the calling route can flash a user-friendly message.
+    """
+    import openpyxl
+    from openpyxl.styles import Alignment, Font, PatternFill
+
+    wb = openpyxl.Workbook()
+    # Workbook() ships with one default sheet; remove it so our first
+    # tab is at index 0 with the right title.
+    default = wb.active
+    wb.remove(default)
+
+    if not sheets:
+        # Empty workbook: still produce a placeholder sheet so the download
+        # isn't corrupt, and the user sees a clear "no events yet" signal.
+        ws = wb.create_sheet("No Events")
+        ws["A1"] = "This tournament has no events with heats yet."
+        try:
+            wb.save(path)
+        except Exception as exc:  # noqa: BLE001
+            raise VideoJudgeWorkbookError(f"Could not save workbook: {exc}") from exc
+        return
+
+    # Sanitise + dedupe sheet titles first so we know upfront what to write.
+    raw_titles = list(sheets.keys())
+    sanitised = [_sanitize_sheet_name(t) for t in raw_titles]
+    final_titles = _dedupe_sheet_names(sanitised)
+
+    for title, raw_title in zip(final_titles, raw_titles):
+        entry = sheets[raw_title]
+        event = entry["event"]
+        rows = entry["rows"]
+        ws = wb.create_sheet(title)
+        col1, col2 = _column_labels(event)
+
+        headers = [
+            "Heat",
+            "Run",
+            "Stand",
+            "Competitor",
+            "Team" if event.event_type == "college" else "",
+            col1,
+            col2,
+            "Status",
+            "Reason",
+        ]
+        # Drop the empty "Team" column slot for pro events.
+        if event.event_type != "college":
+            headers = [h for h in headers if h != ""]
+
+        ws.append(headers)
+        # Header styling: bold + light grey fill so the VJ crew can scan.
+        header_fill = PatternFill("solid", fgColor="E8E8E8")
+        bold = Font(bold=True)
+        for cell in ws[1]:
+            cell.font = bold
+            cell.fill = header_fill
+            cell.alignment = Alignment(horizontal="center")
+
+        n_runs = _num_runs(event)
+        for row in rows:
+            base_cols = [
+                row["heat_number"],
+                row["run_number"],
+                row["stand_display"],
+                row["competitor_name"],
+            ]
+            if event.event_type == "college":
+                base_cols.append(row["team_code"] or "")
+            # Triple-run: stack run 1 / 2 / 3 as separate lines per competitor.
+            if n_runs == 3:
+                for run_idx in range(1, 4):
+                    ws.append(
+                        [
+                            row["heat_number"],
+                            run_idx,
+                            row["stand_display"],
+                            row["competitor_name"],
+                            *(
+                                [row["team_code"] or ""]
+                                if event.event_type == "college"
+                                else []
+                            ),
+                            "",  # VJ 1
+                            "",  # VJ 2
+                            "",  # status
+                            "",  # reason
+                        ]
+                    )
+            else:
+                ws.append(
+                    [
+                        *base_cols,
+                        "",  # VJ 1
+                        "",  # VJ 2
+                        "",  # status
+                        "",  # reason
+                    ]
+                )
+
+        # Column widths sized for printing on a Letter-landscape screen.
+        widths = [6, 5, 7, 28]
+        if event.event_type == "college":
+            widths.append(8)
+        widths += [12, 12, 10, 22]
+        for idx, width in enumerate(widths, start=1):
+            ws.column_dimensions[chr(ord("A") + idx - 1)].width = width
+
+    try:
+        wb.save(path)
+    except Exception as exc:  # noqa: BLE001
+        raise VideoJudgeWorkbookError(f"Could not save workbook: {exc}") from exc

--- a/services/video_judge_export.py
+++ b/services/video_judge_export.py
@@ -30,14 +30,12 @@ from __future__ import annotations
 import re
 from collections import OrderedDict
 
-from config import LIST_ONLY_EVENT_NAMES
+# Events whose run 1 and run 2 live on different days — emit as two sheets so
+# the Friday video-judge crew and the Saturday crew each get a clean tab.
+from config import DAY_SPLIT_EVENT_NAMES, LIST_ONLY_EVENT_NAMES
 from models import Event, Heat, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 from services.partner_resolver import pair_competitors_for_heat
-
-# Events whose run 1 and run 2 live on different days — emit as two sheets so
-# the Friday video-judge crew and the Saturday crew each get a clean tab.
-from config import DAY_SPLIT_EVENT_NAMES
 
 # Excel sheet name constraints (openpyxl)
 _SHEET_NAME_INVALID = re.compile(r"[\[\]\:\*\?/\\]")

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -194,6 +194,12 @@
                 <i class="bi bi-printer sb-icon"></i>
                 <span class="sb-text ms-2">Heat Sheets</span>
             </a>
+            <a href="{{ url_for('reporting.export_video_judge_workbook', tournament_id=tournament.id) }}"
+               class="nav-link sidebar-child"
+               title="Video Judge Workbook (.xlsx)">
+                <i class="bi bi-file-earmark-spreadsheet sb-icon"></i>
+                <span class="sb-text ms-2">Video Judge Workbook</span>
+            </a>
             <a href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}"
                class="nav-link sidebar-child" target="_blank" rel="noopener"
                title="Birling Brackets (seeded, printable)">

--- a/templates/tournament_detail.html
+++ b/templates/tournament_detail.html
@@ -345,6 +345,11 @@
                    title="Blank judge scoring sheets for every event that has heats — one document, one click before the day starts.">
                     <i class="bi bi-pencil-square me-1"></i>Print All Judge Sheets
                 </a>
+                <a href="{{ url_for('reporting.export_video_judge_workbook', tournament_id=tournament.id) }}"
+                   class="btn btn-outline-warning btn-sm"
+                   title="Excel workbook with one sheet per event, rows for every competitor and run, and two VJ timer columns per row.">
+                    <i class="bi bi-file-earmark-spreadsheet me-1"></i>Video Judge Workbook
+                </a>
                 <a href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}"
                    class="btn btn-outline-info btn-sm" target="_blank"
                    title="Printable seeded birling brackets — round-1 matchups filled in, advancement slots blank.">
@@ -499,6 +504,13 @@
                         <span>
                             <span class="pl-title">Print Heat Sheets</span>
                             <span class="pl-desc">Printable heat assignments for judges</span>
+                        </span>
+                    </a>
+                    <a class="phase-link" href="{{ url_for('reporting.export_video_judge_workbook', tournament_id=tournament.id) }}">
+                        <i class="bi bi-file-earmark-spreadsheet pl-icon" style="color:#6cb6f5;"></i>
+                        <span>
+                            <span class="pl-title">Video Judge Workbook</span>
+                            <span class="pl-desc">Excel rows per competitor per run, two VJ timer columns</span>
                         </span>
                     </a>
                     <a class="phase-link" href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}" target="_blank">

--- a/tests/test_routes_video_judge.py
+++ b/tests/test_routes_video_judge.py
@@ -1,0 +1,151 @@
+"""
+Route-level tests for the Video Judge workbook endpoints (PR C).
+
+Covers:
+    - GET /reporting/<tid>/export-video-judge  (sync download, xlsx)
+    - POST /reporting/<tid>/export-video-judge/async  (queues a background job)
+    - Missing tournament → 404
+    - Empty tournament → still returns a valid workbook (placeholder sheet)
+
+Run:  pytest tests/test_routes_video_judge.py -v
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from tests.conftest import (
+    make_college_competitor,
+    make_event,
+    make_pro_competitor,
+    make_team,
+    make_tournament,
+)
+
+
+@pytest.fixture()
+def vj_auth_client(app, db_session):
+    """Test client authenticated as a unique admin per test.
+
+    Avoids the conftest admin_user fixture, which reuses the same username
+    and collides when multiple tests in one class exercise vj_auth_client
+    after an earlier test has committed.  Unique username per test bypasses
+    the unique constraint entirely.
+    """
+    from models.user import User
+
+    username = f"vj_admin_{uuid.uuid4().hex[:8]}"
+    user = User(username=username, role="admin")
+    user.set_password("vj_pass")
+    db_session.add(user)
+    db_session.flush()
+
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+    return c
+
+
+def _make_heat(
+    session, event, comp_ids, run_number=1, heat_number=1, stand_assignments=None
+):
+    from models import Heat
+
+    h = Heat(
+        event_id=event.id,
+        heat_number=heat_number,
+        run_number=run_number,
+    )
+    h.set_competitors(comp_ids)
+    if stand_assignments:
+        for cid, stand in stand_assignments.items():
+            h.set_stand_assignment(cid, stand)
+    session.add(h)
+    session.flush()
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Sync download
+# ---------------------------------------------------------------------------
+
+
+class TestSyncDownload:
+    def test_sync_download_returns_xlsx_attachment(self, vj_auth_client, db_session):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand Speed",
+            event_type="college",
+            scoring_type="time",
+            stand_type="underhand",
+            gender=None,
+        )
+        team = make_team(db_session, t)
+        c = make_college_competitor(
+            db_session,
+            t,
+            team,
+            name="Alice Chopper",
+            gender="F",
+        )
+        _make_heat(db_session, ev, [c.id], stand_assignments={c.id: 1})
+        db_session.flush()
+
+        resp = vj_auth_client.get(f"/reporting/{t.id}/export-video-judge")
+        assert resp.status_code == 200
+        assert resp.mimetype in (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/octet-stream",  # Flask sometimes falls back
+        )
+        # Content-Disposition carries the suffix we configured.
+        cd = resp.headers.get("Content-Disposition", "")
+        assert "video_judge_sheets.xlsx" in cd
+        assert resp.data[:2] == b"PK"  # all xlsx are ZIP files
+
+    def test_sync_download_404_for_missing_tournament(self, vj_auth_client):
+        resp = vj_auth_client.get("/reporting/99999/export-video-judge")
+        assert resp.status_code == 404
+
+    def test_sync_download_empty_tournament_still_returns_xlsx(
+        self,
+        vj_auth_client,
+        db_session,
+    ):
+        """Zero events → placeholder workbook, not a 500."""
+        t = make_tournament(db_session)
+        db_session.flush()
+
+        resp = vj_auth_client.get(f"/reporting/{t.id}/export-video-judge")
+        assert resp.status_code == 200
+        assert resp.data[:2] == b"PK"
+
+
+# ---------------------------------------------------------------------------
+# Auth gating
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGating:
+    def test_unauthenticated_redirects_to_login(self, client, db_session):
+        t = make_tournament(db_session)
+        db_session.flush()
+        resp = client.get(f"/reporting/{t.id}/export-video-judge")
+        # management blueprint gate: 302 to login, or 401 depending on config
+        assert resp.status_code in (302, 401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Async job trigger
+# ---------------------------------------------------------------------------
+#
+# The async POST path redirects to /reporting/<tid>/jobs/<job_id>, which
+# the existing background_jobs + reporting_export tests already cover at
+# the service layer.  Exercising it end-to-end here would spawn a worker
+# thread against the same SQLite file the test transaction holds, causing
+# an intermittent "database is locked" deadlock.  The route is a 6-line
+# handler that just calls submit_video_judge_export_job and redirects —
+# low surface area, easy to verify by reading.

--- a/tests/test_video_judge_export.py
+++ b/tests/test_video_judge_export.py
@@ -1,0 +1,473 @@
+"""
+Tests for services/video_judge_export.py.
+
+Covers row building + xlsx writing for the Video Judge workbook (2026-04-20).
+Rules from docs/VIDEO_JUDGE_BRACKET_PLAN.md:
+    - Skip scoring_type='bracket' (Birling).
+    - Skip LIST_ONLY events (no heats).
+    - Dual-run day-split events split into two sheets by run.
+    - Triple-run events stack 3 rows per competitor on one sheet.
+    - Hits/score events flip column labels to 'VJ Score 1 / VJ Score 2'.
+    - Sheet names sanitised + deduped (31-char limit, no [ ] : * ? / \\).
+    - Stable row order: heat / run / stand / competitor-name.
+
+Run:  pytest tests/test_video_judge_export.py -v
+"""
+
+from __future__ import annotations
+
+import openpyxl
+import pytest
+
+from services.video_judge_export import (
+    VideoJudgeWorkbookError,
+    _dedupe_sheet_names,
+    _sanitize_sheet_name,
+    build_video_judge_rows,
+    write_workbook,
+)
+from tests.conftest import (
+    make_college_competitor,
+    make_event,
+    make_pro_competitor,
+    make_team,
+    make_tournament,
+)
+
+
+def _make_heat(
+    session, event, comp_ids, run_number=1, heat_number=1, stand_assignments=None
+):
+    """Create a Heat row with competitors + stand assignments."""
+    from models import Heat
+
+    h = Heat(
+        event_id=event.id,
+        heat_number=heat_number,
+        run_number=run_number,
+    )
+    h.set_competitors(comp_ids)
+    if stand_assignments:
+        for cid, stand in stand_assignments.items():
+            h.set_stand_assignment(cid, stand)
+    session.add(h)
+    session.flush()
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Sheet name sanitisation / dedup
+# ---------------------------------------------------------------------------
+
+
+class TestSheetNameHelpers:
+    def test_sanitize_truncates_to_31_chars(self):
+        long = "A" * 50
+        out = _sanitize_sheet_name(long)
+        assert len(out) == 31
+        assert out == "A" * 31
+
+    def test_sanitize_strips_invalid_chars(self):
+        out = _sanitize_sheet_name("Men's [Underhand]: Round 1?/2*")
+        for bad in "[]:*?/\\":
+            assert bad not in out
+
+    def test_sanitize_empty_becomes_sheet(self):
+        assert _sanitize_sheet_name("") == "Sheet"
+        assert _sanitize_sheet_name(None) == "Sheet"
+
+    def test_dedupe_single_no_change(self):
+        assert _dedupe_sheet_names(["Foo"]) == ["Foo"]
+
+    def test_dedupe_two_same(self):
+        assert _dedupe_sheet_names(["Foo", "Foo"]) == ["Foo", "Foo (2)"]
+
+    def test_dedupe_three_same(self):
+        assert _dedupe_sheet_names(["Foo", "Foo", "Foo"]) == [
+            "Foo",
+            "Foo (2)",
+            "Foo (3)",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# build_video_judge_rows — event filtering + partner pairing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRows:
+    def test_skips_bracket_events(self, db_session):
+        t = make_tournament(db_session)
+        birling = make_event(
+            db_session,
+            t,
+            name="Birling",
+            event_type="college",
+            scoring_type="bracket",
+            stand_type="birling",
+            gender=None,
+        )
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand Speed",
+            event_type="college",
+            scoring_type="time",
+            stand_type="underhand",
+            gender=None,
+        )
+        team = make_team(db_session, t)
+        a = make_college_competitor(
+            db_session,
+            t,
+            team,
+            name="Alice Chopper",
+            gender="F",
+        )
+        _make_heat(db_session, ev, [a.id], stand_assignments={a.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        titles = list(sheets.keys())
+        assert "Birling" not in titles
+        assert "Underhand Speed" in titles
+
+    def test_skips_list_only_events(self, db_session):
+        t = make_tournament(db_session)
+        # Axe Throw is LIST_ONLY by name.  Even with heats somehow, it should skip.
+        axe = make_event(
+            db_session,
+            t,
+            name="Axe Throw",
+            event_type="college",
+            scoring_type="score",
+            stand_type="axe_throw",
+            gender=None,
+        )
+        ev = make_event(
+            db_session,
+            t,
+            name="Single Buck",
+            event_type="college",
+            scoring_type="time",
+            stand_type="saw_hand",
+            gender=None,
+        )
+        team = make_team(db_session, t)
+        a = make_college_competitor(db_session, t, team, name="Alice", gender="F")
+        _make_heat(db_session, axe, [a.id], stand_assignments={a.id: 1})
+        _make_heat(db_session, ev, [a.id], stand_assignments={a.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        assert "Axe Throw" not in sheets
+        assert "Single Buck" in sheets
+
+    def test_no_heats_event_excluded(self, db_session):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand Speed",
+            event_type="college",
+            scoring_type="time",
+            stand_type="underhand",
+            gender=None,
+        )
+        # No heat — should not appear in workbook sheets.
+        sheets = build_video_judge_rows(t)
+        assert "Underhand Speed" not in sheets
+
+    def test_partnered_event_one_row_per_pair(self, db_session):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Jack & Jill Sawing",
+            event_type="pro",
+            scoring_type="time",
+            stand_type="saw_hand",
+            gender=None,
+            is_partnered=True,
+        )
+        a = make_pro_competitor(
+            db_session,
+            t,
+            "Alice Chopper",
+            gender="F",
+            partners={"Jack & Jill Sawing": "Bob Splitter"},
+        )
+        b = make_pro_competitor(
+            db_session,
+            t,
+            "Bob Splitter",
+            gender="M",
+            partners={"Jack & Jill Sawing": "Alice Chopper"},
+        )
+        _make_heat(
+            db_session,
+            ev,
+            [a.id, b.id],
+            stand_assignments={a.id: 1, b.id: 1},
+        )
+
+        sheets = build_video_judge_rows(t)
+        entry = sheets["Jack & Jill Sawing"]
+        assert len(entry["rows"]) == 1
+        assert entry["rows"][0]["competitor_name"] == "Alice Chopper & Bob Splitter"
+
+    def test_college_rows_include_team_code(self, db_session):
+        t = make_tournament(db_session)
+        team = make_team(db_session, t, code="UM-A", school="University of Montana")
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand Speed",
+            event_type="college",
+            scoring_type="time",
+            stand_type="underhand",
+            gender=None,
+        )
+        c = make_college_competitor(
+            db_session,
+            t,
+            team,
+            name="Alice Chopper",
+            gender="F",
+        )
+        _make_heat(db_session, ev, [c.id], stand_assignments={c.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        row = sheets["Underhand Speed"]["rows"][0]
+        assert row["team_code"] == "UM-A"
+
+    def test_pro_rows_team_code_none(self, db_session):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Springboard",
+            event_type="pro",
+            scoring_type="time",
+            stand_type="springboard",
+        )
+        c = make_pro_competitor(db_session, t, "Alice Chopper", gender="F")
+        _make_heat(db_session, ev, [c.id], stand_assignments={c.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        row = sheets["Springboard"]["rows"][0]
+        assert row["team_code"] is None
+
+    def test_day_split_dual_run_splits_into_two_sheets(self, db_session):
+        """Speed Climb is day-split dual-run → 'Speed Climb - Run 1' and 'Run 2'."""
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Speed Climb",
+            event_type="college",
+            scoring_type="time",
+            stand_type="speed_climb",
+            gender=None,
+            requires_dual_runs=True,
+        )
+        team = make_team(db_session, t)
+        a = make_college_competitor(db_session, t, team, name="Alice", gender="F")
+        _make_heat(db_session, ev, [a.id], run_number=1, stand_assignments={a.id: 1})
+        _make_heat(
+            db_session,
+            ev,
+            [a.id],
+            run_number=2,
+            heat_number=1,
+            stand_assignments={a.id: 1},
+        )
+
+        sheets = build_video_judge_rows(t)
+        titles = list(sheets.keys())
+        # Speed Climb is in DAY_SPLIT_EVENT_NAMES so we expect separate sheets.
+        assert "Speed Climb - Run 1" in titles
+        assert "Speed Climb - Run 2" in titles
+        assert "Speed Climb" not in titles
+
+    def test_stable_row_ordering(self, db_session):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand",
+            event_type="pro",
+            scoring_type="time",
+            stand_type="underhand",
+            gender=None,
+        )
+        a = make_pro_competitor(db_session, t, "Zach Z", gender="M")
+        b = make_pro_competitor(db_session, t, "Anna A", gender="M")
+        c = make_pro_competitor(db_session, t, "Bob B", gender="M")
+        # Two heats, out-of-order.
+        _make_heat(
+            db_session,
+            ev,
+            [a.id, b.id],
+            heat_number=2,
+            stand_assignments={a.id: 2, b.id: 1},
+        )
+        _make_heat(
+            db_session,
+            ev,
+            [c.id],
+            heat_number=1,
+            stand_assignments={c.id: 1},
+        )
+        sheets = build_video_judge_rows(t)
+        rows = sheets["Underhand"]["rows"]
+        # Ordered by heat_number, then stand_number.  Heat 1 first, then heat 2.
+        assert rows[0]["heat_number"] == 1 and rows[0]["competitor_name"] == "Bob B"
+        # Heat 2: stand 1 (Anna A) before stand 2 (Zach Z).
+        assert rows[1]["heat_number"] == 2 and rows[1]["competitor_name"] == "Anna A"
+        assert rows[2]["heat_number"] == 2 and rows[2]["competitor_name"] == "Zach Z"
+
+
+# ---------------------------------------------------------------------------
+# write_workbook — xlsx output contents
+# ---------------------------------------------------------------------------
+
+
+class TestWriteWorkbook:
+    def _read_sheet_names(self, path):
+        wb = openpyxl.load_workbook(path)
+        return wb.sheetnames
+
+    def test_empty_sheets_writes_placeholder_workbook(self, db_session, tmp_path):
+        from collections import OrderedDict
+
+        path = str(tmp_path / "out.xlsx")
+        write_workbook(OrderedDict(), path)
+        names = self._read_sheet_names(path)
+        assert names == ["No Events"]
+
+    def test_writes_sheet_per_event(self, db_session, tmp_path):
+        t = make_tournament(db_session)
+        ev1 = make_event(
+            db_session,
+            t,
+            name="Underhand Speed",
+            event_type="college",
+            scoring_type="time",
+            stand_type="underhand",
+            gender=None,
+        )
+        ev2 = make_event(
+            db_session,
+            t,
+            name="Springboard",
+            event_type="pro",
+            scoring_type="time",
+            stand_type="springboard",
+        )
+        team = make_team(db_session, t)
+        a = make_college_competitor(db_session, t, team, name="Alice", gender="F")
+        b = make_pro_competitor(db_session, t, "Bob", gender="M")
+        _make_heat(db_session, ev1, [a.id], stand_assignments={a.id: 1})
+        _make_heat(db_session, ev2, [b.id], stand_assignments={b.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        path = str(tmp_path / "vj.xlsx")
+        write_workbook(sheets, path)
+        names = self._read_sheet_names(path)
+        assert "Underhand Speed" in names
+        assert "Springboard" in names
+
+    def test_timed_event_uses_timer_column_headers(self, db_session, tmp_path):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Springboard",
+            event_type="pro",
+            scoring_type="time",
+            stand_type="springboard",
+        )
+        b = make_pro_competitor(db_session, t, "Bob", gender="M")
+        _make_heat(db_session, ev, [b.id], stand_assignments={b.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        path = str(tmp_path / "vj.xlsx")
+        write_workbook(sheets, path)
+
+        wb = openpyxl.load_workbook(path)
+        ws = wb["Springboard"]
+        header_row = [c.value for c in ws[1]]
+        assert "VJ Timer 1" in header_row
+        assert "VJ Timer 2" in header_row
+        assert "VJ Score 1" not in header_row
+
+    def test_hits_event_uses_score_column_headers(self, db_session, tmp_path):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand Hard Hit",
+            event_type="college",
+            scoring_type="hits",
+            stand_type="underhand",
+            gender=None,
+        )
+        team = make_team(db_session, t)
+        a = make_college_competitor(db_session, t, team, name="Alice", gender="F")
+        _make_heat(db_session, ev, [a.id], stand_assignments={a.id: 1})
+
+        sheets = build_video_judge_rows(t)
+        path = str(tmp_path / "vj.xlsx")
+        write_workbook(sheets, path)
+
+        wb = openpyxl.load_workbook(path)
+        ws = wb["Underhand Hard Hit"]
+        header_row = [c.value for c in ws[1]]
+        assert "VJ Score 1" in header_row
+        assert "VJ Score 2" in header_row
+        assert "VJ Timer 1" not in header_row
+
+    def test_sheet_name_truncation_does_not_crash(self, db_session, tmp_path):
+        from collections import OrderedDict
+        from types import SimpleNamespace
+
+        long_title = "A Very Long Event Title That Exceeds Thirty One Characters"
+        assert len(long_title) > 31
+        sheets = OrderedDict()
+        sheets[long_title] = {
+            "event": SimpleNamespace(scoring_type="time", event_type="pro"),
+            "rows": [],
+        }
+        path = str(tmp_path / "vj.xlsx")
+        write_workbook(sheets, path)
+        names = self._read_sheet_names(path)
+        assert len(names[0]) == 31
+        assert names[0] == long_title[:31]
+
+    def test_invalid_chars_stripped_from_sheet_name(self, db_session, tmp_path):
+        from collections import OrderedDict
+        from types import SimpleNamespace
+
+        title = "Men's [Underhand]: Round 1?/2*"
+        sheets = OrderedDict()
+        sheets[title] = {
+            "event": SimpleNamespace(scoring_type="time", event_type="pro"),
+            "rows": [],
+        }
+        path = str(tmp_path / "vj.xlsx")
+        write_workbook(sheets, path)
+        names = self._read_sheet_names(path)
+        for bad in "[]:*?/\\":
+            assert bad not in names[0]
+
+    def test_openpyxl_failure_raises_custom_exception(self, tmp_path):
+        """An unwritable path → VideoJudgeWorkbookError, not raw OSError/500.
+
+        Openpyxl is imported lazily inside write_workbook so we can't cheaply
+        monkeypatch it.  Instead, point at a non-existent nested directory
+        so openpyxl's save() fails; write_workbook must catch and re-raise.
+        """
+        from collections import OrderedDict
+
+        bad_path = str(tmp_path / "does" / "not" / "exist" / "vj.xlsx")
+        with pytest.raises(VideoJudgeWorkbookError):
+            write_workbook(OrderedDict(), bad_path)


### PR DESCRIPTION
## Summary

New show-prep deliverable for April 24-25: one .xlsx workbook per tournament with a sheet per event, long-format rows (row per competitor per run; row per partnered pair per run), and two VJ timer/score columns per row. Lets a video-judging team record independent times off recorded heats for any disputed finish.

> ⚠ **Depends on #42** — this branch carries a merge of \`feat/partner-resolver-service\` so the service compiles and tests run. Once #42 merges, the diff GitHub shows for this PR collapses to just the VJ-specific changes. Review this PR against #42 or wait until #42 merges.

- \`services/video_judge_export.py\`: builds the rows (skips Birling + LIST_ONLY events, batch-loads competitors to avoid N+1, uses \`services/partner_resolver\` for pair rendering, stable row order by heat → run → stand → name). Writes the workbook with sheet-name sanitise + truncate-to-31-chars + dedup-on-collision. Timed events get "VJ Timer 1 / 2" column headers; hits/score events flip to "VJ Score 1 / 2". Triple-run events stack 3 rows per competitor; day-split dual-run events emit two sheets (Run 1 / Run 2).
- \`services/reporting_export.py\`: \`build_video_judge_export\` + \`submit_video_judge_export_job\` follow the existing all-results pattern.
- \`routes/reporting.py\`: GET /reporting/\<tid\>/export-video-judge (sync), POST /export-video-judge/async. Job-status page now picks its download-name suffix based on job kind.
- \`templates/_sidebar.html\` + \`templates/tournament_detail.html\`: sidebar child under Run Show, button in Ready-for-Game-Day action bar, phase-link card in Before-the-Show panel.

## Test plan

- [x] \`tests/test_video_judge_export.py\` — 21 tests: sheet-name sanitise/dedup (6), event filter + partner pairing + row order (8), xlsx write (4), column header flip (2), 31-char truncation, invalid-char strip, custom-exception on bad path.
- [x] \`tests/test_routes_video_judge.py\` — 4 tests: sync download returns xlsx attachment, unauthenticated 302/401/403, missing tournament 404, empty tournament graceful placeholder.
- [x] Full regression: 332 passed. 5 failed (4 pre-existing SQLite-async-lock smoke + 1 new \`test_smoke_reporting_export_video_judge_workbook_async\` which shares the same known background_jobs + SQLite contention pattern as the existing async smoke failures).