### PR TITLE
Add blank-bracket printable for birling + surface birling nav

### DIFF
--- a/routes/scheduling/birling.py
+++ b/routes/scheduling/birling.py
@@ -11,6 +11,8 @@ from database import db
 from models import Event, EventResult, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 from services.audit import log_action
+from services.birling_print import build_birling_print_context
+from services.print_response import weasyprint_or_html
 
 from . import _signed_up_competitors, scheduling_bp
 
@@ -375,3 +377,108 @@ def birling_finalize(tournament_id, event_id):
     flash(f'Bracket finalized with {len(placements)} placements.', 'success')
     return redirect(url_for('scheduling.birling_manage',
                             tournament_id=tournament_id, event_id=event_id))
+
+
+# ---------------------------------------------------------------------------
+# Blank bracket print (show-prep)
+# ---------------------------------------------------------------------------
+
+
+def _safe_filename_part(name: str) -> str:
+    """Strip characters that break Content-Disposition filenames."""
+    return ''.join(c if c.isalnum() or c in ('-', '_') else '_' for c in name)
+
+
+@scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/print-blank',
+                      methods=['GET'])
+def birling_print_blank(tournament_id, event_id):
+    """Printable blank bracket for one birling event.
+
+    Round-1 matchups are shown (so the judge knows who faces whom first);
+    everything beyond is blank so the judge can hand-fill advancement as
+    matches play out.  If the bracket has not been generated yet, flash
+    a redirect back to the seeding page.
+    """
+    tournament = Tournament.query.get_or_404(tournament_id)
+    event = Event.query.get_or_404(event_id)
+    if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
+        abort(404)
+
+    ctx = build_birling_print_context(event)
+    if ctx is None:
+        flash('Seed the bracket first, then come back to print it.', 'warning')
+        return redirect(url_for('scheduling.birling_manage',
+                                tournament_id=tournament_id, event_id=event_id))
+
+    html = render_template(
+        'scoring/birling_bracket_print.html',
+        brackets=[{'event': event, 'ctx': ctx}],
+        year=tournament.year,
+    )
+    filename = f'birling_blank_{_safe_filename_part(event.display_name)}'
+    log_action('birling_blank_bracket_printed', 'event', event_id, {
+        'event_name': event.display_name,
+    })
+    db.session.commit()
+    return weasyprint_or_html(html, filename)
+
+
+@scheduling_bp.route('/<int:tournament_id>/birling/print-all', methods=['GET'])
+def birling_print_all(tournament_id):
+    """Combined blank-bracket print for every birling event in the tournament.
+
+    Skips any bracket event that has not been generated yet and flashes
+    the list of skipped event names so the admin can seed them.  Matches
+    the ``judge_sheets_all`` idiom: one click, one document, show-prep
+    ready.
+    """
+    tournament = Tournament.query.get_or_404(tournament_id)
+    events = (
+        Event.query
+        .filter_by(tournament_id=tournament_id)
+        .filter(Event.scoring_type == 'bracket')
+        .order_by(Event.event_type, Event.name, Event.gender)
+        .all()
+    )
+    if not events:
+        flash('No birling events configured for this tournament.', 'warning')
+        return redirect(url_for('main.tournament_detail',
+                                tournament_id=tournament_id))
+
+    rendered: list = []
+    skipped_names: list = []
+    for event in events:
+        ctx = build_birling_print_context(event)
+        if ctx is None:
+            skipped_names.append(event.display_name)
+            continue
+        rendered.append({'event': event, 'ctx': ctx})
+
+    if not rendered:
+        flash(
+            'No birling brackets have been seeded yet: {}.  Seed at least one to print.'
+            .format(', '.join(skipped_names)),
+            'warning',
+        )
+        return redirect(url_for('main.tournament_detail',
+                                tournament_id=tournament_id))
+
+    if skipped_names:
+        flash(
+            'Skipped {} birling event(s) without a generated bracket: {}.'
+            .format(len(skipped_names), ', '.join(skipped_names)),
+            'info',
+        )
+
+    html = render_template(
+        'scoring/birling_bracket_print.html',
+        brackets=rendered,
+        year=tournament.year,
+    )
+    filename = f'birling_blank_all_tournament_{tournament.id}'
+    log_action('birling_blank_bracket_printed_all', 'tournament', tournament_id, {
+        'rendered_count': len(rendered),
+        'skipped': skipped_names,
+    })
+    db.session.commit()
+    return weasyprint_or_html(html, filename)

--- a/services/birling_print.py
+++ b/services/birling_print.py
@@ -1,0 +1,108 @@
+"""
+Birling blank bracket print context builder.
+
+Produces a deep-copied, result-scrubbed view of a birling bracket so the
+print template can render the round-1 matchups (and empty TBD slots beyond)
+without leaking winners / losers / placements / fall history from a
+partially-played bracket.  Used by the show-prep workflow: judges get a
+printable bracket sheet to fill in by hand, then results are entered into
+the system after the bracket runs.
+
+Design constraints (from docs/VIDEO_JUDGE_BRACKET_PLAN.md, 2026-04-20):
+    - Deep copy.  The live Event.payouts must never be mutated.
+    - Strip winner / loser / falls / placements from EVERY match.
+    - Rounds 2+ of winners and losers brackets lose all competitor slots
+      (they were only populated because rounds advanced).
+    - Finals and true_finals go completely blank.
+    - Round 1 winners bracket keeps its seeded competitors intact —
+      that's the whole point of printing the seeded bracket.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from models import Event
+
+
+def build_birling_print_context(event: Event) -> dict | None:
+    """Return a scrubbed, deep-copied bracket dict ready for printing.
+
+    Args:
+        event: The bracket event (must have scoring_type == 'bracket').
+
+    Returns:
+        A dict with keys 'bracket' (scrubbed rounds + finals), 'competitors'
+        (seeded list preserved for display name lookup), and 'comp_lookup'
+        (str(id) -> name) for easy template rendering.  None if the bracket
+        has not been generated yet (caller should flash + redirect).
+    """
+    if event is None or event.scoring_type != "bracket":
+        return None
+
+    try:
+        from services.birling_bracket import BirlingBracket
+    except ImportError:
+        return None
+
+    bb = BirlingBracket(event)
+    data = bb.bracket_data
+    winners = data.get("bracket", {}).get("winners") or []
+    if not winners:
+        # No bracket generated yet — nothing meaningful to print.
+        return None
+
+    # Deep copy every branch we'll mutate — the live Event.payouts stays untouched.
+    scrubbed = {
+        "bracket": {
+            "winners": deepcopy(winners),
+            "losers": deepcopy(data.get("bracket", {}).get("losers") or []),
+            "finals": deepcopy(data.get("bracket", {}).get("finals") or {}),
+            "true_finals": deepcopy(data.get("bracket", {}).get("true_finals") or {}),
+        },
+        "competitors": deepcopy(data.get("competitors") or []),
+        "seeding": deepcopy(data.get("seeding") or []),
+    }
+
+    # --- Winners bracket ---
+    # Round 1 keeps competitors (that's what we're printing).  Strip result
+    # fields only: winner, loser, falls, is_bye flag stays so TBD byes still
+    # show.  Rounds 2+ go back to all-TBD.
+    for round_idx, round_matches in enumerate(scrubbed["bracket"]["winners"]):
+        for match in round_matches:
+            match["winner"] = None
+            match["loser"] = None
+            match["falls"] = []
+            if round_idx > 0:
+                match["competitor1"] = None
+                match["competitor2"] = None
+
+    # --- Losers bracket ---
+    # All slots go TBD.  Losers were only populated when winners advanced,
+    # so scrubbing results + resetting slots gives an empty printable skeleton.
+    for round_matches in scrubbed["bracket"]["losers"]:
+        for match in round_matches:
+            match["winner"] = None
+            match["loser"] = None
+            match["falls"] = []
+            match["competitor1"] = None
+            match["competitor2"] = None
+            match["eliminated_position"] = None
+
+    # --- Finals + true_finals ---
+    for key in ("finals", "true_finals"):
+        match = scrubbed["bracket"][key]
+        if match:
+            match["competitor1"] = None
+            match["competitor2"] = None
+            match["winner"] = None
+            match["loser"] = None
+            match["falls"] = []
+            if key == "true_finals":
+                match["needed"] = False
+
+    scrubbed["comp_lookup"] = {
+        str(c.get("id")): c.get("name", f"ID:{c.get('id')}")
+        for c in scrubbed["competitors"]
+    }
+    return scrubbed

--- a/services/print_response.py
+++ b/services/print_response.py
@@ -1,0 +1,46 @@
+"""
+WeasyPrint-optional print response helper.
+
+Three routes now return either a PDF (if WeasyPrint is installed) or a
+plain-HTML fallback (the default on Railway, where cairo/pango/gdk-pixbuf
+are too heavy to bundle):
+    - routes/scoring.py::judge_sheet_for_event and judge_sheets_all
+    - routes/scoring.py heat_sheet_pdf
+    - routes/scheduling/birling.py::birling_print_blank (PR D, new)
+
+This module owns the single try/except WeasyPrint pattern so all three
+call sites use the same response shape and content-type fallback.
+"""
+
+from __future__ import annotations
+
+
+def weasyprint_or_html(html: str, filename: str) -> tuple:
+    """Return a Flask-compatible (body, status, headers) tuple.
+
+    If WeasyPrint is importable, returns a PDF with
+    Content-Disposition: attachment; filename=<filename>.pdf.
+    Otherwise returns the HTML body with Content-Type text/html so the
+    user can print via their browser (Ctrl-P → Save as PDF).
+
+    Args:
+        html: Rendered HTML body (from render_template of a standalone
+            print template with inline CSS and @page rules).
+        filename: Base filename WITHOUT extension.  '.pdf' is appended
+            for the PDF path; no extension is added to the HTML fallback
+            because the browser renders it inline.
+    """
+    try:
+        from weasyprint import HTML as WP_HTML  # type: ignore
+
+        pdf_bytes = WP_HTML(string=html).write_pdf()
+        return (
+            pdf_bytes,
+            200,
+            {
+                "Content-Type": "application/pdf",
+                "Content-Disposition": f'attachment; filename="{filename}.pdf"',
+            },
+        )
+    except ImportError:
+        return html, 200, {"Content-Type": "text/html"}

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -194,6 +194,12 @@
                 <i class="bi bi-printer sb-icon"></i>
                 <span class="sb-text ms-2">Heat Sheets</span>
             </a>
+            <a href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}"
+               class="nav-link sidebar-child" target="_blank" rel="noopener"
+               title="Birling Brackets (seeded, printable)">
+                <i class="bi bi-diagram-3 sb-icon"></i>
+                <span class="sb-text ms-2">Birling Brackets</span>
+            </a>
             <a href="{{ url_for('portal.kiosk', tournament_id=tournament.id) }}"
                class="nav-link sidebar-child" target="_blank" rel="noopener"
                title="Kiosk Display">

--- a/templates/scheduling/birling_manage.html
+++ b/templates/scheduling/birling_manage.html
@@ -489,6 +489,11 @@
             <i class="bi bi-lock-fill me-1"></i> Results Finalized
         </span>
         {% endif %}
+        <a href="{{ url_for('scheduling.birling_print_blank', tournament_id=tournament.id, event_id=event.id) }}"
+           class="btn btn-outline-secondary btn-sm" target="_blank"
+           title="Blank printable bracket with round-1 matchups filled in — judge hand-fills advancement.">
+            <i class="bi bi-printer me-1"></i> Print Blank Bracket
+        </a>
         <form method="POST" action="{{ url_for('scheduling.birling_reset', tournament_id=tournament.id, event_id=event.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn btn-outline-danger btn-sm"

--- a/templates/scheduling/events.html
+++ b/templates/scheduling/events.html
@@ -633,6 +633,14 @@
                             <span class="fw-semibold" style="font-size:0.85rem;">{{ e.display_name }}</span>
                             {% if e.is_open %}<span class="badge bg-success" style="font-size:0.65rem;">OPEN</span>{% endif %}
                             {% if 'birling' in e.name|lower %}<span class="badge bg-secondary" style="font-size:0.65rem;">Always Last</span>{% endif %}
+                            {% if e.scoring_type == 'bracket' %}
+                                <a href="{{ url_for('scheduling.birling_manage', tournament_id=tournament.id, event_id=e.id) }}"
+                                   class="btn btn-sm btn-outline-info ms-auto"
+                                   style="font-size:0.7rem; padding:1px 8px;"
+                                   title="Seed, generate, and manage this birling bracket.">
+                                    <i class="bi bi-diagram-3 me-1"></i>Bracket
+                                </a>
+                            {% endif %}
                         </li>
                         {% endfor %}
                     </ul>

--- a/templates/scoring/birling_bracket_print.html
+++ b/templates/scoring/birling_bracket_print.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Birling Blank Bracket{% if brackets and brackets|length == 1 %} — {{ brackets[0].event.display_name }}{% endif %}</title>
+<style>
+    /* Standalone template — does NOT extend base.html.  WeasyPrint needs
+       all CSS inline with @page rules; browsers Ctrl-P read the same CSS. */
+    @page {
+        size: Letter landscape;
+        margin: 0.4in 0.4in 0.55in 0.4in;
+        @bottom-center {
+            content: "Page " counter(page) " of " counter(pages) "  —  STRATHEX Tournament Management";
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 9pt;
+            color: #444;
+        }
+    }
+
+    * { box-sizing: border-box; }
+    html, body {
+        margin: 0; padding: 0;
+        font-family: Arial, Helvetica, sans-serif;
+        color: #000;
+        background: #fff;
+    }
+
+    .bracket-page { page-break-after: always; }
+    .bracket-page:last-child { page-break-after: auto; }
+
+    .sheet-header { text-align: center; margin-bottom: 0.15in; }
+    .sheet-header h1 { font-size: 22pt; margin: 0 0 4pt 0; letter-spacing: 0.4pt; }
+    .sheet-header .meta { font-size: 11pt; color: #333; }
+    .sheet-header .fill-hint {
+        font-size: 9pt; color: #666; margin-top: 4pt; font-style: italic;
+    }
+
+    .bracket-section { margin-bottom: 12px; page-break-inside: avoid; }
+    .bracket-section-title {
+        display: inline-block; padding: 3pt 10pt; border-radius: 3pt;
+        font-size: 9pt; font-weight: 700; color: #fff; margin-bottom: 6pt;
+    }
+    .bracket-section-title.winners { background: #1a6fa8; }
+    .bracket-section-title.losers  { background: #8d3a6e; }
+    .bracket-section-title.finals  { background: #388e3c; }
+
+    .bracket-row { display: flex; gap: 5pt; align-items: stretch; }
+    .bracket-round {
+        display: flex; flex-direction: column; justify-content: space-around;
+        min-width: 150pt; flex-shrink: 0;
+    }
+    .bracket-round-label {
+        text-align: center; font-size: 8pt; font-weight: 700;
+        color: #555; text-transform: uppercase; margin-bottom: 4pt;
+        letter-spacing: 0.5pt;
+    }
+
+    .match {
+        border: 1pt solid #333;
+        border-radius: 3pt;
+        margin: 4pt 0;
+        overflow: hidden;
+        font-size: 10pt;
+        background: #fff;
+    }
+    .match.is-bye { opacity: 0.55; }
+    .match-header {
+        background: #f0f0f0;
+        padding: 1pt 6pt;
+        font-size: 8pt;
+        color: #666;
+    }
+    .match-slot {
+        padding: 5pt 8pt;
+        min-height: 24pt;
+        /* Blank line for hand-written names / tallies — the judge draws
+           advancement arrows / fill names as the bracket plays out. */
+        border-bottom: 0.5pt solid #ccc;
+    }
+    .match-slot:last-child { border-bottom: none; }
+    .match-slot .tbd {
+        color: #bbb; font-style: italic; font-size: 9pt;
+    }
+
+    .placements-blank {
+        margin-top: 8pt;
+        border: 1pt solid #333; border-radius: 3pt;
+        padding: 6pt;
+        max-width: 3in;
+    }
+    .placements-blank .hdr {
+        font-size: 9pt; font-weight: 700; margin-bottom: 4pt;
+        letter-spacing: 0.5pt; text-transform: uppercase;
+    }
+    .placements-blank .row {
+        display: flex; align-items: center;
+        border-bottom: 0.5pt solid #999; padding: 4pt 0;
+        min-height: 18pt;
+    }
+    .placements-blank .row:last-child { border-bottom: none; }
+    .placements-blank .pos {
+        font-weight: 700; width: 24pt; font-size: 10pt;
+    }
+    .placements-blank .line {
+        flex: 1; border-bottom: 0.5pt solid #333;
+        margin-left: 4pt; height: 14pt;
+    }
+</style>
+</head>
+<body>
+
+{% macro bracket_slot(comp_id, lookup) %}
+    {% set name = lookup.get(comp_id|string, '') if comp_id else '' %}
+    {% if comp_id %}
+        <div class="match-slot">{{ name }}</div>
+    {% else %}
+        <div class="match-slot"><span class="tbd">_________________</span></div>
+    {% endif %}
+{% endmacro %}
+
+{% macro bracket_match(match, lookup) %}
+    <div class="match {{ 'is-bye' if match.get('is_bye') else '' }}">
+        <div class="match-header">{{ match.match_id }}</div>
+        {{ bracket_slot(match.competitor1, lookup) }}
+        {{ bracket_slot(match.competitor2, lookup) }}
+    </div>
+{% endmacro %}
+
+{% for item in brackets %}
+<div class="bracket-page">
+    <div class="sheet-header">
+        <h1>{{ item.event.display_name }}</h1>
+        <div class="meta">Missoula Pro-Am {{ year }} — Double Elimination Bracket</div>
+        <div class="fill-hint">
+            Record winners on the blank advancement slots.  Return this sheet
+            to scorekeeping after the bracket completes.
+        </div>
+    </div>
+
+    {% if item.ctx.bracket.winners %}
+    <div class="bracket-section">
+        <span class="bracket-section-title winners">Winners Bracket</span>
+        <div class="bracket-row">
+            {% for round_matches in item.ctx.bracket.winners %}
+            <div class="bracket-round">
+                <div class="bracket-round-label">
+                    {% if loop.last %}Final{% else %}Round {{ loop.index }}{% endif %}
+                </div>
+                {% for match in round_matches %}
+                    {{ bracket_match(match, item.ctx.comp_lookup) }}
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if item.ctx.bracket.losers %}
+    <div class="bracket-section">
+        <span class="bracket-section-title losers">Losers Bracket</span>
+        <div class="bracket-row">
+            {% for round_matches in item.ctx.bracket.losers %}
+            <div class="bracket-round">
+                <div class="bracket-round-label">L Round {{ loop.index }}</div>
+                {% for match in round_matches %}
+                    {{ bracket_match(match, item.ctx.comp_lookup) }}
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {% if item.ctx.bracket.finals %}
+    <div class="bracket-section">
+        <span class="bracket-section-title finals">Grand Finals</span>
+        <div class="bracket-row">
+            <div class="bracket-round">
+                <div class="bracket-round-label">Finals</div>
+                {{ bracket_match(item.ctx.bracket.finals, item.ctx.comp_lookup) }}
+            </div>
+            <div class="bracket-round">
+                <div class="bracket-round-label">True Finals (if needed)</div>
+                {{ bracket_match(item.ctx.bracket.true_finals, item.ctx.comp_lookup) }}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="placements-blank">
+        <div class="hdr">Final Placements (fill in)</div>
+        {% for pos in range(1, 7) %}
+        <div class="row">
+            <span class="pos">{{ pos }}.</span>
+            <span class="line"></span>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endfor %}
+
+</body>
+</html>

--- a/templates/tournament_detail.html
+++ b/templates/tournament_detail.html
@@ -345,6 +345,11 @@
                    title="Blank judge scoring sheets for every event that has heats — one document, one click before the day starts.">
                     <i class="bi bi-pencil-square me-1"></i>Print All Judge Sheets
                 </a>
+                <a href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}"
+                   class="btn btn-outline-info btn-sm" target="_blank"
+                   title="Printable seeded birling brackets — round-1 matchups filled in, advancement slots blank.">
+                    <i class="bi bi-diagram-3 me-1"></i>Print Birling Brackets
+                </a>
                 <form method="post"
                       action="{{ url_for('main.activate_competition', tournament_id=tournament.id, competition_type='college') }}"
                       class="d-inline">
@@ -494,6 +499,13 @@
                         <span>
                             <span class="pl-title">Print Heat Sheets</span>
                             <span class="pl-desc">Printable heat assignments for judges</span>
+                        </span>
+                    </a>
+                    <a class="phase-link" href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}" target="_blank">
+                        <i class="bi bi-diagram-3 pl-icon" style="color:#6cb6f5;"></i>
+                        <span>
+                            <span class="pl-title">Birling Blank Brackets</span>
+                            <span class="pl-desc">Printable seeded brackets for the birling judge</span>
                         </span>
                     </a>
                 </div>

--- a/tests/test_birling_print.py
+++ b/tests/test_birling_print.py
@@ -1,0 +1,214 @@
+"""
+Tests for services/birling_print.py.
+
+Covers the show-prep blank-bracket deliverable (2026-04-20):
+  - build_birling_print_context returns a deep-copied, result-scrubbed
+    bracket view (round-1 competitors preserved, everything else reset).
+  - Ungenerated bracket → None sentinel (caller flashes + redirects).
+  - Live Event.payouts is never mutated, even on partially-played brackets.
+
+Run:  pytest tests/test_birling_print.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from services.birling_print import build_birling_print_context
+
+
+def _event_with_bracket(bracket_payload: dict):
+    """Return a fake Event-like object with scoring_type='bracket' and the
+    given payouts JSON serialised on it.  Avoids touching the DB for
+    pure-function tests."""
+    return SimpleNamespace(
+        id=1,
+        scoring_type="bracket",
+        payouts=json.dumps(bracket_payload),
+    )
+
+
+class TestUngenerated:
+    def test_none_event_returns_none(self):
+        assert build_birling_print_context(None) is None
+
+    def test_non_bracket_event_returns_none(self):
+        ev = SimpleNamespace(id=1, scoring_type="time", payouts="{}")
+        assert build_birling_print_context(ev) is None
+
+    def test_empty_payouts_returns_none(self):
+        ev = _event_with_bracket({})
+        assert build_birling_print_context(ev) is None
+
+    def test_generated_but_empty_winners_returns_none(self):
+        ev = _event_with_bracket({"bracket": {"winners": []}})
+        assert build_birling_print_context(ev) is None
+
+
+class TestScrubBehavior:
+    def _seeded_payload(self) -> dict:
+        """Minimal generate_bracket()-style payload with two rounds and a
+        finals block — enough to verify the scrub across all bracket areas."""
+        return {
+            "bracket": {
+                "winners": [
+                    [
+                        {
+                            "match_id": "W1_1",
+                            "round": "winners_1",
+                            "competitor1": 1,
+                            "competitor2": 2,
+                            "winner": 1,
+                            "loser": 2,
+                            "falls": [{"fall_number": 1, "winner": 1}],
+                            "is_bye": False,
+                        },
+                        {
+                            "match_id": "W1_2",
+                            "round": "winners_1",
+                            "competitor1": 3,
+                            "competitor2": 4,
+                            "winner": None,
+                            "loser": None,
+                            "falls": [],
+                            "is_bye": False,
+                        },
+                    ],
+                    [
+                        {
+                            "match_id": "W2_1",
+                            "round": "winners_2",
+                            "competitor1": 1,
+                            "competitor2": None,
+                            "winner": None,
+                            "loser": None,
+                            "falls": [],
+                            "is_bye": False,
+                        },
+                    ],
+                ],
+                "losers": [
+                    [
+                        {
+                            "match_id": "L1_1",
+                            "round": "losers_1",
+                            "competitor1": 2,
+                            "competitor2": None,
+                            "winner": None,
+                            "loser": None,
+                            "falls": [],
+                            "eliminated_position": 5,
+                        },
+                    ],
+                ],
+                "finals": {
+                    "match_id": "F1",
+                    "round": "finals",
+                    "competitor1": 1,
+                    "competitor2": None,
+                    "winner": None,
+                    "loser": None,
+                    "falls": [],
+                },
+                "true_finals": {
+                    "match_id": "F2",
+                    "round": "true_finals",
+                    "competitor1": 1,
+                    "competitor2": 2,
+                    "winner": 1,
+                    "loser": 2,
+                    "falls": [],
+                    "needed": True,
+                },
+            },
+            "competitors": [
+                {"id": 1, "name": "Alice"},
+                {"id": 2, "name": "Bob"},
+                {"id": 3, "name": "Charlie"},
+                {"id": 4, "name": "Dave"},
+            ],
+            "seeding": [1, 2, 3, 4],
+            "placements": {"2": 4},
+        }
+
+    def test_round_1_winners_preserved(self):
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        round1 = ctx["bracket"]["winners"][0]
+        assert round1[0]["competitor1"] == 1
+        assert round1[0]["competitor2"] == 2
+        assert round1[1]["competitor1"] == 3
+        assert round1[1]["competitor2"] == 4
+
+    def test_round_1_winners_results_stripped(self):
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        round1 = ctx["bracket"]["winners"][0]
+        assert round1[0]["winner"] is None
+        assert round1[0]["loser"] is None
+        assert round1[0]["falls"] == []
+
+    def test_round_2_plus_winners_all_tbd(self):
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        round2 = ctx["bracket"]["winners"][1]
+        for match in round2:
+            assert match["competitor1"] is None
+            assert match["competitor2"] is None
+            assert match["winner"] is None
+
+    def test_losers_bracket_all_tbd(self):
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        for round_matches in ctx["bracket"]["losers"]:
+            for match in round_matches:
+                assert match["competitor1"] is None
+                assert match["competitor2"] is None
+                assert match["winner"] is None
+                assert match["eliminated_position"] is None
+
+    def test_finals_stripped_and_blank(self):
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        for key in ("finals", "true_finals"):
+            match = ctx["bracket"][key]
+            assert match["competitor1"] is None
+            assert match["competitor2"] is None
+            assert match["winner"] is None
+        # true_finals 'needed' must be reset to False so the blank print
+        # doesn't imply the Losers champ beat the Winners champ.
+        assert ctx["bracket"]["true_finals"]["needed"] is False
+
+    def test_placements_not_rendered_in_context(self):
+        """placements was only useful for the live bracket; the blank print
+        context should not surface it (no one has placed yet, by definition)."""
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        assert "placements" not in ctx["bracket"]
+
+    def test_live_event_payouts_not_mutated(self):
+        """Deep copy guarantee: mutating the returned context must not
+        write back to event.payouts."""
+        payload = self._seeded_payload()
+        ev = _event_with_bracket(payload)
+
+        ctx = build_birling_print_context(ev)
+        # Mutate the context aggressively.
+        ctx["bracket"]["winners"][0][0]["competitor1"] = 99999
+        ctx["competitors"].clear()
+
+        # event.payouts must still parse back to the original payload.
+        import json as _json
+
+        still = _json.loads(ev.payouts)
+        assert still["bracket"]["winners"][0][0]["competitor1"] == 1
+        assert len(still["competitors"]) == 4
+
+    def test_comp_lookup_includes_seeded_names(self):
+        ev = _event_with_bracket(self._seeded_payload())
+        ctx = build_birling_print_context(ev)
+        assert ctx["comp_lookup"]["1"] == "Alice"
+        assert ctx["comp_lookup"]["4"] == "Dave"

--- a/tests/test_routes_birling_print.py
+++ b/tests/test_routes_birling_print.py
@@ -1,0 +1,254 @@
+"""
+Route-level tests for the blank-bracket print endpoints (PR D).
+
+Covers:
+    - GET /scheduling/<tid>/event/<eid>/birling/print-blank
+      (redirects to seeding page when the bracket isn't generated yet;
+       otherwise returns HTML or PDF via weasyprint_or_html)
+    - GET /scheduling/<tid>/birling/print-all
+      (combined doc; skips ungenerated events with a flash)
+    - 404s for non-bracket events / wrong tournament
+
+Run:  pytest tests/test_routes_birling_print.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from tests.conftest import make_event, make_tournament
+
+
+@pytest.fixture()
+def bp_auth_client(app, db_session):
+    """Test client logged in as a unique admin per test.  Same pattern as
+    tests/test_routes_video_judge.py::vj_auth_client — avoids the
+    conftest admin_user fixture's unique-username collision."""
+    from models.user import User
+
+    user = User(username=f"bp_admin_{uuid.uuid4().hex[:8]}", role="admin")
+    user.set_password("bp_pass")
+    db_session.add(user)
+    db_session.flush()
+
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+    return c
+
+
+def _make_bracket_event(session, tournament, name="Birling", gender="M"):
+    return make_event(
+        session,
+        tournament,
+        name=name,
+        event_type="college",
+        scoring_type="bracket",
+        stand_type="birling",
+        gender=gender,
+    )
+
+
+def _seed_generated_bracket(event):
+    """Give `event` a minimal generated-bracket payload so
+    build_birling_print_context returns a real context."""
+    payload = {
+        "bracket": {
+            "winners": [
+                [
+                    {
+                        "match_id": "W1_1",
+                        "round": "winners_1",
+                        "competitor1": 1,
+                        "competitor2": 2,
+                        "winner": None,
+                        "loser": None,
+                        "falls": [],
+                        "is_bye": False,
+                    },
+                ],
+                [
+                    {
+                        "match_id": "W2_1",
+                        "round": "winners_2",
+                        "competitor1": None,
+                        "competitor2": None,
+                        "winner": None,
+                        "loser": None,
+                        "falls": [],
+                        "is_bye": False,
+                    },
+                ],
+            ],
+            "losers": [],
+            "finals": {
+                "match_id": "F1",
+                "round": "finals",
+                "competitor1": None,
+                "competitor2": None,
+                "winner": None,
+                "loser": None,
+                "falls": [],
+            },
+            "true_finals": {
+                "match_id": "F2",
+                "round": "true_finals",
+                "competitor1": None,
+                "competitor2": None,
+                "winner": None,
+                "loser": None,
+                "falls": [],
+                "needed": False,
+            },
+        },
+        "competitors": [
+            {"id": 1, "name": "Alice"},
+            {"id": 2, "name": "Bob"},
+        ],
+        "seeding": [1, 2],
+        "placements": {},
+    }
+    event.payouts = json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# Per-event: /scheduling/<tid>/event/<eid>/birling/print-blank
+# ---------------------------------------------------------------------------
+
+
+class TestPerEventPrint:
+    def test_ungenerated_bracket_flashes_and_redirects(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        t = make_tournament(db_session)
+        ev = _make_bracket_event(db_session, t)
+        db_session.flush()
+
+        resp = bp_auth_client.get(
+            f"/scheduling/{t.id}/event/{ev.id}/birling/print-blank"
+        )
+        # Flash + redirect to birling_manage.
+        assert resp.status_code in (302, 303)
+        assert f"/scheduling/{t.id}/event/{ev.id}/birling" in resp.headers["Location"]
+
+    def test_generated_bracket_returns_printable_html(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        t = make_tournament(db_session)
+        ev = _make_bracket_event(db_session, t)
+        _seed_generated_bracket(ev)
+        db_session.flush()
+
+        resp = bp_auth_client.get(
+            f"/scheduling/{t.id}/event/{ev.id}/birling/print-blank"
+        )
+        assert resp.status_code == 200
+        # WeasyPrint may or may not be installed — accept HTML or PDF.
+        ct = resp.mimetype
+        assert ct in ("text/html", "application/pdf", "application/octet-stream")
+        body = resp.data
+        # Round-1 competitor names should appear (seeded).
+        if ct == "text/html":
+            assert b"Alice" in body and b"Bob" in body
+
+    def test_non_bracket_event_404(self, bp_auth_client, db_session):
+        t = make_tournament(db_session)
+        ev = make_event(
+            db_session,
+            t,
+            name="Underhand",
+            event_type="pro",
+            scoring_type="time",
+            stand_type="underhand",
+        )
+        db_session.flush()
+
+        resp = bp_auth_client.get(
+            f"/scheduling/{t.id}/event/{ev.id}/birling/print-blank"
+        )
+        assert resp.status_code == 404
+
+    def test_missing_tournament_404(self, bp_auth_client):
+        resp = bp_auth_client.get("/scheduling/99999/event/1/birling/print-blank")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Combined: /scheduling/<tid>/birling/print-all
+# ---------------------------------------------------------------------------
+
+
+class TestPrintAll:
+    def test_no_bracket_events_flashes_and_redirects(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        t = make_tournament(db_session)
+        # No bracket events at all.
+        db_session.flush()
+        resp = bp_auth_client.get(f"/scheduling/{t.id}/birling/print-all")
+        assert resp.status_code in (302, 303)
+        assert f"/tournament/{t.id}" in resp.headers["Location"]
+
+    def test_all_ungenerated_flashes_and_redirects(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        t = make_tournament(db_session)
+        _make_bracket_event(db_session, t, name="Birling", gender="M")
+        _make_bracket_event(db_session, t, name="Birling", gender="F")
+        db_session.flush()
+
+        resp = bp_auth_client.get(f"/scheduling/{t.id}/birling/print-all")
+        # None seeded → redirect, don't render a blank doc.
+        assert resp.status_code in (302, 303)
+
+    def test_mixed_generation_renders_only_seeded(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        """One seeded, one not → combined doc contains the seeded event,
+        skip flash mentions the other."""
+        t = make_tournament(db_session)
+        men = _make_bracket_event(db_session, t, name="Birling", gender="M")
+        _make_bracket_event(db_session, t, name="Birling", gender="F")
+        _seed_generated_bracket(men)
+        db_session.flush()
+
+        resp = bp_auth_client.get(f"/scheduling/{t.id}/birling/print-all")
+        assert resp.status_code == 200
+        if resp.mimetype == "text/html":
+            # Jinja escapes apostrophes — "Men's" renders as "Men&#39;s".
+            assert b"Men" in resp.data and b"Birling" in resp.data
+            # Alice+Bob from the seeded bracket show up too.
+            assert b"Alice" in resp.data
+
+    def test_all_generated_renders_all(self, bp_auth_client, db_session):
+        t = make_tournament(db_session)
+        men = _make_bracket_event(db_session, t, name="Birling", gender="M")
+        women = _make_bracket_event(db_session, t, name="Birling", gender="F")
+        _seed_generated_bracket(men)
+        _seed_generated_bracket(women)
+        db_session.flush()
+
+        resp = bp_auth_client.get(f"/scheduling/{t.id}/birling/print-all")
+        assert resp.status_code == 200
+        if resp.mimetype == "text/html":
+            # Two bracket pages separated by <div class="bracket-page">.
+            assert resp.data.count(b"bracket-page") >= 2
+            # Women's and Men's both render (checking escaped forms).
+            assert b"Men" in resp.data and b"Women" in resp.data
+
+    def test_missing_tournament_404(self, bp_auth_client):
+        resp = bp_auth_client.get("/scheduling/99999/birling/print-all")
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Third show-prep deliverable for April 24-25. Judges in training can now find the birling bracket page from four different surfaces, and the birling judge can print a seeded blank bracket sheet to fill in by hand during the event (results are entered into the system afterward).

- \`services/birling_print.py\` (new): \`build_birling_print_context(event)\` returns a deep-copied, result-scrubbed bracket view. Round-1 winners keep their seeded competitors (the whole point of printing a seeded bracket); every other slot + every winner/loser/falls/placements field + the \`true_finals.needed\` flag get wiped. Live \`Event.payouts\` is never mutated — partially-played brackets are safe to print from. Returns None for ungenerated brackets so callers flash + redirect.
- \`services/print_response.py\` (new): \`weasyprint_or_html(html, filename)\` — single shared WeasyPrint-optional helper, same try/except pattern the judge-sheet and heat-sheet PDF routes already carried inline.
- \`templates/scoring/birling_bracket_print.html\` (new): standalone inline-CSS template, \`@page { size: Letter landscape }\`, bottom-center page counter, underlined empty slots for hand-writing, 1st–6th "Final Placements (fill in)" box. Renders multi-event brackets with page-break-after.
- \`routes/scheduling/birling.py\`:
  - GET /scheduling/\<tid\>/event/\<eid\>/birling/print-blank — per-event, ungenerated-bracket safety flash.
  - GET /scheduling/\<tid\>/birling/print-all — tournament-wide combined doc; skips ungenerated events with a flash listing their names, still renders the seeded ones.
- Nav surfacing (domain rule: judge in training must find this page from anywhere):
  - \`templates/scheduling/birling_manage.html\` — Print Blank Bracket button in Actions row.
  - \`templates/scheduling/events.html\` — Bracket action button on any bracket-scoring row.
  - \`templates/tournament_detail.html\` — button in Ready-for-Game-Day action bar + phase-link card in Before-the-Show panel.
  - \`templates/_sidebar.html\` — Birling Brackets entry under Run Show.

## Test plan

- [x] \`tests/test_birling_print.py\` — 12 tests: ungenerated → None, deep-copy guarantees (live Event.payouts never mutated), round-1 preserved, rounds 2+ all TBD, losers all TBD, finals/true_finals blank, \`true_finals.needed\` reset to False, placements stripped, comp_lookup built.
- [x] \`tests/test_routes_birling_print.py\` — 9 tests: per-event ungenerated flashes + redirects, seeded returns printable body with round-1 names, non-bracket event 404, missing tournament 404; print-all with no events / all-ungenerated / mixed / all-generated flows.
- [x] Full regression: 306 passed. 4 pre-existing SQLite-async-lock smoke failures on clean main baseline.