### PR TITLE
fix: friendly redirect on expired CSRF tokens (V2.10.1)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,26 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.10.1)
+
+**Patch — friendly redirect on expired CSRF tokens**
+
+Fixes a silent-failure bug where long-open forms (CSRF time limit defaults to 1 hour) submitted a stale token, got a raw `400 Bad Request` page, and left the user thinking the button was broken. The "Integrate Spillover" button on the scheduling page was the first reported case, but the bug affected every CSRF-protected form in the app.
+
+**New error handler — app.py:**
+- `@app.errorhandler(CSRFError)` catches missing/expired CSRF tokens from Flask-WTF.
+- HTML routes: flash `"Your session expired for security. Please try that action again."` and 302-redirect to `request.referrer` (or `request.path` as fallback). The next GET picks up a fresh token, so one more click works.
+- `/api/` routes: return `{"error":"CSRF token missing or expired","status":400}` JSON for programmatic clients.
+
+**Regression tests — tests/test_csrf_error_handler.py (2 new):**
+- Verifies HTML route redirects to referrer with the correct warning flash.
+- Verifies the fallback when the browser omits `Referer` (redirects to `request.path`).
+- Uses a fixture that re-enables CSRF protection for the test app (the global `conftest.py` disables it for every other test).
+
+**Data model:** No schema changes.
+
+---
+
 ### 2026-04-21 (V2.10.0)
 
 **Minor — hand-saw stand block alternation**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.10.0
+# Missoula Pro Am Manager — V2.10.1
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 

--- a/app.py
+++ b/app.py
@@ -10,14 +10,16 @@ from flask import (
     Flask,
     Response,
     abort,
+    flash,
     g,
     jsonify,
+    redirect,
     render_template,
     request,
     send_from_directory,
     session,
 )
-from flask_wtf.csrf import CSRFProtect
+from flask_wtf.csrf import CSRFError, CSRFProtect
 from sqlalchemy import event as sa_event
 from sqlalchemy.engine import Engine
 
@@ -538,6 +540,18 @@ def _create_app_inner():
         if request.path.startswith('/api/'):
             return jsonify({'error': 'Internal server error', 'status': 500}), 500
         return render_template('errors/500.html'), 500
+
+    @app.errorhandler(CSRFError)
+    def handle_csrf_error(error):
+        # Long-open forms (>WTF_CSRF_TIME_LIMIT seconds) submit a stale token and
+        # get a raw "Bad Request" page. On page-load-driven forms (events page,
+        # scheduling actions, etc.) this silently eats clicks. Redirect back to
+        # the referrer with a flash so the next GET loads a fresh token.
+        if request.path.startswith('/api/'):
+            return jsonify({'error': 'CSRF token missing or expired', 'status': 400}), 400
+        flash('Your session expired for security. Please try that action again.', 'warning')
+        target = request.referrer or request.path or '/'
+        return redirect(target)
 
     return app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.10.0"
+version = "2.10.1"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/tests/test_csrf_error_handler.py
+++ b/tests/test_csrf_error_handler.py
@@ -1,0 +1,71 @@
+"""Regression test for the CSRFError handler in app.py.
+
+Context: the default Flask-WTF behavior on a missing/expired CSRF token is a
+raw 400 "Bad Request" page. On long-open forms (CSRF time limit defaults to
+1 hour) this silently ate user clicks, e.g., the "Integrate Spillover" button
+on the scheduling page. The handler in app.py converts that into a flash +
+redirect on HTML routes so the user gets a clear, actionable message.
+
+Found during /investigate on 2026-04-21.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def csrf_app():
+    """App with CSRF protection actually enabled (global conftest disables it)."""
+    os.environ.pop("WTF_CSRF_ENABLED", None)
+    from app import create_app
+
+    app = create_app()
+    app.config["WTF_CSRF_ENABLED"] = True
+    app.config["TESTING"] = True
+    # Re-disable globally so other tests continue to run with CSRF off
+    os.environ["WTF_CSRF_ENABLED"] = "False"
+    yield app
+
+
+def test_csrf_error_on_html_route_redirects_with_flash(csrf_app):
+    """A POST with missing CSRF on an HTML route redirects to the referrer
+    with a user-friendly warning flash, rather than returning a raw 400 page."""
+    with csrf_app.test_client() as client:
+        referrer = "http://localhost/scheduling/2/events"
+        resp = client.post(
+            "/scheduling/2/events",
+            data={"action": "integrate_spillover"},
+            headers={"Referer": referrer},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302, (
+            f"expected redirect (handler caught CSRFError), got {resp.status_code}; "
+            "regression: CSRFError handler is missing or broken"
+        )
+        assert resp.headers.get("Location") == referrer
+
+        with client.session_transaction() as sess:
+            flashes = sess.get("_flashes", [])
+        categories = [c for c, _ in flashes]
+        messages = [m for _, m in flashes]
+        assert "warning" in categories, f"no warning flash: {flashes}"
+        assert any(
+            "session expired" in m.lower() for m in messages
+        ), f"flash did not mention session expired: {messages}"
+
+
+def test_csrf_error_falls_back_to_request_path_when_no_referrer(csrf_app):
+    """If the browser omits the Referer header, redirect to request.path so the
+    user still lands on a usable page and reloads with a fresh token."""
+    with csrf_app.test_client() as client:
+        resp = client.post(
+            "/scheduling/2/events",
+            data={"action": "integrate_spillover"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        location = resp.headers.get("Location", "")
+        assert location.endswith(
+            "/scheduling/2/events"
+        ), f"expected fallback to request path, got {location!r}"


### PR DESCRIPTION
## Summary

Fixes a silent-failure bug where every CSRF-protected form in the app dropped clicks once the 1-hour `WTF_CSRF_TIME_LIMIT` elapsed. Flask-WTF's default is a raw `400 Bad Request` page with no actionable message, so users thought the button was broken.

First reported against the "Integrate Spillover" button on `/scheduling/<tid>/events` after a judge had the tab open configuring spillover selections for >1 hour. Same mechanism affected every POST form in the app.

**Fix ([`app.py`](app.py)):** register a `@app.errorhandler(CSRFError)` that:
- HTML routes → 302 redirect to `request.referrer` (or `request.path` fallback) + flash `"Your session expired for security. Please try that action again."` The next GET loads a fresh token, so one more click actually goes through.
- `/api/` routes → `{"error":"CSRF token missing or expired","status":400}` JSON for programmatic clients.

## Test Coverage

- **2 new regression tests** in [`tests/test_csrf_error_handler.py`](tests/test_csrf_error_handler.py):
  - HTML route with missing CSRF → 302 to referrer + warning flash
  - HTML route with no `Referer` header → fallback to `request.path`
- Tests use a fixture that re-enables CSRF protection for the test app (the project's `conftest.py` disables it for all other tests — `WTF_CSRF_ENABLED=False`).
- Tests: 184/184 passing across `test_csrf_error_handler.py`, `test_routes_smoke.py`, `test_flask_reliability.py`, `test_infrastructure.py`.

## Pre-Landing Review

Manual audit — 16-line diff, no SQL, no LLM trust boundary, no new side effects. Standard Flask-WTF `CSRFError` handler pattern straight from the documentation. Specialist dispatch skipped per `/ship` rule (diff < 50 lines).

## Live Verification

After restarting the dev server to pick up the change:

```
$ curl -i -X POST http://localhost:5000/scheduling/2/events \
    -H "Referer: http://localhost:5000/scheduling/2/events" \
    --data "action=integrate_spillover"
HTTP/1.1 302 FOUND
Location: http://localhost:5000/scheduling/2/events
Set-Cookie: session=...   # flash cookie carries the warning
```

Previously this returned `400 Bad Request` with a raw `<h1>Bad Request</h1>` page.

## Test plan

- [x] `pytest tests/test_csrf_error_handler.py` — 2/2 pass
- [x] Surrounding smoke/reliability/infra suites — 184/184 pass
- [x] Live server returns 302 + flash on POST with missing CSRF
- [x] Live server returns JSON 400 on `/api/` POST with missing CSRF (verified via test client)
- [x] Homepage still 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)