### PR TITLE
feat: hand-saw stand block alternation (V2.10.0)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,46 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.10.0)
+
+**Minor — hand-saw stand block alternation**
+
+Alternates the two physical saw-stand blocks (A = stands 1-4, B = stands 5-8) across consecutive hand-saw heats in each day's run order. The next team can set in on the opposite block while the current team runs. Applies to Single Buck, Double Buck, and Jack & Jill Sawing — all pro and college, all genders. Friday and Saturday each start fresh on Block A.
+
+**New service — services/saw_block_assignment.py:**
+- `assign_saw_blocks(tournament)` iterates Friday then Saturday in authoritative run order, flips Block A↔B on every heat with `stand_type=='saw_hand'`, skips non-saw heats while preserving alternation state. Idempotent — commits on success, rolls back and re-raises on failure.
+- `remap_heat_to_block(heat, target_block)` remaps a heat's `stand_assignments` JSON onto the 4 target-block stand numbers, preserving pair-sharing structure for partnered events (both partners keep the same stand number). Never changes heat composition.
+- `trigger_saw_block_recompute(tournament)` shared hook wrapper — calls `assign_saw_blocks`, logs result, flashes a warning on exception. Hook failures never roll back primary commits.
+
+**Authoritative run-order helpers — services/schedule_builder.py:**
+- `get_friday_ordered_heats(tournament)` returns all Friday college heats (run_number=1) in authoritative order: respects `schedule_config['friday_event_order']` when set, else falls back to `_college_friday_sort_key`. Excludes Saturday spillover events and Friday-Feature events.
+- `get_saturday_ordered_heats(tournament)` returns Saturday heats: iterates `Flight.flight_number` ascending then `flight.get_heats_ordered()` when flights exist, else falls back to pro events by event_id + heat_number. Includes day-split Run 2 heats (Chokerman, Speed Climb).
+- Both are pure reads with no side effects.
+
+**Route hooks — routes/scheduling/{heats,events,flights}.py:**
+- Wired into 9 mutation endpoints: `generate_heats` (single event), `generate_college_heats` (bulk), `event_list` POST actions (`generate_all` / `rebuild_flights` / `integrate_spillover`), `build_flights` POST, `reorder_flight_heats`, `reorder_friday_events`, `reset_event_order`. Hooks run AFTER the route's primary commit; exceptions inside the hook log a warning and flash but never roll back the primary mutation.
+
+**Admin safety valve + status page — routes/scheduling/heats.py, templates/scheduling/saw_blocks_status.html:**
+- `POST /scheduling/<tid>/heats/recompute-saw-blocks` manually re-runs `assign_saw_blocks` with flash feedback (`N heats updated (X Friday, Y Saturday)`). Redirects to `request.referrer` or the events page.
+- `GET /scheduling/<tid>/saw-blocks-status` renders two tables (Friday + Saturday) showing every hand-saw heat in run order with Block A/B badge, stands used, and competitor names. Empty-state message per day when no saw heats.
+
+**Sidebar — templates/_sidebar.html:**
+- New "Saw Block Status" entry under Run Show section, visible only when the tournament has at least one event with `stand_type=='saw_hand'`.
+
+**Tests — 29 new tests, zero regressions:**
+- `tests/test_schedule_builder_ordering.py` (10): custom + default Friday order, heat_number within event, Saturday spillover exclusion, Run 2 exclusion on Friday, Saturday flights-mode + fallback + custom-order + dual-run Run 2 inclusion, pure-reads guarantee.
+- `tests/test_saw_block_assignment.py` (10): within-event alternation, cross-event Friday continuity, non-saw gap preservation, day-boundary reset, partnered pair preservation, Jack & Jill mixed-gender, idempotency, flight-reshuffle recompute, Stock Saw untouched, HeatAssignment sync after remap.
+- `tests/test_saw_block_integration.py` (5): generate_heats triggers recompute, build_flights triggers recompute, reorder_flight_heats triggers recompute, reorder_friday_events triggers recompute, hook failure does not break primary mutation.
+- `tests/test_saw_blocks_admin.py` (4): recompute POST route, status page render, empty-state rendering, sidebar conditional visibility.
+
+**Data model:**
+- Zero schema changes. `Heat.stand_assignments` JSON remains authoritative; `HeatAssignment` rows synced via `heat.sync_assignments()` after every remap. `STAND_CONFIGS['saw_hand']['labels']` unchanged — heat sheets, judge sheets, and the kiosk continue to render raw stand numbers.
+
+**Design docs — docs/SAW_STAND_ALTERNATION_RECON.md, docs/SHOWPREP_WORKFLOW_RECON.md:**
+- Full recon on existing stand-assignment mutation points, the show-prep workflow, and authoritative run-order sources. Documents the 9 hook locations and open design questions answered before implementation.
+
+---
+
 ### 2026-04-19 (V2.9.1)
 
 **Patch — gear-sharing parser overhaul + modal stacking fix + race-day UI hardening**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.9.1
+# Missoula Pro Am Manager — V2.10.0
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 

--- a/docs/SAW_STAND_ALTERNATION_RECON.md
+++ b/docs/SAW_STAND_ALTERNATION_RECON.md
@@ -1,0 +1,306 @@
+# Hand-Saw Stand Block Alternation — Recon Report
+
+**Date:** 2026-04-21
+**Scope:** Read-only recon. No source changes.
+**Domain:** Missoula Pro-Am — Single Buck, Double Buck, Jack & Jill Sawing (all pro/college, all genders).
+
+**Goal:** Determine how stand assignment currently works for hand-sawing events and where block-alternation logic (block A = stands 1-4, block B = stands 5-8) must land so that consecutive hand-saw heats swap physical blocks.
+
+---
+
+## TASK 1 — Current stand configuration for hand-saw events
+
+**File:** [config.py:330-335](../config.py#L330-L335)
+
+```python
+'saw_hand': {
+    'total': 8,
+    'groups': [[1, 2, 3, 4], [5, 6, 7, 8]],
+    'labels': ['Stand 1', 'Stand 2', 'Stand 3', 'Stand 4',
+               'Stand 5', 'Stand 6', 'Stand 7', 'Stand 8']
+},
+```
+
+Findings:
+- `total` (treated as max_stands) = **8**
+- **`groups` key already encodes the two physical blocks** as `[[1,2,3,4],[5,6,7,8]]`. However, grep shows `groups` is **never consumed** by any code in the repo — it is informational only.
+- `labels` are generic `"Stand 1"` .. `"Stand 8"`. No existing label discriminates block A vs B.
+- No `specific_stands` key (saw_hand uses full 1..N fallback in [heat_generator.py:743](../services/heat_generator.py#L743)).
+
+Hand-saw event stand_type assignments — **all six reference the same `saw_hand` key**:
+
+| Event | File / line | stand_type | Partnered | Gender |
+|---|---|---|---|---|
+| College Single Buck | [config.py:400](../config.py#L400) | `saw_hand` | no | gendered |
+| College Double Buck | [config.py:401](../config.py#L401) | `saw_hand` | yes (same gender) | gendered |
+| College Jack & Jill | [config.py:402](../config.py#L402) | `saw_hand` | yes (mixed) | — |
+| Pro Single Buck | PRO_EVENTS — `saw_hand` | `saw_hand` | no | gendered |
+| Pro Double Buck | PRO_EVENTS — `saw_hand` | `saw_hand` | yes (same) | gendered |
+| Pro Jack & Jill | PRO_EVENTS — `saw_hand` | `saw_hand` | yes (mixed) | — |
+
+No deviations. One `saw_hand` config covers every hand-saw event.
+
+---
+
+## TASK 2 — Heat size for hand-saw events
+
+**Files:** [services/heat_generator.py:114-122](../services/heat_generator.py#L114-L122), [services/heat_generator.py:140-142](../services/heat_generator.py#L140-L142), [services/heat_generator.py:667-680](../services/heat_generator.py#L667-L680)
+
+max_stands resolution chain:
+
+```python
+stand_config = config.STAND_CONFIGS.get(event.stand_type, {})
+max_per_heat = event.max_stands if event.max_stands is not None else stand_config.get('total', 4)
+```
+
+Order:
+1. `event.max_stands` (explicit per-event override, usually None)
+2. `STAND_CONFIGS[stand_type]['total']` → returns **8** for saw_hand
+3. Hard default `4` if stand_type unknown
+
+For hand-saw events specifically, `_generate_saw_heats()` at [heat_generator.py:667-680](../services/heat_generator.py#L667-L680) **then caps heat size to 4 regardless**:
+
+```python
+def _generate_saw_heats(competitors, num_heats, max_per_heat, stand_config, event=None,
+                        gear_violations=None):
+    actual_max = min(max_per_heat, 4)        # Saw groups are 4 each
+    num_heats = math.ceil(len(competitors) / actual_max)
+    return _generate_standard_heats(competitors, num_heats, actual_max, event=event,
+                                    gear_violations=gear_violations)
+```
+
+For N=12 competitors: `ceil(12 / 4) = 3 heats of 4 competitors each`.
+
+**Conclusion for Task 2:** Heats are already sized to a max of 4. **The alternation fix does NOT need to split heats.** It is a stand-number-assignment / labeling concern. However — and this is the trap — `_stand_numbers_for_event()` at [heat_generator.py:734-743](../services/heat_generator.py#L734-L743) currently hands the generator `[1, 2, 3, 4]` for every saw heat because it just does `range(1, max_per_heat + 1)`. Every saw heat is therefore pinned to stands 1-4 today; nobody is ever sitting on stands 5-8.
+
+---
+
+## TASK 3 — Stand assignment structure
+
+**File:** [models/heat.py:51-119](../models/heat.py#L51-L119)
+
+`Heat.stand_assignments` column:
+
+```python
+stand_assignments = db.Column(db.Text, nullable=False, default='{}')
+# JSON-encoded dict: { competitor_id_as_str: stand_number_int }
+```
+
+Shape:
+```json
+{ "10": 1, "11": 1, "12": 2, "13": 2 }   // partnered — both partners share stand
+{ "10": 1, "11": 2, "12": 3, "13": 4 }   // non-partnered — one per stand
+```
+
+- Keys are **stringified** competitor IDs (the `set_stand_assignment()` helper at [models/heat.py:110-114](../models/heat.py#L110-L114) forces `str(competitor_id)`).
+- Values are integer stand numbers (1..total).
+- Partnered pairs share one stand number (both competitor IDs map to the same int) — see TASK 7.
+
+Assignment is **computed at heat generation time and persisted**. The logic lives in [heat_generator.py:161-220](../services/heat_generator.py#L161-L220):
+
+```python
+stand_numbers = _stand_numbers_for_event(event, max_per_heat, stand_config)
+# ... per heat ...
+if is_partnered:
+    pair_units = _rebuild_pair_units(heat_competitors, event)
+    stand_idx = 0
+    for unit in pair_units:
+        stand_num = stand_numbers[stand_idx] if stand_idx < len(stand_numbers) else stand_idx + 1
+        for comp in unit:
+            heat.set_stand_assignment(comp['id'], stand_num)
+        stand_idx += 1
+else:
+    for i, comp in enumerate(heat_competitors):
+        stand_num = stand_numbers[i] if i < len(stand_numbers) else i + 1
+        heat.set_stand_assignment(comp['id'], stand_num)
+```
+
+Key properties for the alternation design:
+- Stand numbers come from a single per-event `stand_numbers` list, independent of heat index. There is **no current mechanism for per-heat stand selection**.
+- Dual-run events reverse stands for run 2 ([heat_generator.py:202-217](../services/heat_generator.py#L202-L217)), but saw events are **single-run**, so that path is not relevant.
+- After each write, `heat.sync_assignments(comp_type)` is called ([heat_generator.py:226-227](../services/heat_generator.py#L226-L227)) to mirror the JSON into `HeatAssignment` rows. If alternation changes stand numbers post-generation, `sync_assignments()` must run again.
+
+---
+
+## TASK 4 — Existing stand label rendering
+
+**Helper function:** [routes/scheduling/heat_sheets.py:52-64](../routes/scheduling/heat_sheets.py#L52-L64)
+
+```python
+def _stand_label(stand_type: str | None, stand_number) -> str:
+    """Return the physical stand label from STAND_CONFIGS, or fall back to raw number."""
+    if stand_number is None:
+        return "?"
+    cfg = config.STAND_CONFIGS.get(stand_type or "", {})
+    labels = cfg.get("labels", [])
+    try:
+        idx = int(stand_number) - 1
+        if 0 <= idx < len(labels):
+            return labels[idx]
+    except (ValueError, TypeError):
+        pass
+    return str(stand_number)
+```
+
+Used at [routes/scheduling/heat_sheets.py:177](../routes/scheduling/heat_sheets.py#L177):
+```python
+"stand_label": _stand_label(stand_type, assignments.get(str(comp_id))),
+```
+
+Previous fix for Speed Climb / Obstacle Pole / Chokerman — **CONFIRMED in place** (all three swapped labels to the custom strings named in the task):
+- Obstacle Pole: [config.py:346-349](../config.py#L346-L349) — `['Pole 1', 'Pole 2']`
+- Speed Climb: [config.py:350-353](../config.py#L350-L353) — `['Pole 2', 'Pole 4']`
+- Chokerman: [config.py:354-357](../config.py#L354-L357) — `['Course 1', 'Course 2']`
+
+This means the label-rendering infrastructure is already data-driven from `STAND_CONFIGS.labels[stand_number - 1]`.
+
+Templates using stand labels/numbers (from grep):
+- [templates/scheduling/heats.html](../templates/scheduling/heats.html)
+- [templates/scheduling/day_schedule_print.html](../templates/scheduling/day_schedule_print.html) (renders `comp.stand_label` when defined, falls back to `comp.stand`)
+- [templates/portal/school_dashboard.html](../templates/portal/school_dashboard.html)
+- [templates/portal/competitor_dashboard.html](../templates/portal/competitor_dashboard.html)
+- [templates/portal/event_results.html](../templates/portal/event_results.html)
+
+**Piggyback assessment:** The label pipeline can handle any label text keyed by stand index, so "Block A — Stand 1" style labels work **with no plumbing change**. But the fundamental limit is that `_stand_label` uses only the stand number as an index into a flat `labels` array — it does NOT see heat index or block rotation state. If alternation is implemented via per-heat stand numbers (e.g., heat 1 gets {1,2,3,4}, heat 2 gets {5,6,7,8}), existing labels just work. If alternation is implemented via a rendered "Block A" / "Block B" badge that is separate from the stand number, it needs a new render path.
+
+---
+
+## TASK 5 — Flight / run order state
+
+**File:** [services/flight_builder.py](../services/flight_builder.py)
+
+Heat run order is built in `build_pro_flights()` at [flight_builder.py:59-170+](../services/flight_builder.py#L59). Key steps:
+
+1. All non-axe pro heats batch-loaded at [flight_builder.py:104-109](../services/flight_builder.py#L104-L109):
+   ```python
+   batched_heats = Heat.query.filter(
+       Heat.event_id.in_(non_axe_event_ids),
+       Heat.run_number == 1
+   ).order_by(Heat.event_id, Heat.heat_number).all()
+   ```
+   Initial order is per-event, sequential within each event.
+
+2. `_optimize_heat_order()` at [flight_builder.py:145-146](../services/flight_builder.py#L145-L146) runs `N_OPTIMIZATION_PASSES = 5` greedy passes to interleave events for crowd variety and competitor rest. `EVENT_SPACING_TIERS` gives `saw_hand` a `(5, 7)` min/target spacing ([flight_builder.py:33-43](../services/flight_builder.py#L33-L43)).
+
+3. The optimizer returns a single ordered list `ordered_heats`. Each entry is then written into `Flight` rows with `heat.flight_id = flight.id` and `heat.flight_position = 1..heats_per_flight`.
+
+**Global sequential order data structure:**
+The persistent answer is `Heat.flight_id` + `Heat.flight_position` + `Flight.flight_number`. Joining those three gives the global sequential order of every pro heat during the show. It is **only available after the flight builder runs** — heat generation happens before flight building, so at heat-generation time there is **no authoritative "global heat order" to query**. This is the single biggest design constraint for the alternation feature.
+
+**Existing alternating / round-robin logic:**
+- Snake-draft competitor distribution across heats within a single event (best-to-worst bouncing) exists in `_generate_standard_heats()` and friends — but that is competitor distribution, not stand assignment.
+- `integrate_college_spillover_into_flights()` distributes overflow college events round-robin across flights. That is flight-level, not stand-level.
+- **No code currently does "alternate the stand-group between consecutive heats" for any event type.** This is greenfield.
+
+---
+
+## TASK 6 — Day boundary handling
+
+**Finding:** There is **no `day_of_week` column on `Heat`**. Day context is derived, not stored.
+
+Derivation points:
+- College events (`event.event_type == 'college'`) implicitly run Friday.
+- Pro events (`event.event_type == 'pro'`) implicitly run Saturday.
+- Dual-run split: Friday shows run 1, Saturday shows run 2 — enforced at render time in [routes/scheduling/heat_sheets.py:108-112](../routes/scheduling/heat_sheets.py#L108-L112):
+  ```python
+  if event.requires_dual_runs and event.name in DAY_SPLIT_EVENT_NAMES:
+      if day == "friday":
+          event_heats = [h for h in event_heats if h.run_number == 1]
+      elif day == "saturday" or item.get("is_run2"):
+          event_heats = [h for h in event_heats if h.run_number == 2]
+  ```
+- Friday Night Feature / Saturday show blocks are separated at the **schedule** layer, not the Heat layer — see `_hydrate_schedule_for_display()` at [routes/scheduling/heat_sheets.py:67-79](../routes/scheduling/heat_sheets.py#L67-L79): `schedule` is a dict with `friday_day`, `friday_feature`, `saturday_show` keys.
+
+**Implication for alternation:** Since all hand-saw heats for a given tournament are single-run:
+- College hand-saw heats all run Friday day.
+- Pro hand-saw heats all run Saturday.
+- Friday Night Feature could in principle contain hand-saw heats, but today there is no heat-gen/flight path for it (documented gap in CLAUDE.md §5).
+
+Day boundary detection for alternation can rely on `event.event_type` alone today. If Friday Night Feature ever gains hand-saw heats, a stronger mechanism (a `day` column on Heat or Flight, or a schedule-block tag) will be needed.
+
+---
+
+## TASK 7 — Partnered event compatibility
+
+**Partnered stand assignment:** [heat_generator.py:175-182](../services/heat_generator.py#L175-L182) already assigns one stand number per pair; both partners' IDs map to the same stand in `stand_assignments` JSON.
+
+Example (2-pair Double Buck heat, stands 1-4 available):
+```json
+{ "10": 1, "11": 1, "12": 2, "13": 2 }
+```
+
+So a "stand" in `saw_hand` context = one saw = one pair. With max_per_heat = 4 stands, the maximum heat size for partnered saw events is effectively 4 pairs (8 humans).
+
+**Pair reconstruction:** `_rebuild_pair_units()` at [heat_generator.py:448](../services/heat_generator.py#L448) — returns a list of units `[[comp1, comp2], [comp3, comp4], [solo5], ...]`. Each unit occupies exactly one stand slot. Solos (odd partner out) occupy one stand alone.
+
+**Block alternation compatibility:** The block-alternation idea — "heat N runs on block A = stands 1-4, heat N+1 runs on block B = stands 5-8" — treats each pair/solo as one stand-occupant. The existing pair-per-stand data model supports this **directly**. The change is purely: pick the 4 stand numbers for this heat from {1,2,3,4} or {5,6,7,8} based on alternation state.
+
+No code or schema change needed on the partnered side — `Heat.stand_assignments` already stores pair-shared stand numbers.
+
+---
+
+## TASK 8 — Existing tests and fixtures
+
+Test files that exercise heat generation or stand assignments:
+
+| File | Scope |
+|---|---|
+| [tests/test_heat_generator.py](../tests/test_heat_generator.py) | Primary heat-generator tests. Includes hand-saw cases (gear-sharing conflict detection on Single Buck around lines 250-282; college saw_hand non-partnered around 409-415). |
+| [tests/test_heat_gen_integration.py](../tests/test_heat_gen_integration.py) | Integration tests spanning heat gen + downstream. |
+| [tests/test_flight_builder_25_pros.py](../tests/test_flight_builder_25_pros.py) | Realistic 25-pro flight build; touches saw_hand spacing. |
+| [tests/test_partnered_events_realistic.py](../tests/test_partnered_events_realistic.py) | Partnered events (Double Buck, Jack & Jill) in realistic scenarios. |
+| [tests/test_judge_sheet.py](../tests/test_judge_sheet.py) | Heat sheet / stand label rendering for judge sheets. |
+| [tests/test_route_smoke.py](../tests/test_route_smoke.py) | Route-level smoke of heat/flight endpoints. |
+
+Shared fixtures:
+- [tests/conftest.py](../tests/conftest.py) — in-memory SQLite, app/client/db, seeded tournament.
+- [tests/fixtures/synthetic_data.py](../tests/fixtures/synthetic_data.py) — 25-pro roster with realistic SB/DB/J&J partnerships and gear-sharing; usable as alternation test bed.
+
+No existing test asserts the specific stand numbers chosen for saw heats (grep on `"saw_hand"` combined with `stand_assignments` in tests returned no numeric-stand assertions beyond "stand is assigned"). A new alternation test will need to be written from scratch — not extending an existing one.
+
+---
+
+## Risks and gaps for implementing block alternation
+
+1. **`_stand_numbers_for_event()` is per-event, not per-heat** ([heat_generator.py:734-743](../services/heat_generator.py#L734-L743)). Today it returns a single list that every heat in that event reuses. Alternation requires per-heat stand selection. The natural intervention point is the loop at [heat_generator.py:164-186](../services/heat_generator.py#L164-L186), where `heat_num` is available.
+
+2. **`groups` key in `STAND_CONFIGS['saw_hand']` is unused.** It already lists `[[1,2,3,4],[5,6,7,8]]`. Implementation can consume this directly instead of hardcoding blocks in Python. A future non-4+4 saw layout (e.g., a show with only 6 stands arranged 3+3) would just edit config.
+
+3. **No cross-event alternation state today.** If alternation must span consecutive hand-saw heats across events (e.g., last Single Buck heat on Block A → first Double Buck heat on Block B), the state has to thread between separate `generate_event_heats()` calls. Options:
+   - Per-tournament counter persisted somewhere (new column on Tournament, or derived from max(heat.id) query at gen time).
+   - Re-assign stands post-hoc after flight builder runs — since global order only exists after flight build (Task 5).
+   - Keep alternation strictly within-event and accept a reset at each event boundary.
+
+4. **Flight builder re-orders heats after generation.** The sequence `_optimize_heat_order()` produces is not the same as heat_number order. If alternation is computed at heat-gen time, re-running flight builder can interleave hand-saw heats with non-saw heats or place back-to-back SB heats from different events, breaking the "every other saw heat flips blocks" property the domain wants. The correct point to assign block rotation may be **after** flight builder runs, walking the final global run order and re-assigning stand numbers to saw heats by block-alternation.
+
+5. **`sync_assignments()` must re-run** after any stand re-assignment, or `HeatAssignment` rows (used by the validation service) will drift from the JSON ([models/heat.py:121-135](../models/heat.py#L121-L135)).
+
+6. **Stock Saw override exception:** [heat_generator.py:735-737](../services/heat_generator.py#L735-L737) hardcodes college Stock Saw to stands `[7, 8]`. Stock Saw is `stand_type='stock_saw'` — a different stand_type from saw_hand — so it does not conflict directly. But the code lives in the same `_stand_numbers_for_event` helper, so the "saw_hand-specific block-alternation logic" branch needs to coexist cleanly with the existing Stock Saw branch.
+
+7. **Dual-run saw events don't exist today** but the dual-run branch at [heat_generator.py:192-220](../services/heat_generator.py#L192-L220) reverses stand numbers per-heat. If a saw event ever becomes dual-run, block-alternation and run-2-stand-reversal interact and need a defined precedence.
+
+8. **Label display:** `STAND_CONFIGS['saw_hand']['labels']` today is flat `"Stand 1".."Stand 8"`. If the show wants heat sheets to say "Block A — Stand 1", the labels array can be updated, but existing signage, printed heat-sheet stacks, and crowd-facing kiosk pages may need to be re-checked.
+
+---
+
+## Open Questions for Alex
+
+1. **Scope of alternation.** Does alternation apply **within a single event** (SB heat 1 → Block A, heat 2 → Block B, heat 3 → Block A, …) or across **all consecutive hand-saw heats in global run order**, possibly crossing event boundaries (last SB heat Block A → first DB heat Block B)?
+
+2. **Event boundary reset.** If scope is within-event: when SB ends on Block B and DB starts, does DB also start on Block A (reset) or inherit Block A from "the other block than SB ended on"?
+
+3. **Day boundary reset.** If Friday Night Feature ever hosts saw heats, or college hand-saw spills to Saturday overflow, should alternation reset at the day boundary or continue?
+
+4. **Computation timing.** Compute alternation at (a) heat-generation time (simpler, but ignores flight-builder reshuffles), (b) after flight builder runs (complex, but respects true run order), or (c) both — generate a default at heat-gen and recompute after flight?
+
+5. **Labels.** Do we change `STAND_CONFIGS['saw_hand']['labels']` to block-aware strings (e.g. `"Block A — Stand 1"`), keep the numeric labels and instead add a new "Block" column in templates, or leave labels alone and rely on the crowd/judges to read physical stand numbers?
+
+6. **Pro vs college independence.** Do college hand-saw (Friday) and pro hand-saw (Saturday) each get their own alternation sequence that starts fresh, or should we carry state across days?
+
+7. **Partnered-event stand stability across days.** Jack & Jill and Double Buck on the pro side — if a pair runs first on Block A, is there any domain reason they'd want the same block on a hypothetical re-run (none today, but confirm)?
+
+8. **Gear-sharing override.** The saw-heat generator already has gear-sharing constraints that force specific heat placement ([heat_generator.py:233-252](../services/heat_generator.py#L233-L252) gear_violations fallback). If block alternation conflicts with a gear-share constraint (e.g., putting two saws on Block A back-to-back forces a gear-share violation), which wins — gear-share safety or strict block alternation?
+
+9. **Edge case — 1 or 2 heats.** For a 4-competitor event (1 heat) or 8-competitor event (2 heats), alternation is degenerate or trivial. Any special behavior wanted, or just "put the single heat on Block A"?
+
+10. **Display scope.** Is this a scheduling / logistics change (backstage only — judges and crew see it on heat sheets) or a competitor-facing change (competitors see "Block A" on their portal)?

--- a/docs/SHOWPREP_WORKFLOW_RECON.md
+++ b/docs/SHOWPREP_WORKFLOW_RECON.md
@@ -1,0 +1,447 @@
+# Show-Prep Workflow End-to-End — Recon Report
+
+**Date:** 2026-04-21
+**Scope:** Read-only workflow trace. No code changes.
+**Goal:** Map every step from "empty tournament" to "printing heat sheets", document every state transition that affects heat run order or stand assignment, so that block-alternation for Single Buck / Double Buck / Jack & Jill can hook in at the right point(s) in the pipeline.
+
+---
+
+## Task 1 — Full show-prep workflow trace
+
+Sequential steps visible from [templates/tournament_detail.html](../templates/tournament_detail.html) and [templates/_sidebar.html](../templates/_sidebar.html), following every link and button to its handler.
+
+### Step 1 — Create tournament
+- **UI:** Dashboard → "New Tournament"
+- **Route:** `POST /tournament/new` → [routes/main.py](../routes/main.py) `tournament_new()`
+- **Template:** [templates/tournament_new.html](../templates/tournament_new.html)
+- **Writes:** `Tournament` row (`status='setup'`)
+- **Reads:** nothing
+- **Idempotent:** creates a new row each time. Destructive only if you create duplicates.
+- **Undo:** delete tournament route exists
+
+### Step 2 — Configure events (college + pro)
+- **UI:** Tournament detail → "Set Up Events" (Before Show panel) OR sidebar → Setup Events / Tournament Setup
+- **Routes:**
+  - `GET/POST /tournament/<tid>/setup` → [routes/main.py](../routes/main.py) tournament_setup (consolidated page)
+  - `GET/POST /scheduling/<tid>/events/setup` → [routes/scheduling/events.py](../routes/scheduling/events.py) `setup_events()`
+- **Templates:** [templates/tournament_setup.html](../templates/tournament_setup.html), [templates/scheduling/setup_events.html](../templates/scheduling/setup_events.html)
+- **Writes:** `Event` rows (name, event_type, stand_type, max_stands, scoring_type, is_partnered, is_gendered, is_handicap, is_open, is_finalized=False, payouts JSON)
+- **Reads:** `config.COLLEGE_OPEN_EVENTS`, `COLLEGE_CLOSED_EVENTS`, `PRO_EVENTS`, `HANDICAP_ELIGIBLE_STAND_TYPES`
+- **Idempotent:** yes — upserts via `_upsert_event()`
+- **Undo:** event rows are edited or deleted via same page
+
+### Step 3 — Register college teams/competitors
+- **UI:** Tournament detail → "Import College Teams" OR sidebar → College Registration
+- **Route:** `GET/POST /registration/<tid>/college/upload` → [routes/registration.py](../routes/registration.py) college upload handler
+- **Template:** [templates/college/registration.html](../templates/college/registration.html)
+- **Writes:** `Team` rows, `CollegeCompetitor` rows (with events_entered, partners, gear_sharing JSON), `EventResult` skeleton rows via downstream heat gen
+- **Reads:** uploaded xlsx, existing `Event` rows for name resolution
+- **Idempotent:** partial — reruns may create duplicate teams if not deduped
+- **Undo:** per-row edits; bulk rebuild requires manual cleanup
+
+### Step 4 — Register pro competitors
+- **UI:** Tournament detail → "Add Pro Competitors" / "Import Entry Forms" / sidebar → Pro Registration
+- **Routes:**
+  - `GET/POST /registration/<tid>/pro/new` → [routes/registration.py](../routes/registration.py) `new_pro_competitor()` — triggers `strathmark_sync.enroll_pro_competitor()` after commit
+  - `GET/POST /import/<tid>/pro-entry/*` → [routes/import_routes.py](../routes/import_routes.py) upload → review → confirm flow
+- **Templates:** [templates/pro/new_competitor.html](../templates/pro/new_competitor.html), [templates/pro/import_upload.html](../templates/pro/import_upload.html), [templates/pro/import_review.html](../templates/pro/import_review.html)
+- **Writes:** `ProCompetitor` rows (with events_entered, partners, gear_sharing, entry_fees, fees_paid, strathmark_id JSON/columns)
+- **Reads:** existing `Event` rows
+- **Idempotent:** import pipeline dedupes by timestamp + name
+- **Undo:** per-competitor edit/delete
+
+### Step 5 — Gear-sharing manager
+- **UI:** Sidebar → Gear Sharing (pro only)
+- **Routes:** `GET/POST /registration/<tid>/pro/gear-sharing*` → [routes/registration.py](../routes/registration.py) — gear manager, parse review, confirm, group ops, cleanup scratched
+- **Template:** [templates/pro/gear_sharing.html](../templates/pro/gear_sharing.html)
+- **Writes:** `ProCompetitor.gear_sharing` JSON dict `{event_id: partner_name | "group:NAME" | "category:KEY"}`
+- **Reads:** ProCompetitor roster + events
+- **Idempotent:** yes — edits overwrite
+- **Undo:** manual edit
+
+### Step 6 — Friday Night Feature config
+- **UI:** Sidebar → Fri Feature / Sat Overflow
+- **Route:** `GET/POST /scheduling/<tid>/friday-feature` → [routes/scheduling/friday_feature.py:77](../routes/scheduling/friday_feature.py#L77)
+- **Template:** [templates/scheduling/friday_feature.html](../templates/scheduling/friday_feature.html)
+- **Writes:** `Tournament.schedule_config['friday_pro_event_ids']`, `friday_feature_notes`, `saturday_college_event_ids`
+- **Reads:** Events, current schedule_config
+- **Idempotent:** yes
+- **Undo:** clear selection + save
+
+### Step 7 — Ability rankings (pro)
+- **UI:** Sidebar → Ability Rankings
+- **Route:** `GET/POST /scheduling/<tid>/ability-rankings` → [routes/scheduling/ability_rankings.py](../routes/scheduling/ability_rankings.py)
+- **Template:** [templates/scheduling/ability_rankings.html](../templates/scheduling/ability_rankings.html) — SortableJS drag-drop ranking
+- **Writes:** `ProEventRank` rows per (tournament, competitor, event_category)
+- **Reads:** `ProCompetitor` list filtered by events_entered
+- **Idempotent:** yes — upsert
+- **Undo:** drag back / delete row
+
+### Step 8 — Preflight check (optional)
+- **UI:** Sidebar / Events page → "Preflight Check"
+- **Route:** `GET /scheduling/<tid>/preflight` + JSON variant → [routes/scheduling/preflight.py](../routes/scheduling/preflight.py)
+- **Template:** [templates/scheduling/preflight.html](../templates/scheduling/preflight.html)
+- **Writes:** nothing (read-only)
+- **Reads:** heats, assignments, partner pools, Saturday overflow
+- **Idempotent:** trivially yes
+- **Undo:** n/a
+
+### Step 9 — Generate college heats
+- **UI:** Unified Events & Schedule page → "Generate All College Heats" OR per-event "Generate Heats"
+- **Routes:**
+  - `POST /scheduling/<tid>/events` (action=`generate_all_college`) → [routes/scheduling/events.py](../routes/scheduling/events.py) `event_list()`
+  - `POST /scheduling/<tid>/event/<eid>/generate-heats` → [routes/scheduling/heats.py](../routes/scheduling/heats.py) `generate_heats()`
+- **Template:** [templates/scheduling/events.html](../templates/scheduling/events.html) (tournament page) / [templates/scheduling/heats.html](../templates/scheduling/heats.html) (per-event)
+- **Writes:** `Heat` rows (competitors JSON, stand_assignments JSON), `HeatAssignment` rows via `heat.sync_assignments('college')`
+- **Reads:** `CollegeCompetitor` roster, ability rankings (if any), gear-sharing conflict map
+- **Idempotent:** effectively — deletes existing heats and regenerates. **Destructive to scoring if results exist.**
+- **Undo:** no; guarded by `event.is_finalized` hard block + `has_scored` soft warning
+
+### Step 10 — Generate pro heats
+- Same handler as step 9, but for pro events. Calls `strathmark_sync` hooks on finalization (later). Uses `ProEventRank` for ability grouping when present.
+
+### Step 11 — Build pro flights
+- **UI:** Events & Schedule page → "Build Pro Flights" OR Pro Flights page → "Build Flights"
+- **Routes:**
+  - `POST /scheduling/<tid>/events` (action=`rebuild_flights`) → `event_list()`
+  - `POST /scheduling/<tid>/flights/build` → [routes/scheduling/flights.py:57](../routes/scheduling/flights.py#L57) `build_flights()`
+  - Async variant via `submit_job()`
+- **Templates:** [templates/pro/flights.html](../templates/pro/flights.html), [templates/pro/build_flights.html](../templates/pro/build_flights.html)
+- **Writes:** Deletes all existing `Flight` rows, nulls all `Heat.flight_id`/`flight_position`, creates new flights, sets `Heat.flight_id` + `Heat.flight_position`; rebuilds Partnered Axe show heats via `_prepare_partnered_axe_show_heats()` (these call `heat.sync_assignments('pro')`)
+- **Reads:** pro heats (run_number==1), ProEventRank, gear-sharing conflict pairs
+- **Idempotent:** yes — same input produces same output (see Task 4; optimizer is deterministic, not randomized). Re-running clobbers then rebuilds.
+- **Undo:** no explicit undo; rerun with different parameters or re-order manually
+
+### Step 12 — Integrate Saturday college spillover
+- **UI:** Events & Schedule page → "Integrate Saturday Spillover" (after flights built)
+- **Route:** `POST /scheduling/<tid>/events` (action=`integrate_spillover`) → `event_list()` → `flight_builder.integrate_college_spillover_into_flights()`
+- **Writes:** `Heat.flight_id` for selected college events (esp. Chokerman Run 2 at end of last flight)
+- **Reads:** `schedule_config['saturday_college_event_ids']`, existing flights
+- **Idempotent:** re-runnable
+- **Undo:** re-build flights
+
+### Step 13 — Manual event order (Friday / Saturday fallback)
+- **UI:** Events & Schedule page → drag-drop event cards (SortableJS — [templates/scheduling/events.html:1108](../templates/scheduling/events.html#L1108) loads `sortablejs@1.15.2`)
+- **Routes:**
+  - `POST /scheduling/<tid>/events/reorder-friday` → [routes/scheduling/events.py:473](../routes/scheduling/events.py#L473) `reorder_friday_events()` — writes `schedule_config['friday_event_order']`
+  - `POST /scheduling/<tid>/events/reorder-saturday` → [routes/scheduling/events.py:492](../routes/scheduling/events.py#L492) `reorder_saturday_events()` — writes `schedule_config['saturday_event_order']`
+  - `POST /scheduling/<tid>/events/reset-order` → [routes/scheduling/events.py:511](../routes/scheduling/events.py#L511) `reset_event_order()` — pops keys
+- **Writes:** `Tournament.schedule_config` keys only
+- **Reads:** existing config
+- **Idempotent:** yes
+- **Undo:** reset_event_order
+
+### Step 14 — Manual flight-heat reorder (Saturday show order)
+- **UI:** Heat Sheets page → drag-drop heat cards within a flight (SortableJS in [templates/scheduling/heat_sheets_print.html](../templates/scheduling/heat_sheets_print.html))
+- **Route:** `POST /scheduling/<tid>/flights/<fid>/reorder` → [routes/scheduling/flights.py:130](../routes/scheduling/flights.py#L130) `reorder_flight_heats()`
+- **Writes:** `Heat.flight_position` for each heat in specified order
+- **Reads:** flight's current heats
+- **Idempotent:** yes — validates heat_id set matches before applying
+- **Undo:** manual re-drag
+
+### Step 15 — Assign handicap marks (STRATHMARK, handicap events only)
+- **UI:** Events list → per-event "Assign Marks" (appears only for handicap-eligible events)
+- **Route:** `GET/POST /scheduling/<tid>/events/<eid>/assign-marks` → [routes/scheduling/assign_marks.py](../routes/scheduling/assign_marks.py)
+- **Writes:** `EventResult.handicap_factor`, `EventResult.predicted_time`
+- **Reads:** competitor history from STRATHMARK
+- **Idempotent:** yes — can re-run
+- **Undo:** re-run or edit EventResult
+
+### Step 16 — Print heat sheets (Saturday flights)
+- **UI:** Sidebar → Heat Sheets
+- **Route:** `GET /scheduling/<tid>/heat-sheets` → [routes/scheduling/heat_sheets.py](../routes/scheduling/heat_sheets.py) `heat_sheets()`
+- **Template:** [templates/scheduling/heat_sheets_print.html](../templates/scheduling/heat_sheets_print.html)
+- **Writes:** none (read-only render)
+- **Reads:** `Flight.get_heats_ordered()` ([models/heat.py](../models/heat.py) Flight class), `Heat.competitors`, `Heat.stand_assignments`, `EventResult.status`
+- **Idempotent:** trivially yes
+
+### Step 17 — Print day schedule
+- **UI:** Sidebar → Day Schedule (Print)
+- **Route:** `GET /scheduling/<tid>/day-schedule-print` → [routes/scheduling/heat_sheets.py](../routes/scheduling/heat_sheets.py) `day_schedule_print()` → calls `schedule_builder.build_day_schedule()`
+- **Template:** [templates/scheduling/day_schedule_print.html](../templates/scheduling/day_schedule_print.html)
+- **Writes:** none
+- **Reads:** schedule_config, events, flights (for saturday_show block when flights exist)
+- **Idempotent:** yes
+
+### Step 18 — Print judge sheets / heat sheet PDF
+- **UI:** Score entry page → "Print Judge Sheets" OR per-heat PDF
+- **Routes:**
+  - `GET /scoring/<tid>/heat/<hid>/pdf` → heat sheet PDF (WeasyPrint or print-HTML fallback)
+  - Per-event judge sheet (inside scoring blueprint)
+- **Writes:** none
+- **Reads:** Heat + Event + EventResult
+
+---
+
+## Task 2 — Manual reordering feature status
+
+**Status: IMPLEMENTED.**
+
+**SortableJS is present.** CDN loaded at [templates/scheduling/events.html:1108](../templates/scheduling/events.html#L1108) (`sortablejs@1.15.2`). Also referenced in:
+- [templates/scheduling/heat_sheets_print.html](../templates/scheduling/heat_sheets_print.html) (flight-heat drag-drop)
+- [templates/scheduling/ability_rankings.html](../templates/scheduling/ability_rankings.html) (ability ranks)
+- [templates/proam_relay/manual_teams.html](../templates/proam_relay/manual_teams.html) (relay teams)
+- [templates/portal/user_guide.html](../templates/portal/user_guide.html) (reference)
+
+### Routes and storage
+
+| Scope | Route | Handler | Writes | Reader |
+|---|---|---|---|---|
+| Friday event order | `POST /scheduling/<tid>/events/reorder-friday` | [events.py:473](../routes/scheduling/events.py#L473) `reorder_friday_events()` | `schedule_config['friday_event_order']` (JSON list[int]) | `schedule_builder._build_friday_day_block(custom_order=...)` [schedule_builder.py:93](../services/schedule_builder.py#L93) |
+| Saturday event order (fallback) | `POST /scheduling/<tid>/events/reorder-saturday` | [events.py:492](../routes/scheduling/events.py#L492) `reorder_saturday_events()` | `schedule_config['saturday_event_order']` (JSON list[int]) | `schedule_builder._build_saturday_from_event_order(custom_order=...)` [schedule_builder.py:213](../services/schedule_builder.py#L213) — used **only when no flights exist** |
+| Flight heat order | `POST /scheduling/<tid>/flights/<fid>/reorder` | [flights.py:130](../routes/scheduling/flights.py#L130) `reorder_flight_heats()` | `Heat.flight_position` per heat | `Flight.get_heats_ordered()` [models/heat.py:198](../models/heat.py#L198) |
+| Reset order | `POST /scheduling/<tid>/events/reset-order` | [events.py:511](../routes/scheduling/events.py#L511) `reset_event_order()` | removes `friday_event_order` / `saturday_event_order` keys | n/a |
+| Ability ranks | `POST /scheduling/<tid>/ability-rankings/save` | ability_rankings.py | `ProEventRank` rows | heat_generator snake-draft |
+| Manual relay teams | `POST /proam-relay/...` | proam_relay | ProAmRelay state | proam_relay service |
+
+**Critical subtlety:** `schedule_config['saturday_event_order']` is **advisory only when flights are NOT built**. Once `build_pro_flights()` has created flights, `_build_saturday_from_flights()` at [schedule_builder.py:163](../services/schedule_builder.py#L163) is used instead — it iterates `Flight.query.order_by(flight_number).all()` and calls `flight.get_heats_ordered()`. The `saturday_event_order` key is silently ignored in that path. This is the key structural fact for block alternation: **once flights exist, `Flight.flight_number` + `Heat.flight_position` are authoritative for the pro show.**
+
+---
+
+## Task 3 — College heat/flight pipeline
+
+**College does NOT use the flight builder.** There is no `build_college_flights()`.
+
+College heat generation:
+- Same `generate_event_heats()` [services/heat_generator.py:85](../services/heat_generator.py#L85) as pro, dispatched by `event.event_type=='college'`.
+- Output: `Heat` rows with `heat_number` ascending, `run_number=1` (plus `run_number=2` for dual-run events Chokerman / Speed Climb).
+- No `Flight` rows are created for college. `Heat.flight_id` stays NULL for college heats unless integrated via Saturday spillover.
+
+Friday college day run order:
+- Built by `schedule_builder._build_friday_day_block(events, custom_order=...)` at [schedule_builder.py:93](../services/schedule_builder.py#L93).
+- If `schedule_config['friday_event_order']` present: `_apply_custom_order(events, custom_order)` applies it.
+- Else: `sorted(events, key=_college_friday_sort_key)` — config-default order (OPEN events first, CLOSED in config order, Chokerman Run 1 near end, Birling last).
+- Within each event: heats render in `Heat.heat_number` ascending order (hydration at [heat_sheets.py:104-106](../routes/scheduling/heat_sheets.py#L104-L106): `event.heats.order_by(Heat.heat_number, Heat.run_number)`).
+
+Answer to (a) / (b) / (c):
+- **Between events:** (c) — explicit `friday_event_order` list when present, otherwise (a) config-default sort. No algorithmic optimization. No tier interleaving.
+- **Within an event:** (a) — `heat_number` ascending.
+
+Authoritative source for "first heat on Friday":
+- **Between events:** `schedule_config['friday_event_order'][0]` if set, else first event from `_college_friday_sort_key`.
+- **Within that event:** `min(Heat.heat_number)` with `run_number=1`.
+
+Saturday college overflow: Friday spillover events listed in `schedule_config['saturday_college_event_ids']` get their heats integrated into pro flights via `integrate_college_spillover_into_flights()`. Once integrated, their position is determined by `Heat.flight_id` + `Heat.flight_position` exactly like pro heats.
+
+---
+
+## Task 4 — Pro heat/flight pipeline
+
+`build_pro_flights(tournament, num_flights=None)` — [services/flight_builder.py:59](../services/flight_builder.py#L59)
+
+### When it runs
+- Manual: `POST /scheduling/<tid>/flights/build` → [flights.py:57](../routes/scheduling/flights.py#L57) `build_flights()`
+- Auto-triggered from `event_list()` POST with `action='rebuild_flights'` or `action='generate_all'` bulk path
+- Async wrapper via `submit_job()` in preflight/async routes
+
+### Idempotency
+**Not idempotent in the "side-effect-free" sense — it is destructive and rebuilt-from-scratch**, but **deterministic** so the same input yields the same output:
+
+1. Lines [79-87](../services/flight_builder.py#L79-L87): delete all existing `Flight` rows for the tournament, null out `Heat.flight_id` and `Heat.flight_position` on all affected heats.
+2. Re-load all non-axe pro heats (`run_number==1` only), ordered by `(event_id, heat_number)`.
+3. Pre-compute gear-sharing conflict pairs.
+4. Call `_optimize_heat_order(all_heats, heats_per_flight, N_OPTIMIZATION_PASSES=5, gear_conflict_pairs)` at [line 145](../services/flight_builder.py#L145).
+5. Create new `Flight` rows, assign heats with `flight_position=1,2,3,...`.
+6. Inject Partnered Axe show heats (rebuilt via `_prepare_partnered_axe_show_heats()`, these call `heat.sync_assignments('pro')` around [line 268](../services/flight_builder.py#L268)).
+7. Commit.
+
+Re-running with unchanged heats produces the same `(flight_number, flight_position)` tuple for every heat.
+
+### `_optimize_heat_order()` — [flight_builder.py:328](../services/flight_builder.py#L328)
+
+**Inputs:**
+- `all_heats`: list of `{'heat': Heat, 'event': Event, 'competitors': set[int]}`
+- `heats_per_flight`: int, default 8 (or derived from `num_flights`)
+- `n_passes`: `N_OPTIMIZATION_PASSES = 5`
+- `gear_conflict_pairs`: `dict[int, set[int]]`
+
+**Deterministic — NOT randomized.** [flight_builder.py:369-381](../services/flight_builder.py#L369-L381):
+```python
+actual_passes = min(n_passes, max(1, len(event_ids)))
+for pass_num in range(actual_passes):
+    rotated = event_ids[pass_num:] + event_ids[:pass_num]   # <— rotation, not shuffle
+    candidate = _single_pass_optimize(event_queues, rotated, heats_per_flight,
+                                      gear_conflict_pairs=gear_conflict_pairs)
+    score = _score_ordering(candidate, heats_per_flight,
+                            gear_conflict_pairs=gear_conflict_pairs)
+    if score > best_score:
+        best_score = score
+        best_ordered = candidate
+```
+No `random.*` call in the file. Same input → same output every time. Tie-breaking uses "prefer event with most remaining heats" — deterministic.
+
+### Authoritative source for "first heat on Saturday"
+When flights exist:
+- `Flight.query.filter_by(tournament_id=tid).order_by(Flight.flight_number).first()` → earliest flight
+- Within that flight: `flight.get_heats_ordered()` [models/heat.py:198](../models/heat.py#L198), which returns heats sorted by `(flight_position IS NULL, flight_position, id)`. First heat of first flight = first heat of the show.
+
+This is the pro show's only truth.
+
+---
+
+## Task 5 — State lock points
+
+| Event | Immutable after this point? | Guard | File:line |
+|---|---|---|---|
+| Registration close | No hard lock. Tournament status transitions `setup → college_active → pro_active → completed` are by convention. | `Tournament.status` enum; routes don't block re-registration after status change | `models/tournament.py` |
+| Heat generation complete | No — heats can be regenerated. | Hard guard: `event.is_finalized==True` blocks regen. Soft warning when scored results exist. | [routes/scheduling/heats.py](../routes/scheduling/heats.py) `generate_heats()` |
+| Flight build complete | No — `build_pro_flights()` rebuilds destructively every call. | No lock. | [services/flight_builder.py:59](../services/flight_builder.py#L59) |
+| "Lock schedule" / "finalize show-prep" | **Does not exist.** There is no tournament-wide schedule-lock action. Finalization is per-event (`Event.is_finalized`). | n/a | n/a |
+| First heat scored | Per-heat edit lock via `Heat.acquire_lock(user_id)` + `locked_at` column; TTL = `HEAT_LOCK_TTL_SECONDS=300`. Prevents concurrent judges editing same heat. **Does not prevent heat regeneration**. | Soft lock, expiring | [models/heat.py:152](../models/heat.py#L152) |
+| Event finalized (`Event.is_finalized=True`) | Blocks heat regeneration. Payout config saves trigger a recalculation of positions. | `Event.is_finalized` Boolean; checked in `routes/scheduling/heats.py` generate_heats | [models/event.py](../models/event.py) |
+| Flight started | Soft indicator only. `Flight.status='in_progress'` set by `start_flight()` route; triggers SMS notifications; **does NOT block reorder or rebuild**. | Convention | [routes/scheduling/flights.py:155](../routes/scheduling/flights.py#L155) |
+
+**Key implication for block alternation:** There is no hard "schedule-is-locked" gate. Any stand-assignment write that happens between heat-gen and show-time is legitimate, as long as it respects `event.is_finalized` and the transient `Heat.acquire_lock()` during score entry.
+
+---
+
+## Task 6 — Post-generation mutation hooks
+
+| Operation | Route / Handler | Mutates | Calls `sync_assignments()`? |
+|---|---|---|---|
+| Regenerate heats (one event) | `POST /scheduling/<tid>/event/<eid>/generate-heats` → `generate_heats()` → `generate_event_heats()` | Deletes existing `Heat` rows for event, creates new ones with fresh `stand_assignments` JSON. | Yes — [heat_generator.py:226-227](../services/heat_generator.py#L226-L227) per created heat |
+| Regenerate flights only (heats unchanged) | `POST /scheduling/<tid>/events` action=`rebuild_flights` and `POST /scheduling/<tid>/flights/build` | Clobbers `Flight` rows and `Heat.flight_id`/`Heat.flight_position`. Does **not** rewrite `Heat.stand_assignments` for existing heats. Does rewrite stand_assignments on rebuilt Partnered Axe heats. | Yes, for Partnered Axe rebuild (line ~268); non-axe heats: no, because their stand_assignments are unchanged |
+| Move competitor between heats | `POST /scheduling/<tid>/event/<eid>/heats/swap` (or move) → `move_competitor_between_heats()` | Updates both heats' `competitors` JSON + `stand_assignments` | Yes — both heats synced |
+| Scratch competitor | `POST /scheduling/<tid>/event/<eid>/heats/scratch` → `scratch_competitor()` | Removes competitor from `Heat.competitors`; deletes `HeatAssignment` row; sets `EventResult.status='scratched'` | Not explicit — scratch path modifies HeatAssignment directly |
+| Manual stand reassignment within heat | Heat edit UI → calls `heat.set_stand_assignment(comp_id, stand)` directly in handler | `Heat.stand_assignments` JSON | Caller responsible; `sync_assignments` not universally called post-write |
+| Sync check / sync fix | `GET /scheduling/<tid>/heats/sync-check` (JSON), `POST /scheduling/<tid>/heats/sync-fix` | Re-derives `HeatAssignment` rows from the JSON (authoritative) | Yes — that IS the sync operation |
+| Integrate college spillover | `POST /scheduling/<tid>/events` action=`integrate_spillover` → `integrate_college_spillover_into_flights()` | Sets `Heat.flight_id` + `Heat.flight_position` on selected college heats | No — doesn't touch stand_assignments |
+| Reorder flight heats | `POST /scheduling/<tid>/flights/<fid>/reorder` | `Heat.flight_position` only | No |
+| Partner reassignment during score entry (`partner_resolver`) | scoring blueprint | May update partner linkage; does not mutate `stand_assignments` directly | n/a |
+
+---
+
+## Task 7 — Print export timing
+
+| Export | Route | Reads | Before heats generated | Before flights built | Depends on Flight order? |
+|---|---|---|---|---|---|
+| Heat sheets | `GET /scheduling/<tid>/heat-sheets` → [heat_sheets.py](../routes/scheduling/heat_sheets.py) `heat_sheets()` | `Flight` rows, `flight.get_heats_ordered()`, `Heat.competitors`, `Heat.stand_assignments`, `_stand_label()` | Renders with empty flight list; no heat cards | Renders — heats show grouped by event, not flight, since flight_id is NULL | Yes for pro (flight-grouped view). College heat section renders heats in `heat_number` order regardless. |
+| Judge sheets all | `GET /scoring/<tid>/judge-sheets` → scoring blueprint | Event.heats.order_by(heat_number), `Heat.competitors`, `Heat.stand_assignments`, `EventResult.status` | Flashes "No events with heats available"; redirects | Works fine — judge sheets use event-level heat_number order, not flight order | **No** — depends only on Heat data |
+| Day schedule print | `GET /scheduling/<tid>/day-schedule-print` → `day_schedule_print()` → `build_day_schedule()` [schedule_builder.py:37](../services/schedule_builder.py#L37) | `schedule_config` (friday_pro_event_ids, saturday_college_event_ids, friday_event_order, saturday_event_order), Event rows, `Flight.get_heats_ordered()` when flights exist | Renders event names + slot numbers; heat detail empty | Saturday show block falls back to `_build_saturday_from_event_order()` (uses `saturday_event_order` custom_order or pro_sort_key); Friday day block unaffected | Yes for Saturday once flights exist (flights-first at [schedule_builder.py:155-157](../services/schedule_builder.py#L155-L157)); No for Friday |
+| Video judge workbook | `POST /reporting/<tid>/export-video-judge` (sync) or `POST /reporting/<tid>/export-video-judge-async` (async) → `services/video_judge_export.py` | Event + Heat + EventResult; bracket events from `BirlingBracket` | Likely empty workbook or error | Works — reads heat data directly | **No** — heat data is enough |
+| Birling blank bracket | Under birling routes (e.g. `GET /scheduling/<tid>/birling/print`) | `Event.payouts` bracket JSON | Renders blank bracket (bracket is pre-seeded from registration, not heats) | Works | **No** — bracket is its own structure |
+
+Summary: only **Heat Sheets** and **Day Schedule (Saturday block)** depend on Flight ordering. Judge sheets, video judge workbook, and birling bracket are Flight-independent.
+
+---
+
+## Task 8 — Regenerate / rebuild / redo / reset semantics
+
+| Name | Route / Handler | Rebuilds | Guards | Downstream staleness |
+|---|---|---|---|---|
+| `generate_heats` | `POST /scheduling/<tid>/event/<eid>/generate-heats` → `generate_heats()` | Full heat set for one event | Hard: `event.is_finalized==True` blocks. Soft: `has_scored` confirmation warning. | Orphans `EventResult` rows that still point to old competitor IDs; flight assignments lost for that event |
+| `generate_all_college` | `POST /scheduling/<tid>/events` action=`generate_all_college` | All college event heats | Same as above per event | Same |
+| `rebuild_flights` | `POST /scheduling/<tid>/events` action=`rebuild_flights` AND `POST /scheduling/<tid>/flights/build` | All `Flight` rows + all `Heat.flight_id` assignments | None | Saturday day schedule re-derives; any manual `reorder_flight_heats` changes lost |
+| `integrate_spillover` | `POST /scheduling/<tid>/events` action=`integrate_spillover` | Sets `Heat.flight_id` for selected college events | None | Re-running overwrites previous integration |
+| `reset_event_order` | `POST /scheduling/<tid>/events/reset-order` | Removes `friday_event_order` / `saturday_event_order` keys | None — idempotent | Day schedule reverts to default sort |
+| `birling_reset` | Birling routes — resets bracket state | Clears bracket from `Event.payouts` JSON | Usually requires event not in progress | All bracket results lost |
+| `sync-fix` | `POST /scheduling/<tid>/heats/sync-fix` | Rebuilds `HeatAssignment` rows from `Heat.competitors` + `Heat.stand_assignments` JSON (JSON is authoritative) | None — idempotent | None |
+| Pro-Am Relay redraw / manual rebuild | `POST /proam-relay/...` | Relay state in `Event.payouts` JSON | Relay state-machine guards | Relay teams reshuffled |
+
+---
+
+## Task 9 — `Tournament.schedule_config` JSON schema
+
+Model helpers: `Tournament.get_schedule_config()` / `Tournament.set_schedule_config(dict)` on [models/tournament.py](../models/tournament.py).
+
+Observed keys (grep + schedule_builder + friday_feature confirm):
+
+| Key | Type | Writer | Reader | Role |
+|---|---|---|---|---|
+| `friday_pro_event_ids` | `list[int]` (Event IDs) | [friday_feature.py:77](../routes/scheduling/friday_feature.py#L77) `friday_feature()` POST | `friday_feature()` GET; `build_day_schedule()` [schedule_builder.py:52](../services/schedule_builder.py#L52) | **Authoritative** — which pro events run in Friday Night Feature |
+| `saturday_college_event_ids` | `list[int]` | `friday_feature()`, `event_list()` | `build_day_schedule()` [schedule_builder.py:60](../services/schedule_builder.py#L60); `integrate_college_spillover_into_flights()` | **Authoritative** — which college events spill to Saturday |
+| `friday_event_order` | `list[int]` (Event IDs in order) | [events.py:473](../routes/scheduling/events.py#L473) `reorder_friday_events()` | `_build_friday_day_block(custom_order=...)` [schedule_builder.py:93](../services/schedule_builder.py#L93) | **Authoritative** when present; advisory when absent (default sort kicks in) |
+| `saturday_event_order` | `list[int]` | [events.py:492](../routes/scheduling/events.py#L492) `reorder_saturday_events()` | `_build_saturday_from_event_order(custom_order=...)` [schedule_builder.py:213](../services/schedule_builder.py#L213) | Authoritative **only as fallback when no flights exist**. Ignored entirely when `Flight` rows are present (flights-first path at [schedule_builder.py:155-157](../services/schedule_builder.py#L155-L157)). |
+| `friday_feature_notes` | `str` | `friday_feature()` POST | `friday_feature()` GET | Advisory — display metadata |
+
+No other keys observed in code. `get_schedule_config()` returns `{}` default; setters write minimal diffs.
+
+---
+
+## Task 10 — Every stand_assignments mutation site
+
+Grep for `set_stand_assignment`, `stand_assignments`, direct writes.
+
+| File : line | Function | What it does |
+|---|---|---|
+| [models/heat.py:52-53](../models/heat.py#L52-L53) | `Heat.stand_assignments` column declaration | `db.Text, nullable=False, default='{}'` — JSON-encoded dict `{str(comp_id): int(stand_number)}` |
+| [models/heat.py:103-108](../models/heat.py#L103-L108) | `Heat.get_stand_assignments()` | Read-only loader; returns `{}` on JSONDecodeError |
+| [models/heat.py:110-114](../models/heat.py#L110-L114) | `Heat.set_stand_assignment(comp_id, stand_number)` | **Primary mutation API.** Loads JSON, updates `dict[str(comp_id)]=stand_number`, serializes back. |
+| [models/heat.py:121-135](../models/heat.py#L121-L135) | `Heat.sync_assignments(competitor_type)` | Deletes all `HeatAssignment` rows for this heat, recreates from `competitors` JSON + `stand_assignments` JSON. Must be called after `db.session.flush()` so `heat.id` exists. |
+| [services/heat_generator.py:181](../services/heat_generator.py#L181) | `generate_event_heats()` partnered branch | `heat.set_stand_assignment(comp['id'], stand_num)` for each competitor in each pair-unit |
+| [services/heat_generator.py:186](../services/heat_generator.py#L186) | `generate_event_heats()` non-partnered branch | `heat.set_stand_assignment(comp['id'], stand_num)` per competitor |
+| [services/heat_generator.py:210](../services/heat_generator.py#L210) | `generate_event_heats()` partnered dual-run branch | Assigns reversed stands for run 2 |
+| [services/heat_generator.py:217](../services/heat_generator.py#L217) | `generate_event_heats()` non-partnered dual-run branch | Assigns reversed stands for run 2 |
+| [services/heat_generator.py:227](../services/heat_generator.py#L227) | `generate_event_heats()` | Calls `heat.sync_assignments(comp_type)` for each created heat |
+| [services/flight_builder.py](../services/flight_builder.py) around line 262 (per Explore agent finding) | `_prepare_partnered_axe_show_heats()` | Assigns stand=1 for all competitors in Partnered Axe finals heats; calls `heat.sync_assignments('pro')` at ~line 268 |
+| [routes/scheduling/heats.py](../routes/scheduling/heats.py) `move_competitor_between_heats()` | Move handler | Updates `from_heat.competitors`, `to_heat.competitors`, both `stand_assignments`; calls `sync_assignments` on both heats |
+| [routes/scheduling/heats.py](../routes/scheduling/heats.py) `scratch_competitor()` | Scratch handler | Removes competitor from `Heat.competitors`; deletes `HeatAssignment` row directly; does not call `sync_assignments` explicitly |
+| Sync fix route (`/heats/sync-fix` POST) | Recovery | Calls `heat.sync_assignments(comp_type)` for each heat to rebuild `HeatAssignment` table |
+
+**Surface area for block-alternation hook:** the two calls at [heat_generator.py:181](../services/heat_generator.py#L181) and [heat_generator.py:186](../services/heat_generator.py#L186) (initial heat gen) plus `_prepare_partnered_axe_show_heats()` (Partnered Axe only, irrelevant for saw events) plus the manual move path (`move_competitor_between_heats`). A post-flight rewrite step would need its own call site — none exists today.
+
+---
+
+## Sequential workflow — chronological summary (Task 1 condensed)
+
+1. Create tournament (`status='setup'`).
+2. Configure events (college + pro) on `/tournament/<tid>/setup`.
+3. Import / register college teams + competitors.
+4. Register pro competitors (manual + import pipeline).
+5. Resolve gear-sharing via Gear Sharing Manager.
+6. Select Friday Night Feature + Saturday college spillover events (writes `schedule_config` keys).
+7. Rank pro competitors per event category (`ProEventRank`, SortableJS UI).
+8. (Optional) Run Preflight checks.
+9. Generate college heats (per-event or bulk). `Heat` + `HeatAssignment` rows written; `stand_assignments` JSON populated.
+10. Generate pro heats (same).
+11. Build pro flights — deterministic 5-pass greedy optimization. Creates `Flight` rows, sets `Heat.flight_id` + `Heat.flight_position`.
+12. Integrate Saturday college spillover into flights.
+13. (Optional) Drag-drop reorder of Friday events → `schedule_config['friday_event_order']`.
+14. (Optional) Drag-drop reorder of flight heats → `Heat.flight_position`.
+15. (Optional) Assign handicap marks per handicap-eligible event (STRATHMARK).
+16. Print heat sheets (reads `Flight.get_heats_ordered()` + `stand_assignments`).
+17. Print day schedule (reads `schedule_config` + flights).
+18. Print judge sheets / per-heat PDFs (reads heat data only).
+19. Run the show.
+
+---
+
+## Authoritative statements
+
+> **The authoritative source for global heat run order on Friday is** `schedule_config['friday_event_order']` when present (else the `_college_friday_sort_key` default order over configured events), combined with `Heat.heat_number` (ascending, `run_number=1`) within each event. Dual-run college events show only run 1 on Friday; Chokerman Run 2 + Speed Climb Run 2 are forced to Saturday by [schedule_builder._add_mandatory_day_split_run2](../services/schedule_builder.py).
+
+> **The authoritative source for global heat run order on Saturday is** `Flight.flight_number` ascending, then `Heat.flight_position` ascending within each flight (via `Flight.get_heats_ordered()` at [models/heat.py:198](../models/heat.py#L198)), when flights exist. When no flights exist (pre-build or rebuild-failed state), the fallback is `_build_saturday_from_event_order()` with `schedule_config['saturday_event_order']` custom order or `_pro_sort_key` default. The fallback is the only case where `saturday_event_order` is read.
+
+---
+
+## Mutation windows for stand assignments
+
+Every point in the workflow where `Heat.stand_assignments` can legitimately change:
+
+1. **Heat generation** — [heat_generator.py:181](../services/heat_generator.py#L181) and [heat_generator.py:186](../services/heat_generator.py#L186). Run 1 assignment.
+2. **Heat generation, dual-run events** — [heat_generator.py:210](../services/heat_generator.py#L210) and [heat_generator.py:217](../services/heat_generator.py#L217). Run 2 gets reversed stands (stands reversed relative to heat composition, not re-assigned per heat index). Saw events are single-run, so this path is inert for hand-saw.
+3. **Heat regeneration (same route as #1)** — same mutation, clobbers previous.
+4. **Move competitor between heats** — `move_competitor_between_heats()` updates stand_assignments for both source and destination heat.
+5. **Scratch competitor** — removes entry from stand_assignments JSON (via HeatAssignment delete; JSON may need explicit cleanup — confirm on implementation).
+6. **Partnered Axe show heat rebuild** — during `build_pro_flights()` → `_prepare_partnered_axe_show_heats()`. Assigns all finalists to stand 1 of their show heat.
+7. **Sync fix route** — does NOT change `stand_assignments` JSON; it rebuilds the `HeatAssignment` cache from the JSON. But the JSON is authoritative and unchanged.
+8. **Manual stand reassignment via heat editor** — direct `heat.set_stand_assignment()` call in edit handler (if such a route is surfaced; exists in handler layer but no dedicated UI found in this recon).
+
+**Windows where no stand_assignment mutation currently happens but could be added:**
+- After `build_pro_flights()` completes (global run-order is now known).
+- After `reorder_flight_heats()` (manual reorder has set final run order).
+- Inside `_optimize_heat_order()` as a post-step once heat placement is chosen.
+- At heat-sheet render time (compute block labels on the fly without persisting).
+
+For a hand-saw block-alternation design, windows 2–4 above are the candidate hook points, depending on whether alternation is computed eagerly (heat-gen time, risks being broken by later flight reshuffle) or lazily (after `reorder_flight_heats` or at render time, more accurate but touches more of the pipeline).
+
+---
+
+## Corrections vs. the earlier recon drafts
+
+During this recon the following initial findings from the sub-agent were verified and partially corrected:
+
+- **SortableJS is present in multiple templates**, not absent. Confirmed at [templates/scheduling/events.html:1108](../templates/scheduling/events.html#L1108).
+- **`_optimize_heat_order()` is deterministic**, not randomized. Uses rotation of event-id order across 5 passes; best score wins. No `random.*` call in the file.
+- **`saturday_event_order` is only consulted when no flights exist.** Once `Flight` rows are present, `_build_saturday_from_flights()` takes precedence and the custom order is silently ignored.
+- **There is no tournament-wide "lock schedule" action.** Finalization is per-event (`Event.is_finalized`). The only other lock is the 300-second `Heat.acquire_lock()` during concurrent score entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.9.1"
+version = "2.10.0"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.9.1',
+        'version': '2.10.0',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.9.1',
+        'version': '2.10.0',
     })
 
 

--- a/routes/scheduling/events.py
+++ b/routes/scheduling/events.py
@@ -45,6 +45,8 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
     back that step without corrupting the whole session (heat generation already
     commits per-event; flight building commits at the end of build_pro_flights).
     """
+    from services.saw_block_assignment import trigger_saw_block_recompute
+
     action = request.form.get('action', '')
     tournament_id = tournament.id
 
@@ -66,6 +68,7 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
                     'total_heats': sum(post_snap.values()),
                 }
                 session.modified = True
+            trigger_saw_block_recompute(tournament)
         except Exception as exc:
             db.session.rollback()
             flash(f'Heat/flight generation failed and was rolled back: {exc}', 'error')
@@ -87,6 +90,7 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
                     'total_heats': sum(post_snap.values()),
                 }
                 session.modified = True
+            trigger_saw_block_recompute(tournament)
         except Exception as exc:
             db.session.rollback()
             flash(f'Flight rebuild failed and was rolled back: {exc}', 'error')
@@ -98,6 +102,7 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
             flash(integration['message'], 'info')
             if integration['integrated_heats'] > 0:
                 flash(f"Integrated {integration['integrated_heats']} heat(s) into flights.", 'success')
+            trigger_saw_block_recompute(tournament)
         except Exception as exc:
             db.session.rollback()
             flash(f'Spillover integration failed: {exc}', 'error')
@@ -485,6 +490,10 @@ def reorder_friday_events(tournament_id):
     tournament.set_schedule_config(cfg)
     db.session.commit()
     log_action('friday_event_order_set', 'tournament', tournament_id, {'order': event_ids})
+
+    from services.saw_block_assignment import trigger_saw_block_recompute
+    trigger_saw_block_recompute(tournament)
+
     return jsonify({'ok': True})
 
 
@@ -532,6 +541,10 @@ def reset_event_order(tournament_id):
     tournament.set_schedule_config(cfg)
     db.session.commit()
     log_action('event_order_reset', 'tournament', tournament_id, {'day': day or 'both'})
+
+    from services.saw_block_assignment import trigger_saw_block_recompute
+    trigger_saw_block_recompute(tournament)
+
     return jsonify({'ok': True})
 
 

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -103,6 +103,8 @@ def build_flights(tournament_id):
             log_action('flights_built', 'tournament', tournament_id, {'count': built})
             db.session.commit()
             flash(text.FLASH['flights_built'].format(num_flights=built), 'success')
+            from services.saw_block_assignment import trigger_saw_block_recompute
+            trigger_saw_block_recompute(tournament)
         except Exception as e:
             flash(text.FLASH['flights_error'].format(error=str(e)), 'error')
 
@@ -129,7 +131,7 @@ def build_flights(tournament_id):
 @scheduling_bp.route('/<int:tournament_id>/flights/<int:flight_id>/reorder', methods=['POST'])
 def reorder_flight_heats(tournament_id, flight_id):
     """Reorder heats within a flight. Expects JSON {heat_ids: [int, ...]}."""
-    Tournament.query.get_or_404(tournament_id)
+    tournament = Tournament.query.get_or_404(tournament_id)
     flight = Flight.query.filter_by(id=flight_id, tournament_id=tournament_id).first_or_404()
     try:
         data = request.get_json(force=True)
@@ -145,6 +147,10 @@ def reorder_flight_heats(tournament_id, flight_id):
         existing[hid].flight_position = position
     db.session.commit()
     log_action('flight_heats_reordered', 'flight', flight_id, {'order': heat_ids})
+
+    from services.saw_block_assignment import trigger_saw_block_recompute
+    trigger_saw_block_recompute(tournament)
+
     return jsonify({'ok': True})
 
 

--- a/routes/scheduling/heats.py
+++ b/routes/scheduling/heats.py
@@ -150,6 +150,7 @@ def generate_heats(tournament_id, event_id):
 
     # Import heat generation service
     from services.heat_generator import generate_event_heats, get_last_gear_violations
+    from services.saw_block_assignment import trigger_saw_block_recompute
 
     try:
         num_heats = generate_event_heats(event)
@@ -166,6 +167,10 @@ def generate_heats(tournament_id, event_id):
                 f'during heat generation. Review the gear manager before running the show.',
                 'warning'
             )
+        # Recompute hand-saw stand block alternation after heat gen commits.
+        tournament = Tournament.query.get(tournament_id)
+        if tournament is not None:
+            trigger_saw_block_recompute(tournament)
     except Exception as e:
         db.session.rollback()
         flash(text.FLASH['heats_error'].format(error=str(e)), 'error')
@@ -211,6 +216,10 @@ def generate_college_heats(tournament_id):
                 flash(f'Error generating heats for {event.display_name}: {exc}', 'error')
 
     db.session.commit()
+
+    # Recompute hand-saw stand block alternation after bulk college gen.
+    from services.saw_block_assignment import trigger_saw_block_recompute
+    trigger_saw_block_recompute(tournament)
 
     parts = []
     if generated:
@@ -817,3 +826,103 @@ def heat_sync_fix(tournament_id, event_id):
     log_action('heat_assignments_synced', 'event', event_id, {'heats_fixed': fixed})
     flash(f'HeatAssignment table synced for {fixed} heats.', 'success')
     return redirect(url_for('scheduling.event_heats', tournament_id=tournament_id, event_id=event_id))
+
+
+# ---------------------------------------------------------------------------
+# Hand-saw stand block alternation — admin safety valve + status page
+# ---------------------------------------------------------------------------
+
+@scheduling_bp.route('/<int:tournament_id>/heats/recompute-saw-blocks', methods=['POST'])
+def recompute_saw_blocks(tournament_id):
+    """Manually recompute hand-saw stand block assignments for the tournament."""
+    from services.saw_block_assignment import assign_saw_blocks
+
+    tournament = Tournament.query.get_or_404(tournament_id)
+    try:
+        summary = assign_saw_blocks(tournament)
+        flash(
+            f"Saw block assignments recomputed: {summary['heats_updated']} heats updated "
+            f"({summary['friday_saw_heats']} Friday, {summary['saturday_saw_heats']} Saturday).",
+            'success',
+        )
+        log_action('saw_blocks_recomputed', 'tournament', tournament_id, summary)
+    except Exception as exc:
+        flash(f'Saw block recompute failed: {exc}', 'error')
+
+    return redirect(
+        request.referrer
+        or url_for('scheduling.event_list', tournament_id=tournament_id)
+    )
+
+
+@scheduling_bp.route('/<int:tournament_id>/saw-blocks-status')
+def saw_blocks_status(tournament_id):
+    """Per-day status page showing block assignment for every hand-saw heat."""
+    from services.saw_block_assignment import BLOCK_A, SAW_STAND_TYPE
+    from services.schedule_builder import (
+        get_friday_ordered_heats,
+        get_saturday_ordered_heats,
+    )
+
+    tournament = Tournament.query.get_or_404(tournament_id)
+
+    def _rows(ordered_heats):
+        rows = []
+        for heat in ordered_heats:
+            event = heat.event
+            if not event or event.stand_type != SAW_STAND_TYPE:
+                continue
+            assignments = heat.get_stand_assignments()
+            used_stands = sorted({
+                int(v) for v in assignments.values()
+                if v is not None and int(v) > 0
+            })
+            if not used_stands:
+                block_label = '?'
+            else:
+                block_label = 'A' if used_stands[0] in BLOCK_A else 'B'
+            comp_ids = heat.get_competitors()
+            if comp_ids:
+                if event.event_type == 'college':
+                    name_map = {
+                        c.id: c.display_name
+                        for c in CollegeCompetitor.query.filter(
+                            CollegeCompetitor.id.in_(comp_ids)
+                        ).all()
+                    }
+                else:
+                    name_map = {
+                        c.id: c.display_name
+                        for c in ProCompetitor.query.filter(
+                            ProCompetitor.id.in_(comp_ids)
+                        ).all()
+                    }
+            else:
+                name_map = {}
+            names = [name_map.get(int(cid), f'ID:{cid}') for cid in comp_ids]
+            rows.append({
+                'heat_id': heat.id,
+                'event_name': event.display_name,
+                'heat_number': heat.heat_number,
+                'block': block_label,
+                'stands': used_stands,
+                'competitors': names,
+            })
+        return rows
+
+    friday_rows = _rows(get_friday_ordered_heats(tournament))
+    saturday_rows = _rows(get_saturday_ordered_heats(tournament))
+
+    # Re-number run order within each day so the page shows the saw-heat
+    # sequence (1, 2, 3, ...) rather than raw Heat.id or original heat_number.
+    for idx, row in enumerate(friday_rows, start=1):
+        row['run_order'] = idx
+    for idx, row in enumerate(saturday_rows, start=1):
+        row['run_order'] = idx
+
+    return render_template(
+        'scheduling/saw_blocks_status.html',
+        tournament=tournament,
+        friday_rows=friday_rows,
+        saturday_rows=saturday_rows,
+    )

--- a/services/saw_block_assignment.py
+++ b/services/saw_block_assignment.py
@@ -1,0 +1,209 @@
+"""
+Hand-saw stand block alternation service.
+
+Assigns the two physical saw-stand blocks (A = stands 1-4, B = stands 5-8)
+across every hand-saw heat in the tournament so that consecutive hand-saw
+heats in the day's run order land on opposite blocks. This lets the next
+team set in on the free block while the current team runs.
+
+Scope: all events with stand_type == 'saw_hand' — Single Buck, Double Buck,
+Jack & Jill Sawing, across both divisions and genders.
+
+Continuity: the block of heat N+1 depends only on the block of the most
+recent hand-saw heat before it in the day's run order. Non-saw heats
+between two saw heats do NOT reset the alternation.
+
+Day boundary: alternation resets at each day. Friday starts on Block A,
+Saturday starts on Block A, independently.
+
+State source: authoritative run order comes from
+`schedule_builder.get_friday_ordered_heats()` and
+`schedule_builder.get_saturday_ordered_heats()`.
+
+Idempotent. Safe to call after any mutation that affects run order or
+heat composition.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from database import db
+from models import Heat, Tournament
+from services.schedule_builder import (
+    get_friday_ordered_heats,
+    get_saturday_ordered_heats,
+)
+
+logger = logging.getLogger(__name__)
+
+BLOCK_A: list[int] = [1, 2, 3, 4]
+BLOCK_B: list[int] = [5, 6, 7, 8]
+SAW_STAND_TYPE = "saw_hand"
+
+
+def assign_saw_blocks(tournament: Tournament) -> dict:
+    """Recompute and persist hand-saw stand block assignments for every
+    hand-saw heat in the tournament.
+
+    Iterates Friday then Saturday run order, flipping between Block A and
+    Block B at each hand-saw heat encountered. Skips non-saw heats while
+    preserving alternation state. Day boundary resets to Block A.
+
+    Commits once at the end. Rolls back on any exception and re-raises.
+
+    Returns:
+        {
+            'friday_saw_heats': int,
+            'saturday_saw_heats': int,
+            'heats_updated': int,
+            'heats_unchanged': int,
+        }
+    """
+    summary = {
+        "friday_saw_heats": 0,
+        "saturday_saw_heats": 0,
+        "heats_updated": 0,
+        "heats_unchanged": 0,
+    }
+
+    try:
+        # Friday
+        block = BLOCK_A
+        for heat in get_friday_ordered_heats(tournament):
+            event = heat.event
+            if not event or event.stand_type != SAW_STAND_TYPE:
+                continue
+            summary["friday_saw_heats"] += 1
+            changed = remap_heat_to_block(heat, block)
+            if changed:
+                summary["heats_updated"] += 1
+            else:
+                summary["heats_unchanged"] += 1
+            block = BLOCK_B if block is BLOCK_A else BLOCK_A
+
+        # Saturday — day boundary: reset to Block A independent of Friday
+        block = BLOCK_A
+        for heat in get_saturday_ordered_heats(tournament):
+            event = heat.event
+            if not event or event.stand_type != SAW_STAND_TYPE:
+                continue
+            summary["saturday_saw_heats"] += 1
+            changed = remap_heat_to_block(heat, block)
+            if changed:
+                summary["heats_updated"] += 1
+            else:
+                summary["heats_unchanged"] += 1
+            block = BLOCK_B if block is BLOCK_A else BLOCK_A
+
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        raise
+
+    return summary
+
+
+def remap_heat_to_block(heat: Heat, target_block: list[int]) -> bool:
+    """Remap the heat's stand_assignments to use target_block's 4 stand
+    numbers, preserving pair-sharing structure for partnered events.
+
+    Algorithm:
+      1. Load current stand_assignments JSON.
+      2. Collect the unique stand numbers actually in use, sorted ascending.
+      3. Build a slot map: unique[i] -> target_block[i].
+      4. If the mapping is an identity (heat already on target block),
+         return False — no write.
+      5. Apply the slot map via heat.set_stand_assignment().
+      6. Call heat.sync_assignments() with the event's comp type to
+         rebuild HeatAssignment rows.
+      7. Return True.
+
+    Returns:
+        True if any assignment changed, False if no write was needed.
+    """
+    assignments = heat.get_stand_assignments()
+    if not assignments:
+        logger.debug("saw_block: heat %s has no stand_assignments, skipping", heat.id)
+        return False
+
+    # Collect unique stand numbers in use; drop None/0 (unassigned)
+    used_stands = sorted(
+        {
+            int(stand)
+            for stand in assignments.values()
+            if stand is not None and int(stand) > 0
+        }
+    )
+
+    if not used_stands:
+        logger.debug("saw_block: heat %s has no valid stand numbers, skipping", heat.id)
+        return False
+
+    if len(used_stands) > 4:
+        raise ValueError(
+            f"Heat {heat.id} uses {len(used_stands)} unique stands "
+            f"({used_stands}) — exceeds saw block capacity of 4."
+        )
+
+    # Build slot map: sorted-unique -> target_block positions (same length)
+    slot_map = {old: target_block[i] for i, old in enumerate(used_stands)}
+
+    # Identity check — if every old stand already equals its target, no-op
+    if all(old == new for old, new in slot_map.items()):
+        return False
+
+    for comp_id_str, old_stand in list(assignments.items()):
+        if old_stand is None:
+            continue
+        try:
+            old_int = int(old_stand)
+        except (TypeError, ValueError):
+            continue
+        new_stand = slot_map.get(old_int)
+        if new_stand is None:
+            continue
+        try:
+            comp_id_int = int(comp_id_str)
+        except (TypeError, ValueError):
+            continue
+        heat.set_stand_assignment(comp_id_int, new_stand)
+
+    event = heat.event
+    if event and event.event_type in ("college", "pro"):
+        heat.sync_assignments(event.event_type)
+    else:
+        logger.warning(
+            "saw_block: heat %s has unexpected event_type=%r; "
+            "stand_assignments written but HeatAssignment rows not synced",
+            heat.id,
+            getattr(event, "event_type", None),
+        )
+
+    return True
+
+
+def trigger_saw_block_recompute(tournament: Tournament) -> dict | None:
+    """Route-hook wrapper: call assign_saw_blocks, log result, flash on failure.
+
+    Use this inside route handlers after the primary commit so a saw-block
+    failure cannot roll back the route's real work. On exception: logs,
+    flashes a warning, and returns None. On success: logs summary and
+    returns the summary dict.
+    """
+    from flask import current_app, flash
+
+    try:
+        summary = assign_saw_blocks(tournament)
+        current_app.logger.info("saw_blocks recomputed: %s", summary)
+        return summary
+    except Exception as exc:
+        current_app.logger.error(
+            "saw_block_assignment failed: %s", exc, exc_info=True,
+        )
+        flash(
+            "Stand block alternation failed to update. Run it manually "
+            "from the Saw Block Status page.",
+            "warning",
+        )
+        return None

--- a/services/schedule_builder.py
+++ b/services/schedule_builder.py
@@ -370,3 +370,118 @@ def _add_mandatory_day_split_run2(schedule_entries: list[dict], college_events: 
             'is_run2': True,
         })
     return updated
+
+
+# ---------------------------------------------------------------------------
+# Ordered-heats helpers — authoritative per-day run order as Heat rows.
+# Pure reads, no side effects. Consumed by services.saw_block_assignment
+# and safe to call from any route-time context.
+# ---------------------------------------------------------------------------
+
+def get_friday_ordered_heats(tournament: Tournament) -> list:
+    """Return all Friday heats in the authoritative run order.
+
+    Respects schedule_config['friday_event_order'] when present, else falls
+    back to _college_friday_sort_key default. Within each event, heats are
+    ordered by heat_number ascending, run_number=1 only. Excludes dual-run
+    run_number=2 heats (those run Saturday).
+
+    Events selected for Saturday spillover (schedule_config
+    ['saturday_college_event_ids']) or moved to the Friday Night Feature
+    (_extract_collegiate_feature_events) are excluded from the Friday day
+    block, matching the existing _build_friday_day_block() scope.
+    """
+    from models import Heat
+
+    sched_cfg = tournament.get_schedule_config()
+    friday_custom = sched_cfg.get('friday_event_order')
+    saturday_college_ids = set(sched_cfg.get('saturday_college_event_ids') or [])
+
+    college_events = tournament.events.filter_by(event_type='college').all()
+    friday_college = [e for e in college_events if e.id not in saturday_college_ids]
+    friday_college, _ = _extract_collegiate_feature_events(friday_college)
+
+    if friday_custom:
+        ordered_events = _apply_custom_order(friday_college, friday_custom)
+    else:
+        ordered_events = sorted(friday_college, key=_college_friday_sort_key)
+
+    heats: list = []
+    for event in ordered_events:
+        event_heats = (
+            Heat.query
+            .filter_by(event_id=event.id, run_number=1)
+            .order_by(Heat.heat_number)
+            .all()
+        )
+        heats.extend(event_heats)
+    return heats
+
+
+def get_saturday_ordered_heats(tournament: Tournament) -> list:
+    """Return all Saturday heats in the authoritative run order.
+
+    When Flight rows exist: iterates flights by flight_number ascending,
+    calling flight.get_heats_ordered() within each flight. Day-split
+    Run 2 heats are assumed to be attached to flights via the spillover
+    integration; any that are not get appended defensively at the end.
+
+    When no flights exist: falls back to pro heats ordered by event_id +
+    heat_number (run_number=1), using schedule_config['saturday_event_order']
+    when set. Day-split college Run 2 heats are appended at the end
+    (mandatory Saturday placement per CLAUDE.md).
+    """
+    from models import Heat
+
+    flights = (
+        Flight.query
+        .filter_by(tournament_id=tournament.id)
+        .order_by(Flight.flight_number)
+        .all()
+    )
+
+    heats: list = []
+    seen_ids: set[int] = set()
+
+    if flights:
+        for flight in flights:
+            for heat in flight.get_heats_ordered():
+                heats.append(heat)
+                seen_ids.add(heat.id)
+    else:
+        sched_cfg = tournament.get_schedule_config()
+        saturday_custom = sched_cfg.get('saturday_event_order')
+        pro_events = tournament.events.filter_by(event_type='pro').all()
+        if saturday_custom:
+            ordered_events = _apply_custom_order(pro_events, saturday_custom)
+        else:
+            ordered_events = sorted(pro_events, key=lambda e: e.id)
+        for event in ordered_events:
+            event_heats = (
+                Heat.query
+                .filter_by(event_id=event.id, run_number=1)
+                .order_by(Heat.heat_number)
+                .all()
+            )
+            for h in event_heats:
+                heats.append(h)
+                seen_ids.add(h.id)
+
+    # Include dual-run Run 2 heats for day-split college events
+    # (Chokerman's Race, Speed Climb) — their Run 2 is always Saturday.
+    college_events = tournament.events.filter_by(event_type='college').all()
+    for event in college_events:
+        if event.name not in DAY_SPLIT_EVENT_NAMES:
+            continue
+        run2_heats = (
+            Heat.query
+            .filter_by(event_id=event.id, run_number=2)
+            .order_by(Heat.heat_number)
+            .all()
+        )
+        for h in run2_heats:
+            if h.id not in seen_ids:
+                heats.append(h)
+                seen_ids.add(h.id)
+
+    return heats

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -200,6 +200,15 @@
                 <i class="bi bi-file-earmark-spreadsheet sb-icon"></i>
                 <span class="sb-text ms-2">Video Judge Workbook</span>
             </a>
+            {% if tournament.events.filter_by(stand_type='saw_hand').first() %}
+            <a href="{{ url_for('scheduling.saw_blocks_status', tournament_id=tournament.id) }}"
+               class="nav-link sidebar-child {{ 'active' if request.endpoint == 'scheduling.saw_blocks_status' else '' }}"
+               {% if request.endpoint == 'scheduling.saw_blocks_status' %}aria-current="page"{% endif %}
+               title="Saw Block Status">
+                <i class="bi bi-grid-3x3 sb-icon"></i>
+                <span class="sb-text ms-2">Saw Block Status</span>
+            </a>
+            {% endif %}
             <a href="{{ url_for('scheduling.birling_print_all', tournament_id=tournament.id) }}"
                class="nav-link sidebar-child" target="_blank" rel="noopener"
                title="Birling Brackets (seeded, printable)">

--- a/templates/scheduling/saw_blocks_status.html
+++ b/templates/scheduling/saw_blocks_status.html
@@ -1,0 +1,140 @@
+{% extends "base.html" %}
+
+{% block title %}Saw Stand Block Assignments — {{ tournament.name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid mt-3">
+    <nav aria-label="breadcrumb" class="mb-2">
+        <ol class="breadcrumb" style="font-size:0.85rem;">
+            <li class="breadcrumb-item">
+                <a href="{{ url_for('main.tournament_detail', tournament_id=tournament.id) }}">
+                    {{ tournament.name }} {{ tournament.year }}
+                </a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">Saw Block Status</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-start flex-wrap mb-3">
+        <div>
+            <h1 class="h3 mb-1">Saw Stand Block Assignments</h1>
+            <p class="text-muted mb-0" style="font-size:0.9rem;">
+                Block A = stands 1–4 &middot; Block B = stands 5–8 &middot;
+                Consecutive hand-saw heats alternate blocks so the next team sets in
+                while the current team runs.
+            </p>
+        </div>
+        <form method="POST"
+              action="{{ url_for('scheduling.recompute_saw_blocks', tournament_id=tournament.id) }}"
+              class="mt-2 mt-md-0">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-outline-primary btn-sm">
+                <i class="bi bi-arrow-clockwise"></i> Recompute Now
+            </button>
+        </form>
+    </div>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ 'danger' if category == 'error' else category }} py-2">
+                    {{ message }}
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    {# ── Friday ───────────────────────────────────────────────── #}
+    <section class="mb-4">
+        <h2 class="h5 mb-2">Friday</h2>
+        {% if friday_rows %}
+            <div class="table-responsive">
+                <table class="table table-sm table-striped align-middle">
+                    <thead>
+                        <tr>
+                            <th style="width:5rem;">Run Order</th>
+                            <th>Event</th>
+                            <th style="width:5rem;">Heat</th>
+                            <th style="width:7rem;">Stand Block</th>
+                            <th>Stands</th>
+                            <th>Competitors</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in friday_rows %}
+                            <tr>
+                                <td>{{ row.run_order }}</td>
+                                <td>{{ row.event_name }}</td>
+                                <td>Heat {{ row.heat_number }}</td>
+                                <td>
+                                    <span class="badge {% if row.block == 'A' %}bg-primary{% elif row.block == 'B' %}bg-success{% else %}bg-secondary{% endif %}">
+                                        Block {{ row.block }}
+                                    </span>
+                                </td>
+                                <td style="font-variant-numeric:tabular-nums;">
+                                    {{ row.stands|join(', ') if row.stands else '—' }}
+                                </td>
+                                <td style="font-size:0.9rem;">
+                                    {{ row.competitors|join(', ') if row.competitors else '—' }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted">No hand-saw heats scheduled.</p>
+        {% endif %}
+    </section>
+
+    {# ── Saturday ─────────────────────────────────────────────── #}
+    <section class="mb-4">
+        <h2 class="h5 mb-2">Saturday</h2>
+        {% if saturday_rows %}
+            <div class="table-responsive">
+                <table class="table table-sm table-striped align-middle">
+                    <thead>
+                        <tr>
+                            <th style="width:5rem;">Run Order</th>
+                            <th>Event</th>
+                            <th style="width:5rem;">Heat</th>
+                            <th style="width:7rem;">Stand Block</th>
+                            <th>Stands</th>
+                            <th>Competitors</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in saturday_rows %}
+                            <tr>
+                                <td>{{ row.run_order }}</td>
+                                <td>{{ row.event_name }}</td>
+                                <td>Heat {{ row.heat_number }}</td>
+                                <td>
+                                    <span class="badge {% if row.block == 'A' %}bg-primary{% elif row.block == 'B' %}bg-success{% else %}bg-secondary{% endif %}">
+                                        Block {{ row.block }}
+                                    </span>
+                                </td>
+                                <td style="font-variant-numeric:tabular-nums;">
+                                    {{ row.stands|join(', ') if row.stands else '—' }}
+                                </td>
+                                <td style="font-size:0.9rem;">
+                                    {{ row.competitors|join(', ') if row.competitors else '—' }}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="text-muted">No hand-saw heats scheduled.</p>
+        {% endif %}
+    </section>
+
+    <div class="mt-4">
+        <a href="{{ url_for('main.tournament_detail', tournament_id=tournament.id) }}"
+           class="btn btn-link">
+            <i class="bi bi-arrow-left"></i> Back to Tournament
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_saw_block_assignment.py
+++ b/tests/test_saw_block_assignment.py
@@ -1,0 +1,562 @@
+"""
+Tests for services.saw_block_assignment.
+
+Covers block alternation within a saw event, cross-event continuation on
+the same day, non-saw-gap preservation of alternation state, day boundary
+reset, partnered event pair preservation, idempotency, pre-flight vs
+post-flight recompute, and exclusion of non-saw events.
+
+Run:
+    pytest tests/test_saw_block_assignment.py -v
+"""
+
+import json
+import os
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+
+    with _app.app_context():
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture()
+def tournament(db_session):
+    from models import Tournament
+
+    t = Tournament(name="SawBlock Test 2026", year=2026, status="setup")
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+def _make_event(
+    db_session,
+    tournament,
+    name,
+    event_type="college",
+    gender="M",
+    stand_type="saw_hand",
+    is_partnered=False,
+    requires_dual_runs=False,
+):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type=event_type,
+        gender=gender,
+        scoring_type="time",
+        stand_type=stand_type,
+        is_partnered=is_partnered,
+        requires_dual_runs=requires_dual_runs,
+    )
+    db_session.add(e)
+    db_session.flush()
+    return e
+
+
+def _make_flight(db_session, tournament, flight_number):
+    from models.heat import Flight
+
+    f = Flight(tournament_id=tournament.id, flight_number=flight_number)
+    db_session.add(f)
+    db_session.flush()
+    return f
+
+
+def _make_heat(
+    db_session,
+    event,
+    heat_number,
+    competitors,
+    stand_assignments,
+    run_number=1,
+    flight=None,
+    flight_position=None,
+):
+    """Create a Heat with pre-populated competitors + stand_assignments JSON."""
+    from models import Heat
+
+    h = Heat(
+        event_id=event.id,
+        heat_number=heat_number,
+        run_number=run_number,
+        competitors=json.dumps(competitors),
+        stand_assignments=json.dumps(stand_assignments),
+    )
+    if flight is not None:
+        h.flight_id = flight.id
+        h.flight_position = flight_position
+    db_session.add(h)
+    db_session.flush()
+    return h
+
+
+def _assignments(heat):
+    """Convenience: return {int(comp_id): int(stand)} for a heat."""
+    return {int(k): int(v) for k, v in heat.get_stand_assignments().items()}
+
+
+# ---------------------------------------------------------------------------
+# 1. Within-event alternation (college Single Buck, 3 heats)
+# ---------------------------------------------------------------------------
+
+
+def test_within_event_alternation_single_buck(db_session, tournament):
+    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+
+    sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
+
+    # 3 heats of 4 competitors each, all currently on stands 1-4 (Block A)
+    h1 = _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    h2 = _make_heat(
+        db_session,
+        sb,
+        2,
+        competitors=[5, 6, 7, 8],
+        stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+    )
+    h3 = _make_heat(
+        db_session,
+        sb,
+        3,
+        competitors=[9, 10, 11, 12],
+        stand_assignments={"9": 1, "10": 2, "11": 3, "12": 4},
+    )
+
+    summary = assign_saw_blocks(tournament)
+
+    # heat 1 -> Block A (1-4), heat 2 -> Block B (5-8), heat 3 -> Block A
+    assert set(_assignments(h1).values()) == set(BLOCK_A)
+    assert set(_assignments(h2).values()) == set(BLOCK_B)
+    assert set(_assignments(h3).values()) == set(BLOCK_A)
+    assert summary["friday_saw_heats"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 2. Cross-event continuation on Friday
+# ---------------------------------------------------------------------------
+
+
+def test_cross_event_continuation_friday(db_session, tournament):
+    """Single Buck ends on Block B (odd heat count) -> next saw event starts Block A."""
+    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+
+    sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
+    jj = _make_event(
+        db_session,
+        tournament,
+        "Jack & Jill Sawing",
+        "college",
+        gender=None,
+        is_partnered=True,
+    )
+    dbuck = _make_event(
+        db_session, tournament, "Double Buck", "college", "M", is_partnered=True
+    )
+
+    # Force Friday order: SB -> JJ -> DB
+    tournament.set_schedule_config(
+        {
+            "friday_event_order": [sb.id, jj.id, dbuck.id],
+        }
+    )
+
+    # SB: 1 heat (ends Block A)  -> then JJ first heat must be Block B
+    h_sb1 = _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    # JJ: 2 pairs, 1 heat  -> Block B -> next DB heat Block A
+    h_jj1 = _make_heat(
+        db_session,
+        jj,
+        1,
+        competitors=[10, 11, 12, 13],
+        stand_assignments={"10": 1, "11": 1, "12": 2, "13": 2},
+    )
+    h_db1 = _make_heat(
+        db_session,
+        dbuck,
+        1,
+        competitors=[20, 21, 22, 23],
+        stand_assignments={"20": 1, "21": 1, "22": 2, "23": 2},
+    )
+
+    db_session.flush()
+    assign_saw_blocks(tournament)
+
+    assert set(_assignments(h_sb1).values()) == set(BLOCK_A)
+    # JJ inherits Block B (flip from SB's Block A). Only 2 pair-stands used
+    # (stands 1 & 2 pre-remap); they map to the first 2 positions of BLOCK_B.
+    jj_stands = set(_assignments(h_jj1).values())
+    assert jj_stands.issubset(set(BLOCK_B))
+    assert jj_stands == {5, 6}
+    # DB continues flip -> Block A. Same 2-pair structure -> stands 1 & 2.
+    db_stands = set(_assignments(h_db1).values())
+    assert db_stands.issubset(set(BLOCK_A))
+    assert db_stands == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-saw gap preserves alternation
+# ---------------------------------------------------------------------------
+
+
+def test_non_saw_gap_preserves_continuity(db_session, tournament):
+    """Saw heat N+1 still flips from saw heat N even with non-saw heats between."""
+    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+
+    sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
+    underhand = _make_event(
+        db_session,
+        tournament,
+        "Underhand Speed",
+        "college",
+        "M",
+        stand_type="underhand",
+    )
+
+    tournament.set_schedule_config(
+        {
+            "friday_event_order": [
+                sb.id,
+                underhand.id,
+                sb.id,
+            ],  # SB -> UH -> (SB already in list)
+        }
+    )
+
+    # SB heat 1 -> A, SB heat 2 -> B (not A, despite UH gap)
+    h_sb1 = _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    h_sb2 = _make_heat(
+        db_session,
+        sb,
+        2,
+        competitors=[5, 6, 7, 8],
+        stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+    )
+    # Underhand heat — not saw_hand, should not affect alternation
+    h_uh1 = _make_heat(
+        db_session,
+        underhand,
+        1,
+        competitors=[30, 31, 32],
+        stand_assignments={"30": 1, "31": 2, "32": 3},
+    )
+
+    db_session.flush()
+    assign_saw_blocks(tournament)
+
+    assert set(_assignments(h_sb1).values()) == set(BLOCK_A)
+    assert set(_assignments(h_sb2).values()) == set(BLOCK_B)
+    # Underhand untouched — still on its original stands
+    assert _assignments(h_uh1) == {30: 1, 31: 2, 32: 3}
+
+
+# ---------------------------------------------------------------------------
+# 4. Day boundary resets to Block A
+# ---------------------------------------------------------------------------
+
+
+def test_day_boundary_resets(db_session, tournament):
+    """Saturday saw heats restart from Block A regardless of Friday's end state."""
+    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A
+
+    # Friday: 1 college SB heat (ends on Block A, so Friday ends mid-cycle)
+    sb_coll = _make_event(db_session, tournament, "Single Buck", "college", "M")
+    h_fri = _make_heat(
+        db_session,
+        sb_coll,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+
+    # Saturday: pro saw events, no flights
+    sb_pro = _make_event(db_session, tournament, "Single Buck", "pro", "M")
+    h_sat = _make_heat(
+        db_session,
+        sb_pro,
+        1,
+        competitors=[50, 51, 52, 53],
+        stand_assignments={"50": 1, "51": 2, "52": 3, "53": 4},
+    )
+
+    db_session.flush()
+    assign_saw_blocks(tournament)
+
+    # Friday's first (and only) heat is Block A
+    assert set(_assignments(h_fri).values()) == set(BLOCK_A)
+    # Saturday's first heat ALSO Block A — reset, not continuation
+    assert set(_assignments(h_sat).values()) == set(BLOCK_A)
+
+
+# ---------------------------------------------------------------------------
+# 5. Partnered event preserves pair-sharing
+# ---------------------------------------------------------------------------
+
+
+def test_partnered_event_pair_preservation(db_session, tournament):
+    """Double Buck with 2 pairs: pairs share stand, and remap preserves that."""
+    from services.saw_block_assignment import assign_saw_blocks
+
+    sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
+    dbuck = _make_event(
+        db_session, tournament, "Double Buck", "college", "M", is_partnered=True
+    )
+
+    tournament.set_schedule_config(
+        {
+            "friday_event_order": [sb.id, dbuck.id],
+        }
+    )
+
+    # SB heat 1 -> Block A
+    _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    # DB heat 1 starts on {10:1, 11:1, 12:2, 13:2} (2 pairs on stands 1+2)
+    h_db = _make_heat(
+        db_session,
+        dbuck,
+        1,
+        competitors=[10, 11, 12, 13],
+        stand_assignments={"10": 1, "11": 1, "12": 2, "13": 2},
+    )
+
+    db_session.flush()
+    assign_saw_blocks(tournament)
+
+    # SB on Block A -> DB flips to Block B.
+    # Pair-sharing structure: 10&11 share one stand, 12&13 share another.
+    # Block B stands used: 5 and 6 (the first two positions of BLOCK_B).
+    assigns = _assignments(h_db)
+    assert assigns[10] == assigns[11]
+    assert assigns[12] == assigns[13]
+    assert assigns[10] != assigns[12]
+    assert assigns[10] == 5
+    assert assigns[12] == 6
+
+
+# ---------------------------------------------------------------------------
+# 6. Jack & Jill mixed-gender pair remap
+# ---------------------------------------------------------------------------
+
+
+def test_jack_and_jill_mixed_gender_assignment(db_session, tournament):
+    from services.saw_block_assignment import assign_saw_blocks
+
+    jj = _make_event(
+        db_session,
+        tournament,
+        "Jack & Jill Sawing",
+        "college",
+        gender=None,
+        is_partnered=True,
+    )
+    # 2 mixed-gender pairs, starting on Block A stands 1 & 2
+    h = _make_heat(
+        db_session,
+        jj,
+        1,
+        competitors=[100, 101, 102, 103],
+        stand_assignments={"100": 1, "101": 1, "102": 2, "103": 2},
+    )
+
+    db_session.flush()
+    assign_saw_blocks(tournament)
+
+    # First saw heat of Friday -> Block A, so {1,1,2,2} stays identical
+    a = _assignments(h)
+    assert a[100] == a[101]
+    assert a[102] == a[103]
+    assert a[100] != a[102]
+    assert {a[100], a[102]} == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# 7. Idempotent re-run
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_rerun(db_session, tournament):
+    from services.saw_block_assignment import assign_saw_blocks
+
+    sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
+    _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    _make_heat(
+        db_session,
+        sb,
+        2,
+        competitors=[5, 6, 7, 8],
+        stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+    )
+
+    assign_saw_blocks(tournament)  # first pass: heat 2 moves from A to B
+    second = assign_saw_blocks(tournament)  # second pass: no changes
+
+    assert second["heats_updated"] == 0
+    assert second["heats_unchanged"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 8. Flight builder reshuffle -> recompute reflects new run order
+# ---------------------------------------------------------------------------
+
+
+def test_flight_builder_reshuffle_recomputes_correctly(db_session, tournament):
+    """Pre-flight assignment differs from post-flight. Re-running after flight
+    build gives correct blocks for the new run order."""
+    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+
+    sb = _make_event(db_session, tournament, "Single Buck", "pro", "M")
+
+    # 2 pro saw heats — no flights yet (pre-flight fallback)
+    h_a = _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    h_b = _make_heat(
+        db_session,
+        sb,
+        2,
+        competitors=[5, 6, 7, 8],
+        stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+    )
+
+    assign_saw_blocks(tournament)
+    # Pre-flight order: h_a (heat_number 1) then h_b (heat_number 2)
+    assert set(_assignments(h_a).values()) == set(BLOCK_A)
+    assert set(_assignments(h_b).values()) == set(BLOCK_B)
+
+    # Simulate flight-build reshuffling: h_b runs first, then h_a
+    f1 = _make_flight(db_session, tournament, 1)
+    h_b.flight_id = f1.id
+    h_b.flight_position = 1
+    h_a.flight_id = f1.id
+    h_a.flight_position = 2
+    db_session.flush()
+
+    assign_saw_blocks(tournament)
+
+    # Now h_b is first -> Block A, h_a is second -> Block B
+    assert set(_assignments(h_b).values()) == set(BLOCK_A)
+    assert set(_assignments(h_a).values()) == set(BLOCK_B)
+
+
+# ---------------------------------------------------------------------------
+# 9. Stock Saw is unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_stock_saw_unaffected(db_session, tournament):
+    """Non-saw_hand stand types are not touched."""
+    from services.saw_block_assignment import assign_saw_blocks
+
+    stock = _make_event(
+        db_session, tournament, "Stock Saw", "college", "M", stand_type="stock_saw"
+    )
+
+    # Stock saw runs on stands 7-8 per Missoula rule
+    h = _make_heat(
+        db_session, stock, 1, competitors=[1, 2], stand_assignments={"1": 7, "2": 8}
+    )
+
+    assign_saw_blocks(tournament)
+
+    assert _assignments(h) == {1: 7, 2: 8}
+
+
+# ---------------------------------------------------------------------------
+# 10. HeatAssignment sync after remap
+# ---------------------------------------------------------------------------
+
+
+def test_sync_assignments_called(db_session, tournament):
+    """After assign_saw_blocks, HeatAssignment rows match the JSON."""
+    from models import HeatAssignment
+    from services.saw_block_assignment import assign_saw_blocks
+
+    sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
+    h1 = _make_heat(
+        db_session,
+        sb,
+        1,
+        competitors=[1, 2, 3, 4],
+        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+    )
+    h2 = _make_heat(
+        db_session,
+        sb,
+        2,
+        competitors=[5, 6, 7, 8],
+        stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+    )
+
+    # Seed HeatAssignment rows that reflect the pre-remap state so we can
+    # verify they get rewritten.
+    h1.sync_assignments("college")
+    h2.sync_assignments("college")
+    db_session.flush()
+
+    assign_saw_blocks(tournament)
+
+    # For each heat, HeatAssignment rows must match stand_assignments JSON
+    for heat in (h1, h2):
+        json_map = heat.get_stand_assignments()
+        rows = HeatAssignment.query.filter_by(heat_id=heat.id).all()
+        assert len(rows) == len(json_map)
+        for row in rows:
+            assert row.stand_number == json_map.get(str(row.competitor_id))

--- a/tests/test_saw_block_assignment.py
+++ b/tests/test_saw_block_assignment.py
@@ -126,7 +126,7 @@ def _assignments(heat):
 
 
 def test_within_event_alternation_single_buck(db_session, tournament):
-    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B, assign_saw_blocks
 
     sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
 
@@ -169,7 +169,7 @@ def test_within_event_alternation_single_buck(db_session, tournament):
 
 def test_cross_event_continuation_friday(db_session, tournament):
     """Single Buck ends on Block B (odd heat count) -> next saw event starts Block A."""
-    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B, assign_saw_blocks
 
     sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
     jj = _make_event(
@@ -237,7 +237,7 @@ def test_cross_event_continuation_friday(db_session, tournament):
 
 def test_non_saw_gap_preserves_continuity(db_session, tournament):
     """Saw heat N+1 still flips from saw heat N even with non-saw heats between."""
-    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B, assign_saw_blocks
 
     sb = _make_event(db_session, tournament, "Single Buck", "college", "M")
     underhand = _make_event(
@@ -299,7 +299,7 @@ def test_non_saw_gap_preserves_continuity(db_session, tournament):
 
 def test_day_boundary_resets(db_session, tournament):
     """Saturday saw heats restart from Block A regardless of Friday's end state."""
-    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A
+    from services.saw_block_assignment import BLOCK_A, assign_saw_blocks
 
     # Friday: 1 college SB heat (ends on Block A, so Friday ends mid-cycle)
     sb_coll = _make_event(db_session, tournament, "Single Buck", "college", "M")
@@ -456,7 +456,7 @@ def test_idempotent_rerun(db_session, tournament):
 def test_flight_builder_reshuffle_recomputes_correctly(db_session, tournament):
     """Pre-flight assignment differs from post-flight. Re-running after flight
     build gives correct blocks for the new run order."""
-    from services.saw_block_assignment import assign_saw_blocks, BLOCK_A, BLOCK_B
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B, assign_saw_blocks
 
     sb = _make_event(db_session, tournament, "Single Buck", "pro", "M")
 

--- a/tests/test_saw_block_integration.py
+++ b/tests/test_saw_block_integration.py
@@ -1,0 +1,481 @@
+"""
+Integration tests for saw-block recompute hooks wired into mutation routes.
+
+Covers:
+  - generate_heats (single event) triggers block assignment
+  - build_flights triggers block assignment post-flight
+  - reorder_flight_heats triggers recompute reflecting new flight order
+  - reorder_friday_events triggers recompute reflecting new event order
+  - Hook failure does not break the primary mutation
+
+Run:  pytest tests/test_saw_block_integration.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-saw-block-integration")
+os.environ.setdefault("WTF_CSRF_ENABLED", "False")
+
+
+@pytest.fixture(scope="module")
+def app():
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    db_path = tmp.name
+    tmp.close()
+
+    old_url = os.environ.get("DATABASE_URL")
+    old_create_all = os.environ.get("TEST_USE_CREATE_ALL")
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["TEST_USE_CREATE_ALL"] = "1"
+
+    try:
+        from app import create_app
+
+        _app = create_app()
+        _app.config.update(
+            {
+                "TESTING": True,
+                "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+                "WTF_CSRF_ENABLED": False,
+                "WTF_CSRF_CHECK_DEFAULT": False,
+            }
+        )
+
+        from database import db as _db
+
+        with _app.app_context():
+            _db.create_all()
+            yield _app
+            _db.session.remove()
+    finally:
+        if old_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = old_url
+        if old_create_all is None:
+            os.environ.pop("TEST_USE_CREATE_ALL", None)
+        else:
+            os.environ["TEST_USE_CREATE_ALL"] = old_create_all
+        try:
+            os.unlink(db_path)
+        except OSError:
+            pass
+
+
+@pytest.fixture(autouse=True)
+def clean_db(app):
+    from database import db as _db
+
+    with app.app_context():
+        yield
+        _db.session.remove()
+        for table in reversed(_db.metadata.sorted_tables):
+            _db.session.execute(table.delete())
+        _db.session.commit()
+        # Clear heat_generator's module-level tournament-events cache to prevent
+        # detached-instance leaks across test modules (pre-existing cache bug
+        # in services/heat_generator.py: `_get_tournament_events._cache`).
+        try:
+            from services.heat_generator import _get_tournament_events
+            if hasattr(_get_tournament_events, '_cache'):
+                _get_tournament_events._cache.clear()
+        except Exception:
+            pass
+
+
+@pytest.fixture()
+def auth_client(app):
+    """Return a test client authenticated as an admin user."""
+    from database import db as _db
+    from models.user import User
+
+    with app.app_context():
+        u = User(username="sawblock_admin", role="admin")
+        u.set_password("pass")
+        _db.session.add(u)
+        _db.session.commit()
+        uid = u.id
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess["_user_id"] = str(uid)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers — create realistic saw-event tournaments
+# ---------------------------------------------------------------------------
+
+
+def _seed_tournament(db):
+    from models import Tournament
+
+    t = Tournament(name="SawBlock Integration Test 2026", year=2026, status="setup")
+    db.session.add(t)
+    db.session.flush()
+    return t
+
+
+def _seed_team(db, tournament):
+    from models import Team
+
+    team = Team(
+        tournament_id=tournament.id,
+        team_code="UM-A",
+        school_name="University of Montana",
+        school_abbreviation="UM",
+    )
+    db.session.add(team)
+    db.session.flush()
+    return team
+
+
+def _seed_college_competitors(
+    db, tournament, team, count=12, gender="M", event_name="Single Buck"
+):
+    from models.competitor import CollegeCompetitor
+
+    comps = []
+    for i in range(count):
+        c = CollegeCompetitor(
+            tournament_id=tournament.id,
+            team_id=team.id,
+            name=f"Competitor {i + 1}",
+            gender=gender,
+            events_entered=json.dumps([event_name]),
+            status="active",
+        )
+        db.session.add(c)
+        comps.append(c)
+    db.session.flush()
+    return comps
+
+
+def _seed_saw_event(
+    db,
+    tournament,
+    name="Single Buck",
+    event_type="college",
+    gender="M",
+    is_partnered=False,
+):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type=event_type,
+        gender=gender,
+        scoring_type="time",
+        stand_type="saw_hand",
+        is_partnered=is_partnered,
+    )
+    db.session.add(e)
+    db.session.flush()
+    return e
+
+
+def _seed_event_results(db, event, competitors, comp_type="college"):
+    from models.event import EventResult
+
+    for c in competitors:
+        r = EventResult(
+            event_id=event.id,
+            competitor_id=c.id,
+            competitor_type=comp_type,
+            competitor_name=c.name,
+            status="pending",
+        )
+        db.session.add(r)
+    db.session.flush()
+
+
+def _seed_heat(
+    db,
+    event,
+    heat_number,
+    competitors,
+    stand_assignments,
+    run_number=1,
+    flight=None,
+    flight_position=None,
+):
+    from models import Heat
+
+    h = Heat(
+        event_id=event.id,
+        heat_number=heat_number,
+        run_number=run_number,
+        competitors=json.dumps(competitors),
+        stand_assignments=json.dumps(stand_assignments),
+    )
+    if flight is not None:
+        h.flight_id = flight.id
+        h.flight_position = flight_position
+    db.session.add(h)
+    db.session.flush()
+    return h
+
+
+def _seed_flight(db, tournament, flight_number):
+    from models.heat import Flight
+
+    f = Flight(tournament_id=tournament.id, flight_number=flight_number)
+    db.session.add(f)
+    db.session.flush()
+    return f
+
+
+def _used_stands(heat):
+    return sorted({int(v) for v in heat.get_stand_assignments().values()})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_heats_triggers_block_assignment(app, auth_client):
+    """POST generate-heats should trigger saw-block recompute."""
+    from database import db as _db
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        team = _seed_team(_db, t)
+        comps = _seed_college_competitors(
+            _db, t, team, count=12, gender="M", event_name="Single Buck"
+        )
+        sb = _seed_saw_event(_db, t, name="Single Buck", event_type="college")
+        _seed_event_results(_db, sb, comps, comp_type="college")
+
+        # Tie competitors to the event by ID — generate_event_heats uses
+        # competitor_entered_event which tries both name and ID.
+        for c in comps:
+            c.events_entered = json.dumps([str(sb.id)])
+        _db.session.commit()
+
+        tid = t.id
+        eid = sb.id
+
+    resp = auth_client.post(
+        f"/scheduling/{tid}/event/{eid}/generate-heats",
+        data={},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 303)
+
+    with app.app_context():
+        from models import Heat
+
+        heats = (
+            Heat.query.filter_by(event_id=eid, run_number=1)
+            .order_by(Heat.heat_number)
+            .all()
+        )
+        assert len(heats) >= 2
+        # First heat on Block A, second on Block B
+        assert _used_stands(heats[0]) == BLOCK_A
+        assert _used_stands(heats[1]) == BLOCK_B
+
+
+def test_build_flights_triggers_block_assignment(app, auth_client):
+    """After build_flights reshuffles heats, blocks reflect new flight order."""
+    from database import db as _db
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck", event_type="pro")
+        # Seed 2 pro saw heats with stand_assignments already on Block A
+        h1 = _seed_heat(
+            _db,
+            sb,
+            1,
+            competitors=[1, 2, 3, 4],
+            stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+        )
+        h2 = _seed_heat(
+            _db,
+            sb,
+            2,
+            competitors=[5, 6, 7, 8],
+            stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+        )
+        _db.session.commit()
+        tid = t.id
+        h1_id = h1.id
+        h2_id = h2.id
+
+    resp = auth_client.post(
+        f"/scheduling/{tid}/flights/build",
+        data={"num_flights": "1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 303)
+
+    with app.app_context():
+        from models import Heat
+
+        h1 = Heat.query.get(h1_id)
+        h2 = Heat.query.get(h2_id)
+        # After build_flights, both heats are in flight 1.
+        # The first heat in flight_position order gets Block A, the second Block B.
+        ordered_by_flight = sorted(
+            [h1, h2], key=lambda h: (h.flight_position or 999, h.id)
+        )
+        assert _used_stands(ordered_by_flight[0]) == BLOCK_A
+        assert _used_stands(ordered_by_flight[1]) == BLOCK_B
+
+
+def test_reorder_flight_heats_triggers_recompute(app, auth_client):
+    """Reordering heats within a flight recomputes blocks per new run order."""
+    from database import db as _db
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck", event_type="pro")
+        flight = _seed_flight(_db, t, flight_number=1)
+        h_a = _seed_heat(
+            _db,
+            sb,
+            1,
+            competitors=[1, 2, 3, 4],
+            stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+            flight=flight,
+            flight_position=1,
+        )
+        h_b = _seed_heat(
+            _db,
+            sb,
+            2,
+            competitors=[5, 6, 7, 8],
+            stand_assignments={"5": 5, "6": 6, "7": 7, "8": 8},
+            flight=flight,
+            flight_position=2,
+        )
+        _db.session.commit()
+        tid = t.id
+        fid = flight.id
+        h_a_id = h_a.id
+        h_b_id = h_b.id
+
+    # Reverse the flight order: h_b first, h_a second
+    resp = auth_client.post(
+        f"/scheduling/{tid}/flights/{fid}/reorder",
+        json={"heat_ids": [h_b_id, h_a_id]},
+    )
+    assert resp.status_code == 200
+
+    with app.app_context():
+        from models import Heat
+
+        h_a = Heat.query.get(h_a_id)
+        h_b = Heat.query.get(h_b_id)
+        # h_b is now first in flight -> Block A; h_a is second -> Block B
+        assert _used_stands(h_b) == BLOCK_A
+        assert _used_stands(h_a) == BLOCK_B
+
+
+def test_reorder_friday_events_triggers_recompute(app, auth_client):
+    """Reordering Friday events reassigns blocks to match new event order."""
+    from database import db as _db
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(
+            _db, t, name="Single Buck", event_type="college", gender="M"
+        )
+        dbuck = _seed_saw_event(
+            _db,
+            t,
+            name="Double Buck",
+            event_type="college",
+            gender="M",
+            is_partnered=True,
+        )
+        # Each event has 1 heat
+        h_sb = _seed_heat(
+            _db,
+            sb,
+            1,
+            competitors=[1, 2, 3, 4],
+            stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+        )
+        h_db = _seed_heat(
+            _db,
+            dbuck,
+            1,
+            competitors=[10, 11, 12, 13],
+            stand_assignments={"10": 1, "11": 1, "12": 2, "13": 2},
+        )
+        _db.session.commit()
+        tid = t.id
+        sb_id = sb.id
+        dbuck_id = dbuck.id
+        h_sb_id = h_sb.id
+        h_db_id = h_db.id
+
+    # Force order: Double Buck first, Single Buck second
+    resp = auth_client.post(
+        f"/scheduling/{tid}/events/reorder-friday",
+        json={"event_ids": [dbuck_id, sb_id]},
+    )
+    assert resp.status_code == 200
+
+    with app.app_context():
+        from models import Heat
+
+        h_sb = Heat.query.get(h_sb_id)
+        h_db = Heat.query.get(h_db_id)
+        # DB runs first -> Block A (stands 1 and 2 for the pairs)
+        assert set(h_db.get_stand_assignments().values()).issubset(set(BLOCK_A))
+        # SB runs second -> Block B
+        assert _used_stands(h_sb) == BLOCK_B
+
+
+def test_hook_failure_does_not_break_primary_mutation(app, auth_client, monkeypatch):
+    """An exception inside trigger_saw_block_recompute must not 500 the route."""
+    from database import db as _db
+
+    # Monkeypatch assign_saw_blocks to raise
+    from services import saw_block_assignment as sba
+
+    def _boom(_t):
+        raise RuntimeError("synthetic failure for test")
+
+    monkeypatch.setattr(sba, "assign_saw_blocks", _boom)
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck", event_type="pro")
+        _seed_heat(
+            _db,
+            sb,
+            1,
+            competitors=[1, 2, 3, 4],
+            stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+        )
+        _db.session.commit()
+        tid = t.id
+
+    # Primary mutation (build_flights) must succeed despite hook failure
+    resp = auth_client.post(
+        f"/scheduling/{tid}/flights/build",
+        data={"num_flights": "1"},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 303)
+
+    with app.app_context():
+        from models import Flight
+
+        flights = Flight.query.filter_by(tournament_id=tid).all()
+        assert len(flights) == 1  # primary mutation committed

--- a/tests/test_saw_blocks_admin.py
+++ b/tests/test_saw_blocks_admin.py
@@ -1,0 +1,314 @@
+"""
+Admin safety valve + status page tests for hand-saw block alternation.
+
+Covers:
+  - POST /scheduling/<tid>/heats/recompute-saw-blocks succeeds, flashes,
+    redirects, and triggers assign_saw_blocks
+  - GET  /scheduling/<tid>/saw-blocks-status renders 200 and shows
+    the expected run-order rows per day
+  - Status page empty state: tournament with no saw events renders
+    an empty-state message for both days
+  - Sidebar link is hidden when the tournament has no saw events, and
+    present when it does
+
+Run:  pytest tests/test_saw_blocks_admin.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-saw-blocks-admin")
+os.environ.setdefault("WTF_CSRF_ENABLED", "False")
+
+
+@pytest.fixture(scope="module")
+def app():
+    tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+    db_path = tmp.name
+    tmp.close()
+
+    old_url = os.environ.get("DATABASE_URL")
+    old_create_all = os.environ.get("TEST_USE_CREATE_ALL")
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["TEST_USE_CREATE_ALL"] = "1"
+
+    try:
+        from app import create_app
+
+        _app = create_app()
+        _app.config.update(
+            {
+                "TESTING": True,
+                "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+                "WTF_CSRF_ENABLED": False,
+                "WTF_CSRF_CHECK_DEFAULT": False,
+            }
+        )
+
+        from database import db as _db
+
+        with _app.app_context():
+            _db.create_all()
+            yield _app
+            _db.session.remove()
+    finally:
+        if old_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = old_url
+        if old_create_all is None:
+            os.environ.pop("TEST_USE_CREATE_ALL", None)
+        else:
+            os.environ["TEST_USE_CREATE_ALL"] = old_create_all
+        try:
+            os.unlink(db_path)
+        except OSError:
+            pass
+
+
+@pytest.fixture(autouse=True)
+def clean_db(app):
+    from database import db as _db
+
+    with app.app_context():
+        yield
+        _db.session.remove()
+        for table in reversed(_db.metadata.sorted_tables):
+            _db.session.execute(table.delete())
+        _db.session.commit()
+        try:
+            from services.heat_generator import _get_tournament_events
+
+            if hasattr(_get_tournament_events, "_cache"):
+                _get_tournament_events._cache.clear()
+        except Exception:
+            pass
+
+
+@pytest.fixture()
+def auth_client(app):
+    from database import db as _db
+    from models.user import User
+
+    with app.app_context():
+        u = User(username="sba_admin", role="admin")
+        u.set_password("pass")
+        _db.session.add(u)
+        _db.session.commit()
+        uid = u.id
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess["_user_id"] = str(uid)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_tournament(db, name="SawAdmin 2026"):
+    from models import Tournament
+
+    t = Tournament(name=name, year=2026, status="setup")
+    db.session.add(t)
+    db.session.flush()
+    return t
+
+
+def _seed_saw_event(
+    db, tournament, name="Single Buck", event_type="college", gender="M"
+):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type=event_type,
+        gender=gender,
+        scoring_type="time",
+        stand_type="saw_hand",
+    )
+    db.session.add(e)
+    db.session.flush()
+    return e
+
+
+def _seed_non_saw_event(db, tournament):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name="Underhand Speed",
+        event_type="college",
+        gender="M",
+        scoring_type="time",
+        stand_type="underhand",
+    )
+    db.session.add(e)
+    db.session.flush()
+    return e
+
+
+def _seed_heat(db, event, heat_number, competitors, stand_assignments):
+    from models import Heat
+
+    h = Heat(
+        event_id=event.id,
+        heat_number=heat_number,
+        run_number=1,
+        competitors=json.dumps(competitors),
+        stand_assignments=json.dumps(stand_assignments),
+    )
+    db.session.add(h)
+    db.session.flush()
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_recompute_route_succeeds(app, auth_client):
+    """POST recompute-saw-blocks triggers assign_saw_blocks, flashes, redirects."""
+    from database import db as _db
+    from services.saw_block_assignment import BLOCK_A, BLOCK_B
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck")
+        # 2 heats, both pre-seeded on Block A
+        h1 = _seed_heat(
+            _db,
+            sb,
+            1,
+            competitors=[1, 2, 3, 4],
+            stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+        )
+        h2 = _seed_heat(
+            _db,
+            sb,
+            2,
+            competitors=[5, 6, 7, 8],
+            stand_assignments={"5": 1, "6": 2, "7": 3, "8": 4},
+        )
+        _db.session.commit()
+        tid = t.id
+        h1_id = h1.id
+        h2_id = h2.id
+
+    resp = auth_client.post(
+        f"/scheduling/{tid}/heats/recompute-saw-blocks",
+        data={},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 303)
+
+    with app.app_context():
+        from models import Heat
+
+        h1 = Heat.query.get(h1_id)
+        h2 = Heat.query.get(h2_id)
+        # Alternation applied: heat 1 -> Block A, heat 2 -> Block B
+        used_1 = sorted({int(v) for v in h1.get_stand_assignments().values()})
+        used_2 = sorted({int(v) for v in h2.get_stand_assignments().values()})
+        assert used_1 == BLOCK_A
+        assert used_2 == BLOCK_B
+
+
+def test_status_page_renders(app, auth_client):
+    """GET saw-blocks-status returns 200 and includes expected rows."""
+    from database import db as _db
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck")
+        _seed_heat(
+            _db,
+            sb,
+            1,
+            competitors=[1, 2, 3, 4],
+            stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+        )
+        _seed_heat(
+            _db,
+            sb,
+            2,
+            competitors=[5, 6, 7, 8],
+            stand_assignments={"5": 5, "6": 6, "7": 7, "8": 8},
+        )
+        _db.session.commit()
+        tid = t.id
+
+    resp = auth_client.get(f"/scheduling/{tid}/saw-blocks-status")
+    assert resp.status_code == 200
+
+    body = resp.get_data(as_text=True)
+    # Page header is present
+    assert "Saw Stand Block Assignments" in body
+    # Both blocks appear
+    assert "Block A" in body
+    assert "Block B" in body
+    # Single Buck event name is in the rendered table
+    assert "Single Buck" in body
+    # Both day sections render
+    assert "Friday" in body
+    assert "Saturday" in body
+    # Recompute form is rendered
+    assert "/heats/recompute-saw-blocks" in body
+
+
+def test_status_page_empty_state(app, auth_client):
+    """Tournament with no saw events renders empty-state message for both days."""
+    from database import db as _db
+
+    with app.app_context():
+        t = _seed_tournament(_db, name="No Saw Tournament")
+        _seed_non_saw_event(_db, t)
+        _db.session.commit()
+        tid = t.id
+
+    resp = auth_client.get(f"/scheduling/{tid}/saw-blocks-status")
+    assert resp.status_code == 200
+
+    body = resp.get_data(as_text=True)
+    # Expect the empty-state message to appear (once per day section)
+    assert body.count("No hand-saw heats scheduled.") >= 2
+
+
+def test_sidebar_link_hidden_when_no_saw_events(app, auth_client):
+    """Sidebar renders WITHOUT the Saw Block Status link for a saw-free tournament,
+    and WITH the link once at least one saw_hand event exists."""
+    from database import db as _db
+
+    with app.app_context():
+        # Tournament A: no saw events
+        t_a = _seed_tournament(_db, name="No Saw")
+        _seed_non_saw_event(_db, t_a)
+        _db.session.commit()
+        tid_a = t_a.id
+
+    # Hitting tournament_detail renders the sidebar context
+    resp_a = auth_client.get(f"/tournament/{tid_a}")
+    assert resp_a.status_code == 200
+    body_a = resp_a.get_data(as_text=True)
+    assert "Saw Block Status" not in body_a
+
+    with app.app_context():
+        # Tournament B: one saw event
+        t_b = _seed_tournament(_db, name="Has Saw")
+        _seed_saw_event(_db, t_b, name="Single Buck")
+        _db.session.commit()
+        tid_b = t_b.id
+
+    resp_b = auth_client.get(f"/tournament/{tid_b}")
+    assert resp_b.status_code == 200
+    body_b = resp_b.get_data(as_text=True)
+    assert "Saw Block Status" in body_b
+    assert f"/scheduling/{tid_b}/saw-blocks-status" in body_b

--- a/tests/test_schedule_builder_ordering.py
+++ b/tests/test_schedule_builder_ordering.py
@@ -1,0 +1,356 @@
+"""
+Tests for services.schedule_builder.get_friday_ordered_heats and
+services.schedule_builder.get_saturday_ordered_heats.
+
+Verifies that the ordered-heats helpers expose the same authoritative run
+order that build_day_schedule() is built on, with no side effects.
+
+Run:
+    pytest tests/test_schedule_builder_ordering.py -v
+"""
+
+import os
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    """Test Flask app with temp-file SQLite built via flask db upgrade."""
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+
+    with _app.app_context():
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    """Wrap each test in a transaction and roll back afterward."""
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture()
+def tournament(db_session):
+    from models import Tournament
+
+    t = Tournament(name="Ordering Test 2026", year=2026, status="setup")
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+def _make_event(
+    db_session,
+    tournament,
+    name,
+    event_type="college",
+    gender=None,
+    stand_type="saw_hand",
+    requires_dual_runs=False,
+    is_open=False,
+):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type=event_type,
+        gender=gender,
+        scoring_type="time",
+        stand_type=stand_type,
+        requires_dual_runs=requires_dual_runs,
+        is_open=is_open,
+    )
+    db_session.add(e)
+    db_session.flush()
+    return e
+
+
+def _make_flight(db_session, tournament, flight_number):
+    from models.heat import Flight
+
+    f = Flight(tournament_id=tournament.id, flight_number=flight_number)
+    db_session.add(f)
+    db_session.flush()
+    return f
+
+
+def _make_heat(
+    db_session, event, heat_number, run_number=1, flight=None, flight_position=None
+):
+    from models import Heat
+
+    h = Heat(
+        event_id=event.id,
+        heat_number=heat_number,
+        run_number=run_number,
+    )
+    if flight is not None:
+        h.flight_id = flight.id
+        h.flight_position = flight_position
+    db_session.add(h)
+    db_session.flush()
+    return h
+
+
+# ---------------------------------------------------------------------------
+# Friday ordering
+# ---------------------------------------------------------------------------
+
+
+def test_friday_default_order_uses_college_sort_key(db_session, tournament):
+    """Absent friday_event_order, events order by _college_friday_sort_key.
+
+    Axe Throw (open) should come before Single Buck (closed), which is
+    before Birling (always last).
+    """
+    from services.schedule_builder import get_friday_ordered_heats
+
+    axe = _make_event(
+        db_session,
+        tournament,
+        "Axe Throw",
+        "college",
+        "M",
+        stand_type="axe_throw",
+        is_open=True,
+    )
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "college", "M", stand_type="saw_hand"
+    )
+    birling = _make_event(
+        db_session, tournament, "Birling", "college", "M", stand_type="birling"
+    )
+
+    _make_heat(db_session, axe, 1)
+    _make_heat(db_session, sb, 1)
+    _make_heat(db_session, birling, 1)
+
+    ordered = get_friday_ordered_heats(tournament)
+    event_ids = [h.event_id for h in ordered]
+    assert event_ids == [axe.id, sb.id, birling.id]
+
+
+def test_friday_custom_order_overrides_default(db_session, tournament):
+    """friday_event_order in schedule_config dictates event order."""
+    from services.schedule_builder import get_friday_ordered_heats
+
+    axe = _make_event(
+        db_session,
+        tournament,
+        "Axe Throw",
+        "college",
+        "M",
+        stand_type="axe_throw",
+        is_open=True,
+    )
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "college", "M", stand_type="saw_hand"
+    )
+    db = _make_event(
+        db_session, tournament, "Double Buck", "college", "M", stand_type="saw_hand"
+    )
+
+    _make_heat(db_session, axe, 1)
+    _make_heat(db_session, sb, 1)
+    _make_heat(db_session, db, 1)
+
+    # Force Double Buck first, Axe Throw second, Single Buck third
+    tournament.set_schedule_config({"friday_event_order": [db.id, axe.id, sb.id]})
+    db_session.flush()
+
+    ordered = get_friday_ordered_heats(tournament)
+    event_ids = [h.event_id for h in ordered]
+    assert event_ids == [db.id, axe.id, sb.id]
+
+
+def test_friday_multiple_heats_ordered_by_heat_number(db_session, tournament):
+    """Within an event, heats come out in heat_number ascending order."""
+    from services.schedule_builder import get_friday_ordered_heats
+
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "college", "M", stand_type="saw_hand"
+    )
+    _make_heat(db_session, sb, 3)
+    _make_heat(db_session, sb, 1)
+    _make_heat(db_session, sb, 2)
+
+    ordered = get_friday_ordered_heats(tournament)
+    assert [h.heat_number for h in ordered] == [1, 2, 3]
+
+
+def test_friday_excludes_saturday_spillover_events(db_session, tournament):
+    """Events listed in saturday_college_event_ids don't appear on Friday."""
+    from services.schedule_builder import get_friday_ordered_heats
+
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "college", "M", stand_type="saw_hand"
+    )
+    spillover = _make_event(
+        db_session,
+        tournament,
+        "Standing Block Speed",
+        "college",
+        "M",
+        stand_type="standing_block",
+    )
+
+    _make_heat(db_session, sb, 1)
+    _make_heat(db_session, spillover, 1)
+
+    tournament.set_schedule_config(
+        {
+            "saturday_college_event_ids": [spillover.id],
+        }
+    )
+    db_session.flush()
+
+    ordered = get_friday_ordered_heats(tournament)
+    event_ids = {h.event_id for h in ordered}
+    assert sb.id in event_ids
+    assert spillover.id not in event_ids
+
+
+def test_friday_excludes_run_2_heats(db_session, tournament):
+    """Dual-run run_number=2 heats do not appear on Friday."""
+    from services.schedule_builder import get_friday_ordered_heats
+
+    sb = _make_event(
+        db_session,
+        tournament,
+        "Single Buck",
+        "college",
+        "M",
+        stand_type="saw_hand",
+        requires_dual_runs=True,
+    )
+    _make_heat(db_session, sb, 1, run_number=1)
+    _make_heat(db_session, sb, 1, run_number=2)
+
+    ordered = get_friday_ordered_heats(tournament)
+    assert all(h.run_number == 1 for h in ordered)
+
+
+# ---------------------------------------------------------------------------
+# Saturday ordering
+# ---------------------------------------------------------------------------
+
+
+def test_saturday_uses_flight_order_when_flights_exist(db_session, tournament):
+    """With flights: Flight.flight_number + flight.get_heats_ordered() rules."""
+    from services.schedule_builder import get_saturday_ordered_heats
+
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "pro", "M", stand_type="saw_hand"
+    )
+    dbuck = _make_event(
+        db_session, tournament, "Double Buck", "pro", "M", stand_type="saw_hand"
+    )
+
+    f1 = _make_flight(db_session, tournament, 1)
+    f2 = _make_flight(db_session, tournament, 2)
+
+    h_sb1 = _make_heat(db_session, sb, 1, flight=f1, flight_position=1)
+    h_db1 = _make_heat(db_session, dbuck, 1, flight=f1, flight_position=2)
+    h_sb2 = _make_heat(db_session, sb, 2, flight=f2, flight_position=1)
+
+    ordered = get_saturday_ordered_heats(tournament)
+    heat_ids = [h.id for h in ordered]
+    assert heat_ids == [h_sb1.id, h_db1.id, h_sb2.id]
+
+
+def test_saturday_fallback_to_event_order_when_no_flights(db_session, tournament):
+    """No flights: pro heats ordered by event_id + heat_number ascending."""
+    from services.schedule_builder import get_saturday_ordered_heats
+
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "pro", "M", stand_type="saw_hand"
+    )
+    dbuck = _make_event(
+        db_session, tournament, "Double Buck", "pro", "M", stand_type="saw_hand"
+    )
+
+    h_sb1 = _make_heat(db_session, sb, 1)
+    h_sb2 = _make_heat(db_session, sb, 2)
+    h_db1 = _make_heat(db_session, dbuck, 1)
+
+    ordered = get_saturday_ordered_heats(tournament)
+    # event_id ascending: sb (smaller id) first, then dbuck
+    assert ordered[0].id == h_sb1.id
+    assert ordered[1].id == h_sb2.id
+    assert ordered[2].id == h_db1.id
+
+
+def test_saturday_fallback_respects_custom_order(db_session, tournament):
+    """No flights + saturday_event_order -> custom pro event order is used."""
+    from services.schedule_builder import get_saturday_ordered_heats
+
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "pro", "M", stand_type="saw_hand"
+    )
+    dbuck = _make_event(
+        db_session, tournament, "Double Buck", "pro", "M", stand_type="saw_hand"
+    )
+
+    _make_heat(db_session, sb, 1)
+    _make_heat(db_session, dbuck, 1)
+
+    tournament.set_schedule_config({"saturday_event_order": [dbuck.id, sb.id]})
+    db_session.flush()
+
+    ordered = get_saturday_ordered_heats(tournament)
+    assert [h.event_id for h in ordered] == [dbuck.id, sb.id]
+
+
+def test_saturday_includes_dual_run_run_2_heats(db_session, tournament):
+    """Day-split Run 2 heats route to Saturday even without flight attachment."""
+    from services.schedule_builder import get_saturday_ordered_heats
+
+    chokerman = _make_event(
+        db_session,
+        tournament,
+        "Chokerman's Race",
+        "college",
+        "M",
+        stand_type="chokerman",
+        requires_dual_runs=True,
+    )
+    # Run 2 heats only — no flights, no pro heats
+    h_run2 = _make_heat(db_session, chokerman, 1, run_number=2)
+
+    ordered = get_saturday_ordered_heats(tournament)
+    assert h_run2.id in [h.id for h in ordered]
+
+
+def test_saturday_and_friday_helpers_are_pure_reads(db_session, tournament):
+    """Calling the helpers does not mutate schedule_config or any heat."""
+    from services.schedule_builder import (
+        get_friday_ordered_heats,
+        get_saturday_ordered_heats,
+    )
+
+    sb = _make_event(
+        db_session, tournament, "Single Buck", "college", "M", stand_type="saw_hand"
+    )
+    h = _make_heat(db_session, sb, 1)
+    # capture pre-state
+    stands_before = h.stand_assignments
+    config_before = tournament.schedule_config
+
+    get_friday_ordered_heats(tournament)
+    get_saturday_ordered_heats(tournament)
+
+    assert h.stand_assignments == stands_before
+    assert tournament.schedule_config == config_before


### PR DESCRIPTION
## Summary

Alternates the two physical saw-stand blocks (A = stands 1-4, B = stands 5-8) across consecutive hand-saw heats in each day's run order. The next team can set in on the opposite block while the current team runs. Applies to Single Buck, Double Buck, and Jack & Jill Sawing — all pro and college, all genders. Friday and Saturday each start fresh on Block A.

**New service** — `services/saw_block_assignment.py`:
- `assign_saw_blocks(tournament)` walks Friday then Saturday in authoritative run order, flips Block A↔B on every `stand_type=='saw_hand'` heat, skips non-saw heats while preserving alternation state. Idempotent. Commits on success, rolls back + re-raises on failure.
- `remap_heat_to_block(heat, target_block)` remaps a heat's `stand_assignments` JSON onto the 4 target-block stands, preserving pair-sharing (both partners keep the same stand number).
- `trigger_saw_block_recompute(tournament)` shared route-hook wrapper. Logs + flashes warning on exception. Never re-raises.

**Authoritative run-order helpers** — `services/schedule_builder.py`:
- `get_friday_ordered_heats(tournament)` respects `schedule_config['friday_event_order']` when set, else `_college_friday_sort_key`. Excludes Saturday spillover + Friday Feature events, Run 2 heats.
- `get_saturday_ordered_heats(tournament)` iterates `Flight.flight_number` + `flight.get_heats_ordered()` when flights exist, else falls back to pro events by event_id + heat_number. Includes day-split Run 2 heats.

**9 route hooks** — `routes/scheduling/{heats,events,flights}.py`:
- `generate_heats` (single event), `generate_college_heats` (bulk), `event_list` actions (`generate_all`, `rebuild_flights`, `integrate_spillover`), `build_flights` POST, `reorder_flight_heats`, `reorder_friday_events`, `reset_event_order`. All fire after the primary commit; exceptions never roll back the primary mutation.

**Admin surfaces** — `routes/scheduling/heats.py`, `templates/scheduling/saw_blocks_status.html`, `templates/_sidebar.html`:
- `POST /scheduling/<tid>/heats/recompute-saw-blocks` — manual re-run with flash feedback.
- `GET /scheduling/<tid>/saw-blocks-status` — per-day tables with Block A/B badge, stands, competitors.
- Sidebar nav link visible only when the tournament has saw_hand events.

**Zero schema changes.** `Heat.stand_assignments` JSON stays authoritative; `HeatAssignment` rows synced via `heat.sync_assignments()` after every remap. `STAND_CONFIGS['saw_hand']['labels']` unchanged — heat sheets / judge sheets / kiosk continue rendering raw stand numbers.

## Tests

**29 new tests, 29/29 pass. Zero regressions.**

- `tests/test_schedule_builder_ordering.py` (10): Friday custom/default order, within-event heat_number order, spillover + Run 2 exclusion, Saturday flights-mode + fallback + custom-order + dual-run inclusion, pure-reads guarantee.
- `tests/test_saw_block_assignment.py` (10): within-event alternation, cross-event Friday continuity, non-saw gap preservation, day-boundary reset, partnered pair preservation, J&J mixed-gender, idempotency, flight-reshuffle recompute, Stock Saw untouched, HeatAssignment sync.
- `tests/test_saw_block_integration.py` (5): generate_heats / build_flights / reorder_flight_heats / reorder_friday_events trigger recompute; hook failure does not break primary mutation.
- `tests/test_saw_blocks_admin.py` (4): recompute POST, status page render, empty state, sidebar conditional.

**Full suite:** 3033 pass, 10 skip, 1 xpass. 8 pre-existing failures unchanged (3 in `test_model_json_safety.py` forcing NOT NULL columns to None; 5 in `test_route_smoke.py` blocked by a `background_jobs` table missing in the test DB). None in code this PR touches.

## Pre-Landing Review

Ran in a separate /review pass before ship. 0 critical findings. 3 informational notes:
1. CLAUDE.md scope-creep reverted.
2. Minor N+1 in ordered-heats helpers (~10 Heat.query calls per hook fire; acceptable).
3. Sidebar conditional fires one extra query per tournament-page render; moving to context processor is out of scope.

## QA (live browser)

Hit the running Flask app at localhost:5055 via the gstack browse harness.

- Sidebar conditional: 1 link on tournament with saw events, 0 on tournament without ✓
- `/saw-blocks-status`: 200 OK, 0 console errors, Friday + Saturday tables render
- Recompute POST first run: 17 heats updated (existing data)
- Recompute POST second run: 0 heats updated (idempotent) ✓
- Adjacent routes (`/events`, `/flights`, `/heat-sheets`): 200 OK

**Health: 9.5/10. Zero bugs.**

## Test plan

- [x] `pytest tests/test_saw_block_assignment.py tests/test_saw_block_integration.py tests/test_saw_blocks_admin.py tests/test_schedule_builder_ordering.py` — 29 pass
- [x] Full suite — 3033 pass (same 8 pre-existing failures as main)
- [x] Live browser smoke on localhost:5055 — clean
- [ ] Verify block alternation on Railway after merge: navigate to `/scheduling/<tid>/saw-blocks-status` on the production tournament; flip back and forth via Recompute Now; confirm alternation pattern matches the printed heat sheet order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)