### PR TITLE
Saturday one-click Generate + Friday Night Feature schedule & print

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,9 @@ build/
 .coverage
 htmlcov/
 
+# gstack skill artifacts (retros, QA reports, checkpoints — local tooling output)
+.context/
+.gstack/
+
 # Logs
 *.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,9 @@ Saturday overflow college events are judged and scored as normal college events 
 
 ### Friday Night Feature
 
-The Friday Night Feature is an optional overflow or special events session run after the college day concludes on Friday. It is built separately from both the main college and pro schedules. Typical events are Collegiate 1-Board, Pro 1-Board, and Pro 3-Board Jigger. The `Tournament` model has a `friday_feature_date` field to record when this session is held, but no dedicated scheduling UI, heat generation logic, or flight structure exists for it. Flag as a known gap (see Section 5).
+The Friday Night Feature is an optional overflow or special events session run after the college day concludes on Friday. It is built separately from both the main college and pro schedules. Typical events are Collegiate 1-Board, Pro 1-Board, and Pro 3-Board Jigger. The `Tournament` model has a `friday_feature_date` field to record when this session is held.
+
+As of V2.11.0, FNF has full scheduling: events selected via the Friday Showcase page are saved to `schedule_config['friday_pro_event_ids']`. The flight builder excludes those event IDs from Saturday pro flights (their heats stay in the DB with `flight_id=NULL`). The Friday Showcase page renders a heat-by-heat schedule table in Springboard → Pro 1-Board → 3-Board Jigger order (see `_fnf_event_order()` in `routes/scheduling/friday_feature.py`). A printable view lives at `/scheduling/<tid>/friday-night/print`. FNF intentionally runs as a straight heat-by-heat schedule (like college day), not as flight blocks — there is nothing to interleave with only 1-3 events.
 
 ---
 
@@ -408,7 +410,8 @@ PayoutTemplate  (tournament-independent, standalone)
 - Validation service for teams, college competitors, pro competitors, heat constraints; validation API (JSON) endpoints
 - Saturday priority route (`/scheduling/<tid>/college/saturday-priority`) for college overflow event flagging
 - College Saturday overflow flight integration: `integrate_college_spillover_into_flights()` places Chokerman's Race Run 2 at the end of the last flight in heat-number order; other overflow events distributed round-robin; wired to `event_list` POST actions
-- Friday Night Feature: route, config (JSON in `instance/`), and template (`/scheduling/<tid>/friday-feature`) — UI exists, no heat generation or flight integration
+- Friday Night Feature (V2.11.0): full heat-by-heat schedule at `/scheduling/<tid>/friday-night` with event-ordered table (Springboard → Pro 1-Board → 3-Board Jigger), inline Score links, and `schedule_config['friday_pro_event_ids']` persistence. Flight builder (`build_pro_flights`) excludes these event IDs from Saturday flights — heats stay in DB with `flight_id=NULL`. Printable view at `/scheduling/<tid>/friday-night/print`; CSP-compliant (script block with nonce-injected `addEventListener`, not inline `onclick`)
+- One-click Saturday show build (V2.11.0): `POST /scheduling/<tid>/flights/one-click-generate` runs `_generate_all_heats` → `build_pro_flights` → `integrate_college_spillover_into_flights` in a single transaction; flashes per-step progress; redirects to Flights. Button uses `data-confirm` + `data-confirm-danger` attributes (base.html delegated handler) instead of blocked inline `onsubmit`
 - Flask-Login authentication: 7 roles (admin, judge, scorer, registrar, competitor, spectator, viewer); login/logout/bootstrap/user-management; audit log viewer (`/auth/audit`, admin-only, paginated, filterable)
 - `require_judge_for_management_routes` before_request hook; portal and auth routes are public
 - Portal — spectator: college standings (live), pro standings, event results, relay results; mobile/desktop view toggle; kiosk TV display (`/portal/kiosk/<tid>`, 4-panel 15s rotation)
@@ -494,7 +497,7 @@ PayoutTemplate  (tournament-independent, standalone)
 
 **Excel results export route (direct download):** `export_results_to_excel()` exists in `services/excel_io.py`. An async background export job route exists at `/reporting/<tid>/export-results/async`, but no route triggers a direct synchronous Excel download. The async job approach is the recommended path forward — completing the status/download endpoint would close this gap.
 
-**Friday Night Feature heat generation and flight integration:** The Friday Night Feature has a route, config storage, and UI template. However, no heat generation logic or flight integration exists for it. Heats and flights for Friday Night Feature events must be managed manually or via the standard event/heat flow.
+**Friday Night Feature schedule view (V2.11.0):** The Friday Night Feature now has a heat-by-heat schedule view on the Friday Showcase page plus a printable view at `/scheduling/<tid>/friday-night/print`. FNF events selected into `schedule_config['friday_pro_event_ids']` are excluded from Saturday pro flights (their heats exist in the DB with `flight_id=NULL`). Heats are ordered Springboard → Pro 1-Board → 3-Board Jigger via `_fnf_event_order()` in `routes/scheduling/friday_feature.py`. FNF still runs as a straight heat-by-heat schedule, not flights — intentional, matching college day format.
 
 **Pro event fee configuration UI:** No route or template exists for setting fee amounts per event per tournament. `entry_fees` and `fees_paid` fields exist on `ProCompetitor` but fees must currently be set directly in the database or via the edit competitor form.
 
@@ -730,7 +733,6 @@ The broader vision: STRATHMARK calculates start marks and predicted times, feeds
 The following features remain as planned or implied by the codebase and requirements:
 
 **Remaining gaps (from Section 5):**
-- Friday Night Feature heat generation and flight integration
 - Excel results export direct download route
 - Pro event fee configuration UI
 - Pro entry form redesign (scope pending; current import handled by `registration_import.py` enhanced pipeline)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,44 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.11.0)
+
+**Minor — one-click Saturday show build + Friday Night Feature schedule**
+
+Single button on the Pro Flights page that builds the entire Saturday show, plus a complete Friday Night Feature schedule view and printable layout.
+
+**New — `POST /scheduling/<tid>/flights/one-click-generate`:**
+- Runs `_generate_all_heats` → `build_pro_flights` → `integrate_college_spillover_into_flights` in one transaction.
+- Flashes per-step progress, redirects back to the Flights page.
+- Button uses the app's `data-confirm` / `data-confirm-danger` attribute pattern (Bootstrap modal via `base.html` delegated handler) — NOT inline `onsubmit`, which the app's strict CSP blocks.
+
+**New — Friday Night Feature schedule view:**
+- Friday Showcase page (`/scheduling/<tid>/friday-night`) now renders a heat-by-heat schedule table below the config form. Each row: slot, event, heat + run, competitors with stand assignments, inline Score link. FNF runs as a straight schedule like college day, not flights.
+- Events ordered Springboard → Pro 1-Board → 3-Board Jigger via `_fnf_event_order()`.
+- `_build_fnf_schedule(tournament, eligible_events, fnf_config)` builds the data; shared between the page and print view.
+
+**New — printable FNF schedule:**
+- `GET /scheduling/<tid>/friday-night/print` renders `templates/scheduling/friday_feature_print.html`: event blocks, rowspan-merged heat cells, competitor-by-stand rows, optional notes banner, header/footer with generation timestamp.
+- Print button uses `id="fnf-print-btn"` + inline `<script>` block (auto-nonced by `app.py:_inject_csp_nonce`) with `addEventListener('click', window.print)` — CSP-compliant.
+
+**`services/flight_builder.py` changes:**
+- `build_pro_flights()` reads `tournament.get_schedule_config()['friday_pro_event_ids']` and excludes those event IDs from Saturday flight building. Their heats stay in the DB with `flight_id=NULL` so the FNF schedule view can find them. Handles malformed config gracefully.
+- `MIN_HEATS_PER_FLIGHT = 2` clamp: if caller-supplied `num_flights` would produce fewer than 2 heats per flight, `target_flights` is reduced to `ceil(total_heats / 2)`.
+- `contains_lh` flag scoped to springboard heats only. Prior code flagged ANY heat containing a left-handed-springboard competitor (including Obstacle Pole, Cookie Stack, etc.) as "LH-containing," producing false-positive `LH DUMMY CONTENTION` warnings. The LH dummy is a physical springboard stand; only springboard heats contend for it.
+
+**Regression tests — `tests/test_one_click_and_fnf.py` (12 tests):**
+- `TestFNFExclusion` — 3 tests
+- `TestMinHeatsPerFlightClamp` — 2 tests
+- `TestOneClickGenerateRoute` — 2 tests
+- `TestBuildFnfSchedule` — 4 tests
+- `TestFridayFeaturePrintRoute` — 1 test (includes CSP regression guard — asserts no `onclick=` or `onsubmit=` in rendered body)
+
+All 95 flight-builder + FNF tests pass.
+
+**Data model:** No schema changes. Uses existing `schedule_config` JSON column on `Tournament`.
+
+---
+
 ### 2026-04-21 (V2.10.0)
 
 **Minor — hand-saw stand block alternation**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.10.0
+# Missoula Pro Am Manager — V2.11.0
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 
@@ -526,4 +526,4 @@ Operational docs:
 
 ---
 
-*Last updated: April 2026 — V2.9.0*
+*Last updated: April 2026 — V2.11.0*

--- a/migrations/versions/l2a3b4c5d6e7_add_is_override_to_teams.py
+++ b/migrations/versions/l2a3b4c5d6e7_add_is_override_to_teams.py
@@ -1,0 +1,38 @@
+"""Add is_override column to teams (admin validation override persistence).
+
+Allows a judge to mark a team valid despite failing roster constraints (small
+schools with e.g. 5 men + 0 women that still want to compete). Re-validation
+and Excel re-imports preserve this flag via Team.set_validation_errors so the
+override survives operational churn.
+
+Revision ID: l2a3b4c5d6e7
+Revises: f5a6b7c8d9e0
+Create Date: 2026-04-21 12:00:00
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "l2a3b4c5d6e7"
+down_revision = "f5a6b7c8d9e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Direct op.add_column call for PG safety per CLAUDE.md migration protocol.
+    # Boolean server_default uses sa.text('false') — NEVER '0' or sa.text('0')
+    # because PostgreSQL rejects integer literals on boolean columns.
+    op.add_column(
+        "teams",
+        sa.Column(
+            "is_override",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("teams", "is_override")

--- a/models/team.py
+++ b/models/team.py
@@ -37,6 +37,15 @@ class Team(db.Model):
     # Validation error tracking (JSON list of structured error dicts; None = no errors recorded)
     validation_errors = db.Column(db.Text, nullable=True)
 
+    # Admin override — when True, validation errors are recorded for display but do NOT
+    # flip the team to 'invalid' status. Used for edge-case small rosters (e.g., 5 men + 0
+    # women) where a judge has manually decided the team may still compete. Re-validation
+    # and Excel re-imports preserve this flag; only an explicit "remove override" action
+    # clears it. If re-validation finds zero errors the flag auto-clears (vestigial).
+    is_override = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text('false')
+    )
+
     # Relationships
     members = db.relationship('CollegeCompetitor', backref='team', lazy='dynamic')
 
@@ -93,7 +102,22 @@ class Team(db.Model):
             return []
 
     def set_validation_errors(self, errors: list):
-        """Store structured errors and update team status accordingly."""
+        """Store structured errors and update team status.
+
+        Normal path: errors → status='invalid', no errors → status='active'.
+
+        Override path: if is_override is True, errors are still written for UI
+        display but status stays 'active' — a judge has manually accepted the
+        roster despite the violations. If the team becomes genuinely clean
+        (errors=[]) the override flag auto-clears since it's vestigial.
+        """
         import json
         self.validation_errors = json.dumps(errors)
-        self.status = 'invalid' if errors else 'active'
+        if not errors:
+            self.status = 'active'
+            self.is_override = False
+            return
+        if self.is_override:
+            self.status = 'active'
+            return
+        self.status = 'invalid'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.10.0"
+version = "2.11.0"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/registration.py
+++ b/routes/registration.py
@@ -318,12 +318,22 @@ def revalidate_team(tournament_id, team_id):
 
     errors_by_team = _validate_college_entry_constraints({team_id})
     team_errors = errors_by_team.get(team_id, [])
+    was_override = team.is_override
     team.set_validation_errors(team_errors)
     db.session.commit()
     invalidate_tournament_caches(tournament_id)
 
     if not team_errors:
-        flash(f'Team {team.team_code} passed validation and is now active.', 'success')
+        if was_override:
+            flash(f'Team {team.team_code} now passes validation cleanly. Admin override cleared.', 'success')
+        else:
+            flash(f'Team {team.team_code} passed validation and is now active.', 'success')
+    elif team.is_override:
+        flash(
+            f'Team {team.team_code} still has {len(team_errors)} error(s) but admin override keeps it active. '
+            f'Click "Remove override" to drop the override.',
+            'warning',
+        )
     else:
         flash(f'Team {team.team_code} still has {len(team_errors)} error(s). Fix them and re-validate.', 'warning')
     return redirect(url_for('registration.team_detail', tournament_id=tournament_id, team_id=team_id))
@@ -337,12 +347,68 @@ def override_team_validation(tournament_id, team_id):
         flash('Team not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
 
-    team.status = 'active'
-    team.validation_errors = '[]'
+    # Capture the failing errors so they survive on the team record for display
+    # (the UI shows them as informational warnings under the override badge).
+    from services.excel_io import _validate_college_entry_constraints
+    errors_by_team = _validate_college_entry_constraints({team_id})
+    team_errors = errors_by_team.get(team_id, [])
+
+    team.is_override = True
+    # set_validation_errors respects is_override: status stays 'active', errors
+    # are preserved for display. If the team actually passes cleanly, the flag
+    # auto-clears (harmless — override was vestigial anyway).
+    team.set_validation_errors(team_errors)
     db.session.commit()
     invalidate_tournament_caches(tournament_id)
-    log_action('team_validation_override', 'team', team.id, {'team_code': team.team_code})
-    flash(f'Team {team.team_code} forced to valid via admin override.', 'warning')
+    log_action(
+        'team_validation_override',
+        'team',
+        team.id,
+        {'team_code': team.team_code, 'error_count': len(team_errors)},
+    )
+    flash(
+        f'Team {team.team_code} forced to valid via admin override '
+        f'({len(team_errors)} validation error(s) ignored). '
+        f'Override persists through re-validation and Excel re-imports.',
+        'warning',
+    )
+    return redirect(url_for('registration.team_detail', tournament_id=tournament_id, team_id=team_id))
+
+
+@registration_bp.route('/<int:tournament_id>/college/team/<int:team_id>/remove-override', methods=['POST'])
+def remove_team_override(tournament_id, team_id):
+    """Drop the admin override on a team and re-run validation.
+
+    If the team passes cleanly afterwards, it stays active. If it still has
+    errors, it flips back to 'invalid' and the user must fix the roster or
+    re-apply the override.
+    """
+    from services.excel_io import _validate_college_entry_constraints
+    team = Team.query.get_or_404(team_id)
+    if team.tournament_id != tournament_id:
+        flash('Team not found in this tournament.', 'error')
+        return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
+
+    if not team.is_override:
+        flash(f'Team {team.team_code} is not currently overridden.', 'info')
+        return redirect(url_for('registration.team_detail', tournament_id=tournament_id, team_id=team_id))
+
+    team.is_override = False
+    errors_by_team = _validate_college_entry_constraints({team_id})
+    team_errors = errors_by_team.get(team_id, [])
+    team.set_validation_errors(team_errors)
+    db.session.commit()
+    invalidate_tournament_caches(tournament_id)
+    log_action('team_validation_override_removed', 'team', team.id, {'team_code': team.team_code})
+
+    if team_errors:
+        flash(
+            f'Override removed. Team {team.team_code} now has {len(team_errors)} validation '
+            f'error(s) and is marked invalid. Fix the roster or re-apply the override.',
+            'warning',
+        )
+    else:
+        flash(f'Override removed. Team {team.team_code} passes validation cleanly.', 'success')
     return redirect(url_for('registration.team_detail', tournament_id=tournament_id, team_id=team_id))
 
 

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -11,7 +11,53 @@ from models.competitor import CollegeCompetitor, ProCompetitor
 from services.audit import log_action
 from services.background_jobs import submit as submit_job
 
-from . import scheduling_bp
+from . import _build_pro_flights_if_possible, _generate_all_heats, scheduling_bp
+
+
+@scheduling_bp.route('/<int:tournament_id>/flights/one-click-generate', methods=['POST'])
+def one_click_generate(tournament_id):
+    """Generate heats for every event AND build pro flights AND integrate college
+    spillover — in a single user action. Redirects back to the Flights page.
+
+    This is the button users reach for when they have competitors registered and
+    Friday/Saturday configuration done and just want the show schedule built.
+    """
+    from services.flight_builder import (
+        build_pro_flights,
+        integrate_college_spillover_into_flights,
+    )
+    from services.heat_generator import generate_event_heats
+    from services.saw_block_assignment import trigger_saw_block_recompute
+
+    tournament = Tournament.query.get_or_404(tournament_id)
+
+    db_config = tournament.get_schedule_config() or {}
+    saturday_college_event_ids = [int(i) for i in db_config.get('saturday_college_event_ids', [])]
+
+    try:
+        _generate_all_heats(tournament, generate_event_heats)
+        flights_built = _build_pro_flights_if_possible(tournament, build_pro_flights)
+        if flights_built is not None:
+            flash(f'Built {flights_built} pro flight(s).', 'success')
+            integration = integrate_college_spillover_into_flights(
+                tournament, saturday_college_event_ids,
+            )
+            if integration['integrated_heats'] > 0:
+                db.session.commit()
+                flash(
+                    f"Integrated {integration['integrated_heats']} college spillover heat(s) "
+                    'into Saturday flights.',
+                    'success',
+                )
+        trigger_saw_block_recompute(tournament)
+        log_action('one_click_generate', 'tournament', tournament_id, {
+            'flights_built': flights_built,
+        })
+    except Exception as exc:
+        db.session.rollback()
+        flash(f'One-click generate failed and was rolled back: {exc}', 'error')
+
+    return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
 
 
 @scheduling_bp.route('/<int:tournament_id>/flights')
@@ -78,6 +124,39 @@ def build_flights(tournament_id):
         if pro_heat_count == 0:
             flash('No pro heats found. Generate heats for pro events first, then build flights.', 'warning')
             return redirect(url_for('scheduling.event_list', tournament_id=tournament_id))
+
+        # Flights exist to interleave heats from DIFFERENT events for crowd variety.
+        # Warn when that premise is broken, but still run the builder so the user can
+        # clear stale flight data and see the best grouping for the current heat state.
+        pro_events_with_heats = db.session.query(Event.id).join(Heat).filter(
+            Event.tournament_id == tournament_id,
+            Event.event_type == 'pro',
+            Event.name != 'Partnered Axe Throw',
+            Heat.run_number == 1,
+        ).distinct().count()
+        if pro_events_with_heats <= 1:
+            flash(
+                f'Only {pro_events_with_heats} pro event has heats generated. Flights group '
+                'heats from multiple events for crowd variety — all heats will land in a '
+                'single flight until more events have heats generated.',
+                'warning',
+            )
+            num_flights = None  # let the builder collapse to one flight of up to 8
+
+        # Clamp num_flights so each flight gets at least 2 heats; a "flight" with 1 heat is
+        # just a heat. Mirrors MIN_HEATS_PER_FLIGHT in flight_builder.
+        elif num_flights and num_flights > 0 and pro_heat_count >= 2:
+            effective_heats_per_flight = pro_heat_count // num_flights
+            if effective_heats_per_flight < 2:
+                import math as _math
+                clamped = _math.ceil(pro_heat_count / 2)
+                if clamped != num_flights:
+                    flash(
+                        f'Requested {num_flights} flights for {pro_heat_count} heats would '
+                        f'give less than 2 heats per flight. Building {clamped} flights instead.',
+                        'info',
+                    )
+                num_flights = clamped
 
         if request.form.get('run_async') == '1':
             def _build_flights_async(target_tournament_id: int, requested_num_flights: int | None):

--- a/routes/scheduling/friday_feature.py
+++ b/routes/scheduling/friday_feature.py
@@ -161,6 +161,7 @@ def friday_feature(tournament_id):
         return redirect(url_for('scheduling.friday_feature', tournament_id=tournament_id))
 
     selected_saturday_ids = set(int(i) for i in saved_opts.get('saturday_college_event_ids', []))
+    fnf_schedule = _build_fnf_schedule(tournament, eligible_events, fnf_config)
 
     return render_template(
         'scheduling/friday_feature.html',
@@ -170,4 +171,101 @@ def friday_feature(tournament_id):
         notes=fnf_config.get('notes', ''),
         sat_eligible=sat_eligible,
         selected_saturday_ids=selected_saturday_ids,
+        fnf_schedule=fnf_schedule,
     )
+
+
+@scheduling_bp.route('/<int:tournament_id>/friday-night/print')
+def friday_feature_print(tournament_id):
+    """Printable Friday Night Feature schedule — heat-by-heat order per event."""
+    tournament = Tournament.query.get_or_404(tournament_id)
+    eligible_names = set(config.FRIDAY_NIGHT_EVENTS)
+    pro_events = tournament.events.filter_by(event_type='pro').order_by(Event.name, Event.gender).all()
+    eligible_events = [e for e in pro_events if e.name in eligible_names]
+
+    fnf_config = _load_fnf_config(tournament)
+    fnf_schedule = _build_fnf_schedule(tournament, eligible_events, fnf_config)
+
+    from datetime import datetime
+    return render_template(
+        'scheduling/friday_feature_print.html',
+        tournament=tournament,
+        fnf_schedule=fnf_schedule,
+        notes=fnf_config.get('notes', ''),
+        now=datetime.utcnow(),
+    )
+
+
+def _build_fnf_schedule(tournament, eligible_events, fnf_config):
+    """Build the Friday Night Feature schedule: selected FNF events in run order,
+    each with its heats (run_number, heat_number ordered) and competitor/stand data.
+
+    FNF runs as a straight heat-by-heat schedule similar to college day — no flight
+    grouping. Used by both the interactive page and the printable view.
+    """
+    from models import Heat
+    from models.competitor import ProCompetitor
+
+    selected_event_ids = list(fnf_config.get('event_ids', []))
+    if not selected_event_ids:
+        return []
+
+    ordered_events = sorted(
+        [e for e in eligible_events if e.id in selected_event_ids],
+        key=lambda e: (_fnf_event_order(e.name), e.gender or ''),
+    )
+
+    schedule = []
+    slot = 1
+    for event in ordered_events:
+        event_heats = (
+            Heat.query
+            .filter_by(event_id=event.id)
+            .order_by(Heat.run_number, Heat.heat_number)
+            .all()
+        )
+        heat_rows = []
+        for heat in event_heats:
+            comp_ids = heat.get_competitors()
+            stand_assignments = heat.get_stand_assignments()
+            if comp_ids:
+                pros = {
+                    c.id: c for c in ProCompetitor.query.filter(
+                        ProCompetitor.id.in_(comp_ids)
+                    ).all()
+                }
+            else:
+                pros = {}
+            heat_rows.append({
+                'heat_id': heat.id,
+                'heat_number': heat.heat_number,
+                'run_number': heat.run_number,
+                'competitors': [
+                    {
+                        'name': pros[cid].display_name if cid in pros else f'ID:{cid}',
+                        'stand': stand_assignments.get(str(cid), '?'),
+                    }
+                    for cid in comp_ids
+                ],
+            })
+        schedule.append({
+            'slot': slot,
+            'event': event,
+            'heats': heat_rows,
+        })
+        slot += 1
+
+    return schedule
+
+
+# Friday Night Feature event ordering — Springboard sequencing rules for the showcase.
+# Matches services/schedule_builder._apply_friday_springboard_ordering at a high level:
+# Springboard → Pro 1-Board → 3-Board Jigger, with anything else trailing.
+_FNF_ORDER = ['Springboard', 'Pro 1-Board', '3-Board Jigger']
+
+
+def _fnf_event_order(name: str) -> int:
+    try:
+        return _FNF_ORDER.index(name)
+    except ValueError:
+        return len(_FNF_ORDER) + 1

--- a/services/excel_io.py
+++ b/services/excel_io.py
@@ -200,12 +200,14 @@ def _process_standard_entry_form(df: pd.DataFrame, tournament: Tournament, defau
         if not team:
             continue
         team_errors = errors_by_team.get(team_id, [])
-        if team_errors:
-            team.set_validation_errors(team_errors)
+        # set_validation_errors handles all three cases uniformly:
+        #   errors=[]       -> status='active', is_override auto-cleared (vestigial)
+        #   errors, override -> status='active' (preserved), errors written for display
+        #   errors, no ovr  -> status='invalid', errors written
+        team.set_validation_errors(team_errors)
+        if team.status == 'invalid':
             invalid_count += 1
         else:
-            team.validation_errors = '[]'
-            team.status = 'active'
             valid_count += 1
 
     db.session.commit()

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -155,7 +155,11 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None) -> int:
         event = event_by_id.get(heat.event_id)
         if event:
             comps = set(heat.get_competitors())
-            contains_lh = any(lh_flags.get(cid, False) for cid in comps)
+            # contains_lh is only meaningful for springboard heats — that is the
+            # only event type that physically uses the LH dummy. A LH competitor
+            # racing obstacle pole or cookie stack has no bearing on the dummy.
+            is_springboard = getattr(event, 'stand_type', None) == 'springboard'
+            contains_lh = is_springboard and any(lh_flags.get(cid, False) for cid in comps)
             all_heats.append({
                 'heat': heat,
                 'event': event,

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -94,10 +94,26 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None) -> int:
     )
     partnered_axe_heats = _prepare_partnered_axe_show_heats(partnered_axe_event)
 
+    # Exclude Friday Night Feature events from Saturday flight building.
+    # FNF events (e.g. Pro 1-Board, 3-Board Jigger) run Friday evening as a separate
+    # showcase and must NOT appear in Saturday pro flights.
+    fnf_event_ids: set[int] = set()
+    try:
+        schedule_config = tournament.get_schedule_config() or {}
+        fnf_event_ids = {
+            int(eid) for eid in schedule_config.get('friday_pro_event_ids', [])
+            if str(eid).strip()
+        }
+    except Exception:
+        logger.warning('flight_builder: could not read friday_pro_event_ids', exc_info=True)
+
     # Collect all non-axe heats with their competitor information.
     # Batch-load all heats for non-axe events in a single query to avoid N+1.
-    non_axe_events = [e for e in pro_events
-                      if not (partnered_axe_event and e.id == partnered_axe_event.id)]
+    non_axe_events = [
+        e for e in pro_events
+        if not (partnered_axe_event and e.id == partnered_axe_event.id)
+        and e.id not in fnf_event_ids
+    ]
     non_axe_event_ids = [e.id for e in non_axe_events]
     event_by_id = {e.id: e for e in non_axe_events}
 
@@ -151,10 +167,22 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None) -> int:
         return 0
 
     # Derive heats_per_flight from caller-supplied num_flights, or fall back to default of 8.
+    # A flight is a grouping of heats from different events for crowd variety, so enforce a
+    # minimum of 2 heats per flight — otherwise "flights" are just heats in a wrapper.
     total_non_axe = len(all_heats)
+    MIN_HEATS_PER_FLIGHT = 2
     if num_flights and num_flights > 0 and total_non_axe > 0:
         target_flights = int(num_flights)
         heats_per_flight = math.ceil(total_non_axe / target_flights)
+        if heats_per_flight < MIN_HEATS_PER_FLIGHT and total_non_axe >= MIN_HEATS_PER_FLIGHT:
+            heats_per_flight = MIN_HEATS_PER_FLIGHT
+            clamped = math.ceil(total_non_axe / heats_per_flight)
+            logger.warning(
+                'flight_builder: requested %d flights for %d heats would give <%d per flight; '
+                'clamped to %d flights (%d heats each)',
+                num_flights, total_non_axe, MIN_HEATS_PER_FLIGHT, clamped, heats_per_flight,
+            )
+            target_flights = clamped
     else:
         heats_per_flight = 8
         target_flights = math.ceil(total_non_axe / heats_per_flight) if total_non_axe else 0

--- a/templates/college/registration.html
+++ b/templates/college/registration.html
@@ -92,7 +92,8 @@
                             <tbody>
                                 {% for t in all_teams %}
                                 {% set is_invalid = (t.status == 'invalid') %}
-                                {% set errs = t.get_validation_errors() if is_invalid else [] %}
+                                {% set is_override = t.is_override %}
+                                {% set errs = t.get_validation_errors() if (is_invalid or is_override) else [] %}
                                 <tr data-validity="{{ 'invalid' if is_invalid else 'valid' }}">
                                     <td><strong>{{ t.team_code }}</strong></td>
                                     <td>{{ t.school_name }}</td>
@@ -100,14 +101,22 @@
                                     <td>{{ t.female_count }}</td>
                                     <td>{{ t.member_count }}</td>
                                     <td>
-                                        {% if is_invalid %}
+                                        {% if is_override %}
+                                        <span class="badge bg-warning text-dark" title="Admin override — {{ errs|length }} error(s) ignored, team competes normally">
+                                            <i class="bi bi-shield-exclamation"></i> Override
+                                        </span>
+                                        {% elif is_invalid %}
                                         <span class="badge bg-danger">Invalid</span>
                                         {% else %}
                                         <span class="badge bg-success">Valid</span>
                                         {% endif %}
                                     </td>
                                     <td>
-                                        {% if is_invalid %}
+                                        {% if is_override %}
+                                        <span class="badge bg-warning text-dark" title="{{ errs|map(attribute='message')|join('; ') }}">
+                                            {{ errs|length }} ignored
+                                        </span>
+                                        {% elif is_invalid %}
                                         <span class="badge bg-danger" title="{{ errs|map(attribute='message')|join('; ') }}">
                                             {{ errs|length }} error{% if errs|length != 1 %}s{% endif %}
                                         </span>

--- a/templates/college/team_detail.html
+++ b/templates/college/team_detail.html
@@ -25,7 +25,13 @@
                     <p class="text-muted mb-0">{{ team.school_name }}</p>
                 </div>
                 <div>
-                    {% if team.status == 'invalid' %}
+                    {% if team.is_override %}
+                        <span class="badge bg-warning text-dark fs-6"
+                              title="A judge has manually accepted this roster despite {{ validation_errors|length }} validation error(s). The team competes normally.">
+                            <i class="bi bi-shield-exclamation"></i>
+                            Admin Override — {{ validation_errors|length }} Error{% if validation_errors|length != 1 %}s{% endif %} Ignored
+                        </span>
+                    {% elif team.status == 'invalid' %}
                         <span class="badge bg-danger fs-6">
                             <i class="bi bi-exclamation-triangle-fill"></i>
                             Invalid — {{ validation_errors|length }} Error{% if validation_errors|length != 1 %}s{% endif %}
@@ -49,6 +55,24 @@
             Use the fix forms below to correct each error, then click <strong>Re-validate Team</strong>.
             This team is <em>not counted</em> in standings or scheduling until all errors are resolved.
         </div>
+    </div>
+    {% endif %}
+
+    <!-- Override banner — team has accepted errors but competes normally -->
+    {% if team.is_override %}
+    <div class="alert alert-warning d-flex align-items-start gap-2" role="alert">
+        <i class="bi bi-shield-exclamation fs-5 mt-1 flex-shrink-0"></i>
+        <div class="flex-grow-1">
+            <strong>Admin override active — {{ validation_errors|length }} validation error{% if validation_errors|length != 1 %}s{% endif %} ignored.</strong>
+            This team competes normally: members appear in heats, earn points, and show in standings. The override persists through re-validation and Excel re-imports. Review the ignored errors below.
+        </div>
+        <form action="{{ url_for('registration.remove_team_override', tournament_id=tournament.id, team_id=team.id) }}" method="POST" class="ms-2">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="btn btn-sm btn-outline-dark"
+                    onclick="return confirm('Remove the override and re-run validation? The team will flip back to invalid if errors remain.')">
+                <i class="bi bi-x-circle"></i> Remove Override
+            </button>
+        </form>
     </div>
     {% endif %}
 
@@ -316,14 +340,14 @@
                 </div>
             </div>
 
-            <!-- Errors & Fixes section (invalid teams only) -->
-            {% if team.status == 'invalid' and validation_errors %}
-            <div class="card mt-4 border-danger">
-                <div class="card-header bg-danger bg-opacity-10">
-                    <h6 class="mb-0 text-danger">
+            <!-- Errors & Fixes section — shown for invalid OR overridden teams -->
+            {% if validation_errors and (team.status == 'invalid' or team.is_override) %}
+            <div class="card mt-4 {% if team.is_override %}border-warning{% else %}border-danger{% endif %}">
+                <div class="card-header {% if team.is_override %}bg-warning bg-opacity-10{% else %}bg-danger bg-opacity-10{% endif %}">
+                    <h6 class="mb-0 {% if team.is_override %}text-warning-emphasis{% else %}text-danger{% endif %}">
                         <i class="bi bi-tools"></i>
-                        Errors &amp; Fixes
-                        <span class="badge bg-danger ms-1">{{ validation_errors|length }}</span>
+                        {% if team.is_override %}Errors (Overridden — Informational){% else %}Errors &amp; Fixes{% endif %}
+                        <span class="badge {% if team.is_override %}bg-warning text-dark{% else %}bg-danger{% endif %} ms-1">{{ validation_errors|length }}</span>
                     </h6>
                 </div>
                 <div class="card-body p-0">

--- a/templates/pro/flights.html
+++ b/templates/pro/flights.html
@@ -198,20 +198,28 @@
                     </h1>
                     <p class="text-muted mb-0">{{ tournament.name }} {{ tournament.year }} — Saturday Show Schedule</p>
                 </div>
-                <div class="d-flex gap-2">
+                <div class="d-flex gap-2 align-items-center">
                     <a href="{{ url_for('scheduling.heat_sheets', tournament_id=tournament.id) }}"
                        class="btn btn-outline-secondary btn-sm" target="_blank">
                         <i class="bi bi-printer"></i> Print Heat Sheets
                     </a>
-                    {% if not flights %}
+                    <form method="POST"
+                          action="{{ url_for('scheduling.one_click_generate', tournament_id=tournament.id) }}"
+                          class="d-inline"
+                          data-confirm="Generate heats for every event and build pro flights? This will replace any existing heats and flights."
+                          data-confirm-title="Generate All Heats &amp; Build Flights"
+                          data-confirm-danger>
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <button type="submit" class="btn btn-warning">
+                            <i class="bi bi-lightning-charge-fill"></i>
+                            Generate All Heats &amp; Build Flights
+                        </button>
+                    </form>
+                    {% if flights %}
                     <a href="{{ url_for('scheduling.build_flights', tournament_id=tournament.id) }}"
-                       class="btn btn-warning">
-                        <i class="bi bi-plus-circle"></i> Build Flights
-                    </a>
-                    {% else %}
-                    <a href="{{ url_for('scheduling.build_flights', tournament_id=tournament.id) }}"
-                       class="btn btn-outline-warning btn-sm">
-                        <i class="bi bi-arrow-repeat"></i> Rebuild Flights
+                       class="btn btn-outline-warning btn-sm"
+                       title="Rebuild flights only (heats must already exist)">
+                        <i class="bi bi-arrow-repeat"></i> Rebuild Flights Only
                     </a>
                     {% endif %}
                 </div>
@@ -321,10 +329,17 @@
                 <br>Flights mix events for crowd variety and engagement.
             </p>
             <div class="d-flex justify-content-center gap-3">
-                <a href="{{ url_for('scheduling.build_flights', tournament_id=tournament.id) }}"
-                   class="btn btn-warning btn-lg">
-                    <i class="bi bi-plus-circle"></i> Build Flights Now
-                </a>
+                <form method="POST"
+                      action="{{ url_for('scheduling.one_click_generate', tournament_id=tournament.id) }}"
+                      data-confirm="Generate heats for every event and build pro flights?"
+                      data-confirm-title="Generate All Heats &amp; Build Flights"
+                      data-confirm-danger>
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-warning btn-lg">
+                        <i class="bi bi-lightning-charge-fill"></i>
+                        Generate All Heats &amp; Build Flights
+                    </button>
+                </form>
                 <a href="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}"
                    class="btn btn-outline-secondary btn-lg">
                     <i class="bi bi-arrow-left"></i> Back to Schedule

--- a/templates/scheduling/friday_feature.html
+++ b/templates/scheduling/friday_feature.html
@@ -2,10 +2,19 @@
 {% block title %}Friday Showcase & Saturday Options - {{ tournament.name }} {{ tournament.year }}{% endblock %}
 {% block content %}
 <div class="container-fluid py-3">
-    <div class="d-flex justify-content-between align-items-center mb-3">
+    <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
         <h4 class="mb-0">{{ tournament.name }} {{ tournament.year }} — Friday Showcase &amp; Saturday Options</h4>
-        <a class="btn btn-outline-secondary btn-sm"
-           href="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}">Back to Events</a>
+        <div class="d-flex gap-2">
+            {% if fnf_schedule %}
+            <a class="btn btn-outline-warning btn-sm"
+               href="{{ url_for('scheduling.friday_feature_print', tournament_id=tournament.id) }}"
+               target="_blank">
+                <i class="bi bi-printer"></i> Print FNF Schedule
+            </a>
+            {% endif %}
+            <a class="btn btn-outline-secondary btn-sm"
+               href="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}">Back to Events</a>
+        </div>
     </div>
 
     <form method="POST">
@@ -130,6 +139,91 @@
         </div>
 
     </form>
+
+    {# ── Friday Night Feature Schedule — heats per event, in run order ───── #}
+    {% if fnf_schedule %}
+    <div class="card shadow-sm mt-4">
+        <div class="card-header d-flex justify-content-between align-items-center"
+             style="background:rgba(232,144,18,0.12);">
+            <h6 class="mb-0">
+                <i class="bi bi-calendar-week me-1 text-warning"></i>
+                Friday Night Feature Schedule
+            </h6>
+            <span class="small text-muted">
+                Heat-by-heat order — no flight grouping. Same format as college day.
+            </span>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th style="width:48px;">#</th>
+                            <th>Event</th>
+                            <th style="width:70px;">Heat</th>
+                            <th>Competitors (Stand · Name)</th>
+                            <th style="width:80px;">Score</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% set row_ns = namespace(slot=1) %}
+                        {% for block in fnf_schedule %}
+                            {% if block.heats %}
+                                {% for heat in block.heats %}
+                                <tr>
+                                    <td class="text-muted small">{{ row_ns.slot }}</td>
+                                    <td>
+                                        <strong>{{ block.event.display_name }}</strong>
+                                        {% if block.event.gender %}
+                                        <small class="text-muted">({{ 'Men' if block.event.gender == 'M' else 'Women' }})</small>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        H{{ heat.heat_number }}{% if heat.run_number > 1 %}-R{{ heat.run_number }}{% endif %}
+                                    </td>
+                                    <td class="small">
+                                        {% if heat.competitors %}
+                                            {% for comp in heat.competitors %}
+                                                <span class="me-2">
+                                                    <span class="badge bg-secondary">S{{ comp.stand }}</span>
+                                                    {{ comp.name }}
+                                                </span>
+                                            {% endfor %}
+                                        {% else %}
+                                            <span class="text-muted fst-italic">No competitors assigned</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        <a href="{{ url_for('scoring.enter_heat_results', tournament_id=tournament.id, heat_id=heat.heat_id) }}"
+                                           class="btn btn-sm btn-outline-primary">
+                                            Score
+                                        </a>
+                                    </td>
+                                </tr>
+                                {% set row_ns.slot = row_ns.slot + 1 %}
+                                {% endfor %}
+                            {% else %}
+                                <tr>
+                                    <td class="text-muted small">{{ row_ns.slot }}</td>
+                                    <td>
+                                        <strong>{{ block.event.display_name }}</strong>
+                                        {% if block.event.gender %}
+                                        <small class="text-muted">({{ 'Men' if block.event.gender == 'M' else 'Women' }})</small>
+                                        {% endif %}
+                                    </td>
+                                    <td colspan="3" class="text-muted fst-italic small">
+                                        No heats generated yet — use "Generate Heats for Selected Events" above.
+                                    </td>
+                                </tr>
+                                {% set row_ns.slot = row_ns.slot + 1 %}
+                            {% endif %}
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 
     {# ── Summary card (shown when anything is configured) ─────────────── #}
     {% if selected_ids or selected_saturday_ids %}

--- a/templates/scheduling/friday_feature_print.html
+++ b/templates/scheduling/friday_feature_print.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Friday Night Feature Schedule - {{ tournament.name }} {{ tournament.year }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 11pt;
+            margin: 24px;
+            color: #111;
+        }
+        h1 {
+            margin: 0 0 4px 0;
+            font-size: 18pt;
+            color: #000;
+        }
+        h2 {
+            margin: 0 0 8px 0;
+            font-size: 13pt;
+            color: #000;
+        }
+        .muted {
+            color: #555;
+            font-size: 10pt;
+        }
+        .header-bar {
+            border-bottom: 2px solid #000;
+            padding-bottom: 10px;
+            margin-bottom: 18px;
+        }
+        .notes {
+            margin: 10px 0 18px 0;
+            padding: 8px 10px;
+            background: #f7f3e8;
+            border-left: 3px solid #b48820;
+            font-style: italic;
+        }
+        .event-block {
+            margin: 18px 0;
+            page-break-inside: avoid;
+        }
+        .event-header {
+            background: #f1f1f1;
+            border: 1px solid #bbb;
+            padding: 6px 10px;
+            font-weight: 700;
+            font-size: 11.5pt;
+        }
+        .event-meta {
+            font-size: 9.5pt;
+            color: #444;
+            font-weight: normal;
+        }
+        table.heat-table {
+            width: 100%;
+            border-collapse: collapse;
+            border: 1px solid #bbb;
+            border-top: none;
+            table-layout: fixed;
+        }
+        .heat-table th,
+        .heat-table td {
+            border-top: 1px solid #ddd;
+            padding: 5px 8px;
+            vertical-align: top;
+            font-size: 10pt;
+        }
+        .heat-table thead th {
+            background: #fafafa;
+            font-size: 9pt;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+            border-bottom: 2px solid #bbb;
+        }
+        .col-slot { width: 48px; text-align: center; }
+        .col-heat { width: 80px; }
+        .col-stand { width: 40px; text-align: center; font-weight: 700; }
+        .competitor-row td {
+            padding: 3px 8px;
+            border: none;
+            border-bottom: 1px dotted #ddd;
+        }
+        .competitor-row:last-child td { border-bottom: none; }
+        .no-data {
+            padding: 10px;
+            color: #666;
+            font-style: italic;
+            border: 1px solid #bbb;
+            border-top: none;
+        }
+        .print-footer {
+            margin-top: 30px;
+            padding-top: 8px;
+            border-top: 1px solid #bbb;
+            font-size: 9pt;
+            color: #666;
+            display: flex;
+            justify-content: space-between;
+        }
+        @media print {
+            body { margin: 0.5in; }
+            .no-print { display: none; }
+        }
+        .print-button-wrap {
+            text-align: right;
+            margin-bottom: 10px;
+        }
+        .print-button {
+            background: #b48820;
+            color: white;
+            border: none;
+            padding: 6px 14px;
+            font-size: 10.5pt;
+            cursor: pointer;
+            border-radius: 3px;
+        }
+    </style>
+</head>
+<body>
+    <div class="no-print print-button-wrap">
+        <button id="fnf-print-btn" class="print-button">Print</button>
+    </div>
+    <script>
+        document.getElementById('fnf-print-btn').addEventListener('click', function () {
+            window.print();
+        });
+    </script>
+
+    <div class="header-bar">
+        <h1>Friday Night Feature Schedule</h1>
+        <div class="muted">
+            {{ tournament.name }} {{ tournament.year }}
+            {% if tournament.college_date %}
+                &nbsp;·&nbsp; {{ tournament.college_date.strftime('%A, %B %d, %Y') }}
+            {% endif %}
+        </div>
+    </div>
+
+    {% if notes %}
+    <div class="notes">{{ notes }}</div>
+    {% endif %}
+
+    {% if fnf_schedule %}
+        {% set row_ns = namespace(slot=1) %}
+        {% for block in fnf_schedule %}
+        <div class="event-block">
+            <div class="event-header">
+                {{ block.event.display_name }}
+                {% if block.event.gender %}
+                    <span class="event-meta">({{ 'Men' if block.event.gender == 'M' else 'Women' }})</span>
+                {% endif %}
+                <span class="event-meta">&nbsp;·&nbsp; {{ block.event.stand_type }}</span>
+            </div>
+
+            {% if block.heats %}
+            <table class="heat-table">
+                <thead>
+                    <tr>
+                        <th class="col-slot">#</th>
+                        <th class="col-heat">Heat</th>
+                        <th class="col-stand">Stand</th>
+                        <th>Competitor</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for heat in block.heats %}
+                        {% if heat.competitors %}
+                            {% for comp in heat.competitors %}
+                            <tr class="competitor-row">
+                                {% if loop.first %}
+                                <td class="col-slot" rowspan="{{ heat.competitors|length }}">
+                                    {{ row_ns.slot }}
+                                </td>
+                                <td class="col-heat" rowspan="{{ heat.competitors|length }}">
+                                    H{{ heat.heat_number }}{% if heat.run_number > 1 %}-R{{ heat.run_number }}{% endif %}
+                                </td>
+                                {% endif %}
+                                <td class="col-stand">{{ comp.stand }}</td>
+                                <td>{{ comp.name }}</td>
+                            </tr>
+                            {% endfor %}
+                            {% set row_ns.slot = row_ns.slot + 1 %}
+                        {% else %}
+                            <tr>
+                                <td class="col-slot">{{ row_ns.slot }}</td>
+                                <td class="col-heat">
+                                    H{{ heat.heat_number }}{% if heat.run_number > 1 %}-R{{ heat.run_number }}{% endif %}
+                                </td>
+                                <td colspan="2" class="muted" style="font-style:italic;">No competitors assigned</td>
+                            </tr>
+                            {% set row_ns.slot = row_ns.slot + 1 %}
+                        {% endif %}
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <div class="no-data">No heats generated for this event.</div>
+            {% endif %}
+        </div>
+        {% endfor %}
+    {% else %}
+    <div class="no-data">No Friday Night Feature events configured.</div>
+    {% endif %}
+
+    <div class="print-footer">
+        <span>Missoula Pro-Am Manager</span>
+        <span>Generated {{ now.strftime('%Y-%m-%d %H:%M UTC') }}</span>
+    </div>
+</body>
+</html>

--- a/tests/test_one_click_and_fnf.py
+++ b/tests/test_one_click_and_fnf.py
@@ -1,0 +1,423 @@
+"""
+Regression tests for:
+  - Friday Night Feature (FNF) event exclusion from Saturday pro flights
+  - MIN_HEATS_PER_FLIGHT clamp in build_pro_flights
+  - POST /scheduling/<tid>/flights/one-click-generate end-to-end flow
+  - _build_fnf_schedule helper shape + ordering
+  - GET /scheduling/<tid>/friday-night/print renders without error
+
+Covers the feature shipped in cd451c6 (PR #47).
+
+Run:
+    pytest tests/test_one_click_and_fnf.py -v
+"""
+
+import json
+import os
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        _seed_admin()
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+def _seed_admin():
+    from models.user import User
+
+    if not User.query.filter_by(username="fnf_admin").first():
+        u = User(username="fnf_admin", role="admin")
+        u.set_password("fnf_pass")
+        _db.session.add(u)
+        _db.session.commit()
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture()
+def auth_client(app):
+    c = app.test_client()
+    c.post(
+        "/auth/login",
+        data={"username": "fnf_admin", "password": "fnf_pass"},
+        follow_redirects=True,
+    )
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tournament(session, name="FNF Test 2026"):
+    from models import Tournament
+
+    t = Tournament(name=name, year=2026, status="pro_active")
+    session.add(t)
+    session.flush()
+    return t
+
+
+def _make_pro_event(session, tournament, name, stand_type, **kwargs):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type="pro",
+        scoring_type="time",
+        scoring_order="lowest_wins",
+        stand_type=stand_type,
+        max_stands=kwargs.get("max_stands", 4),
+    )
+    session.add(e)
+    session.flush()
+    return e
+
+
+def _make_pro_comp(session, tournament, name, gender="M"):
+    from models import ProCompetitor
+
+    c = ProCompetitor(
+        tournament_id=tournament.id, name=name, gender=gender, status="active"
+    )
+    session.add(c)
+    session.flush()
+    return c
+
+
+def _make_heat(session, event, heat_number, competitor_ids):
+    from models import Heat
+
+    h = Heat(event_id=event.id, heat_number=heat_number, run_number=1)
+    h.set_competitors(competitor_ids)
+    session.add(h)
+    session.flush()
+    return h
+
+
+def _seed_two_event_show(session):
+    """Seed a tournament with Pro 1-Board (3 heats) + Obstacle Pole (3 heats).
+
+    Pro 1-Board is intended as FNF; Obstacle Pole as Saturday show.
+    """
+    t = _make_tournament(session)
+    comps = [_make_pro_comp(session, t, f"Pro {i}") for i in range(1, 13)]
+
+    p1b = _make_pro_event(session, t, "Pro 1-Board", "springboard", max_stands=2)
+    op = _make_pro_event(session, t, "Obstacle Pole", "obstacle_pole", max_stands=2)
+
+    # 3 heats each, 2 competitors per heat, rotating competitor pool.
+    for i in range(3):
+        _make_heat(session, p1b, i + 1, [comps[i * 2].id, comps[i * 2 + 1].id])
+        _make_heat(
+            session, op, i + 1, [comps[(i * 2 + 6) % 12].id, comps[(i * 2 + 7) % 12].id]
+        )
+
+    return {"tournament": t, "p1b": p1b, "op": op, "comps": comps}
+
+
+# ---------------------------------------------------------------------------
+# FNF exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestFNFExclusion:
+    """Saturday flight builder must exclude events listed in
+    schedule_config['friday_pro_event_ids']."""
+
+    def test_fnf_events_excluded_from_saturday_flights(self, db_session):
+        from models import Heat
+        from services.flight_builder import build_pro_flights
+
+        data = _seed_two_event_show(db_session)
+        t = data["tournament"]
+        # Mark Pro 1-Board for Friday Night Feature
+        t.set_schedule_config({"friday_pro_event_ids": [data["p1b"].id]})
+        db_session.flush()
+
+        built = build_pro_flights(t)
+
+        # Pro 1-Board heats must not be in any flight
+        p1b_heats = Heat.query.filter_by(event_id=data["p1b"].id).all()
+        assert len(p1b_heats) == 3, "Pro 1-Board heats should still exist in DB"
+        for h in p1b_heats:
+            assert (
+                h.flight_id is None
+            ), f"Pro 1-Board heat {h.heat_number} leaked into flight {h.flight_id}"
+
+        # Obstacle Pole heats SHOULD be in a flight
+        op_heats = Heat.query.filter_by(event_id=data["op"].id).all()
+        assert len(op_heats) == 3
+        for h in op_heats:
+            assert (
+                h.flight_id is not None
+            ), f"Obstacle Pole heat {h.heat_number} not assigned to a flight"
+
+        assert built >= 1
+
+    def test_empty_fnf_list_includes_all_events(self, db_session):
+        """When no FNF events are configured, every pro event feeds the Saturday builder."""
+        from models import Heat
+        from services.flight_builder import build_pro_flights
+
+        data = _seed_two_event_show(db_session)
+        t = data["tournament"]
+        t.set_schedule_config({"friday_pro_event_ids": []})
+        db_session.flush()
+
+        build_pro_flights(t)
+
+        # Every heat (both events) should now have a flight_id
+        all_heats = Heat.query.filter(
+            Heat.event_id.in_([data["p1b"].id, data["op"].id])
+        ).all()
+        assert len(all_heats) == 6
+        unassigned = [h for h in all_heats if h.flight_id is None]
+        assert not unassigned, f"{len(unassigned)} heats not assigned to flights"
+
+    def test_fnf_exclusion_survives_malformed_config(self, db_session):
+        """Non-integer garbage in friday_pro_event_ids should not crash the builder."""
+        from services.flight_builder import build_pro_flights
+
+        data = _seed_two_event_show(db_session)
+        t = data["tournament"]
+        # Mixed garbage + valid ID
+        t.set_schedule_config(
+            {
+                "friday_pro_event_ids": [
+                    data["p1b"].id,
+                    "",
+                    "not-an-int-but-will-raise",
+                ],
+            }
+        )
+        db_session.flush()
+
+        # Should not raise; should at minimum exclude the valid FNF id
+        built = build_pro_flights(t)
+        assert built >= 0  # didn't crash
+
+
+# ---------------------------------------------------------------------------
+# MIN_HEATS_PER_FLIGHT clamp
+# ---------------------------------------------------------------------------
+
+
+class TestMinHeatsPerFlightClamp:
+    """num_flights too high → each flight would have <2 heats → clamp kicks in."""
+
+    def test_clamp_prevents_single_heat_flights(self, db_session):
+        from models import Flight
+        from services.flight_builder import build_pro_flights
+
+        data = _seed_two_event_show(db_session)
+        t = data["tournament"]
+        t.set_schedule_config({})  # no FNF, 6 heats total
+
+        # Request 6 flights for 6 heats — that would give 1 heat per flight
+        built = build_pro_flights(t, num_flights=6)
+
+        flights = Flight.query.filter_by(tournament_id=t.id).all()
+        for f in flights:
+            heat_count = len(f.heats.all())
+            assert (
+                heat_count >= 2
+            ), f"Flight {f.flight_number} has {heat_count} heats — clamp failed"
+        # With 6 heats, clamp to 2 per flight = 3 flights
+        assert built == 3
+
+    def test_default_builder_uses_8_per_flight(self, db_session):
+        """num_flights=None → default heats_per_flight=8."""
+        from models import Flight
+        from services.flight_builder import build_pro_flights
+
+        data = _seed_two_event_show(db_session)
+        data["tournament"].set_schedule_config({})
+        built = build_pro_flights(data["tournament"])
+
+        # 6 heats, default 8 per flight → 1 flight
+        assert built == 1
+        flight = Flight.query.filter_by(tournament_id=data["tournament"].id).first()
+        assert flight.heats.count() == 6
+
+
+# ---------------------------------------------------------------------------
+# One-click generate route
+# ---------------------------------------------------------------------------
+
+
+class TestOneClickGenerateRoute:
+    """POST /scheduling/<tid>/flights/one-click-generate runs the full pipeline."""
+
+    def test_route_is_registered_and_requires_auth(self, app):
+        """Unauthenticated POST should redirect to login, not 404 or 500."""
+        client = app.test_client()
+        # Seed a tournament to have a valid id
+        with app.app_context():
+            t = _make_tournament(_db.session)
+            _db.session.commit()
+            tid = t.id
+
+        resp = client.post(
+            f"/scheduling/{tid}/flights/one-click-generate", follow_redirects=False
+        )
+        # Should be a redirect to login (302/303), NOT a 404 or 500
+        assert resp.status_code in (
+            301,
+            302,
+            303,
+        ), f"Expected redirect for unauthed POST, got {resp.status_code}"
+
+    def test_route_runs_full_pipeline_when_authed(self, app, auth_client):
+        from models import Flight, Heat
+
+        with app.app_context():
+            data = _seed_two_event_show(_db.session)
+            t = data["tournament"]
+            t.set_schedule_config({"friday_pro_event_ids": [data["p1b"].id]})
+            _db.session.commit()
+            tid = t.id
+            p1b_id = data["p1b"].id
+            op_id = data["op"].id
+
+        resp = auth_client.post(
+            f"/scheduling/{tid}/flights/one-click-generate",
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303)
+        assert "/flights" in resp.headers.get("Location", "")
+
+        with app.app_context():
+            # Obstacle Pole heats should be in flights
+            op_heats = Heat.query.filter_by(event_id=op_id).all()
+            assert all(
+                h.flight_id is not None for h in op_heats
+            ), "Obstacle Pole heats should be in flights after one-click"
+            # Pro 1-Board heats should NOT be in flights
+            p1b_heats = Heat.query.filter_by(event_id=p1b_id).all()
+            assert all(
+                h.flight_id is None for h in p1b_heats
+            ), "Pro 1-Board (FNF) heats must stay unassigned after one-click"
+            # At least one flight should exist
+            assert Flight.query.filter_by(tournament_id=tid).count() >= 1
+
+
+# ---------------------------------------------------------------------------
+# _build_fnf_schedule helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFnfSchedule:
+    """_build_fnf_schedule returns heat-by-heat schedule data in correct order."""
+
+    def test_returns_empty_when_no_fnf_selected(self, db_session):
+        from routes.scheduling.friday_feature import _build_fnf_schedule
+
+        data = _seed_two_event_show(db_session)
+        result = _build_fnf_schedule(
+            data["tournament"],
+            eligible_events=[data["p1b"]],
+            fnf_config={"event_ids": []},
+        )
+        assert result == []
+
+    def test_includes_only_selected_events(self, db_session):
+        from routes.scheduling.friday_feature import _build_fnf_schedule
+
+        data = _seed_two_event_show(db_session)
+        result = _build_fnf_schedule(
+            data["tournament"],
+            eligible_events=[data["p1b"], data["op"]],
+            fnf_config={"event_ids": [data["p1b"].id]},
+        )
+        assert len(result) == 1
+        assert result[0]["event"].id == data["p1b"].id
+        assert len(result[0]["heats"]) == 3
+
+    def test_heats_ordered_by_run_then_heat_number(self, db_session):
+        """Heats should come back sorted by run_number, then heat_number."""
+        from routes.scheduling.friday_feature import _build_fnf_schedule
+
+        data = _seed_two_event_show(db_session)
+        result = _build_fnf_schedule(
+            data["tournament"],
+            eligible_events=[data["p1b"]],
+            fnf_config={"event_ids": [data["p1b"].id]},
+        )
+        heats = result[0]["heats"]
+        heat_nums = [(h["run_number"], h["heat_number"]) for h in heats]
+        assert heat_nums == sorted(
+            heat_nums
+        ), f"Heats not in (run, heat) order: {heat_nums}"
+
+    def test_heat_row_has_competitor_name_and_stand(self, db_session):
+        from routes.scheduling.friday_feature import _build_fnf_schedule
+
+        data = _seed_two_event_show(db_session)
+        # Set a stand assignment so we can verify it comes through
+        from models import Heat
+
+        h = Heat.query.filter_by(event_id=data["p1b"].id, heat_number=1).first()
+        h.set_stand_assignment(data["comps"][0].id, 1)
+        h.set_stand_assignment(data["comps"][1].id, 2)
+        db_session.flush()
+
+        result = _build_fnf_schedule(
+            data["tournament"],
+            eligible_events=[data["p1b"]],
+            fnf_config={"event_ids": [data["p1b"].id]},
+        )
+        heat_row = result[0]["heats"][0]
+        comp_row = heat_row["competitors"][0]
+        assert "name" in comp_row
+        assert "stand" in comp_row
+        assert comp_row["name"].startswith("Pro ")  # "Pro 1", "Pro 2", etc.
+
+
+# ---------------------------------------------------------------------------
+# FNF print route
+# ---------------------------------------------------------------------------
+
+
+class TestFridayFeaturePrintRoute:
+    """GET /scheduling/<tid>/friday-night/print renders a printable schedule."""
+
+    def test_print_route_renders_200(self, app, auth_client):
+        with app.app_context():
+            data = _seed_two_event_show(_db.session)
+            t = data["tournament"]
+            t.set_schedule_config({"friday_pro_event_ids": [data["p1b"].id]})
+            _db.session.commit()
+            tid = t.id
+
+        resp = auth_client.get(f"/scheduling/{tid}/friday-night/print")
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert "Friday Night Feature Schedule" in body
+        assert "Pro 1-Board" in body
+        # No inline handlers — CSP compliance regression guard
+        assert "onclick=" not in body, "Inline onclick= detected; CSP regression"
+        assert "onsubmit=" not in body, "Inline onsubmit= detected; CSP regression"
+        # The CSP-compliant pattern (id + script with addEventListener)
+        assert "fnf-print-btn" in body

--- a/tests/test_team_override_persistence.py
+++ b/tests/test_team_override_persistence.py
@@ -1,0 +1,226 @@
+"""Tests for Team admin validation override persistence.
+
+Background: small schools with edge-case rosters (e.g., 5 men + 0 women) can be
+marked valid via an admin override. The override must survive re-validation and
+Excel re-imports — the whole point of the feature is that a judge doesn't have
+to re-override the same team every time someone fixes a different competitor
+or re-uploads the entry form.
+
+These tests pin down the contract:
+  1. override_team_validation sets is_override=True AND keeps status='active'
+  2. set_validation_errors on an overridden team preserves status='active'
+  3. set_validation_errors with no errors auto-clears is_override (vestigial)
+  4. revalidate_team route respects the override
+  5. remove_team_override flips back to invalid if errors remain
+  6. Excel re-import (via set_validation_errors) preserves the override
+"""
+
+import uuid
+
+import pytest
+
+from tests.conftest import make_college_competitor, make_team, make_tournament
+
+
+@pytest.fixture()
+def auth_client(app, db_session):
+    """Local override: unique admin username per test so commits across tests
+    within this module don't collide on the users.username UNIQUE constraint.
+    Mirrors the pattern used in tests/test_partner_reassignment.py."""
+    from models.user import User
+
+    unique_name = f"test_admin_tvo_{uuid.uuid4().hex[:8]}"
+    u = User(username=unique_name, role="admin")
+    u.set_password("pass")
+    db_session.add(u)
+    db_session.flush()
+    c = app.test_client()
+    with c.session_transaction() as sess:
+        sess["_user_id"] = str(u.id)
+    return c
+
+# ---------------------------------------------------------------------------
+# Model-level tests — Team.set_validation_errors + is_override interaction
+# ---------------------------------------------------------------------------
+
+
+class TestSetValidationErrorsWithOverride:
+    def test_errors_without_override_flips_to_invalid(self, db_session):
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+        assert team.status == "active"
+        assert team.is_override is False
+
+        team.set_validation_errors([{"type": "too_few_women", "message": "Need 2"}])
+        assert team.status == "invalid"
+        assert team.is_override is False
+
+    def test_errors_with_override_stays_active(self, db_session):
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+        team.is_override = True
+
+        team.set_validation_errors([{"type": "too_few_women", "message": "Need 2"}])
+        assert team.status == "active", "override must preserve active status"
+        assert team.is_override is True, "override flag must persist"
+        assert (
+            len(team.get_validation_errors()) == 1
+        ), "errors still recorded for display"
+
+    def test_clean_errors_auto_clears_override(self, db_session):
+        """Override is vestigial once roster is genuinely clean — auto-clear."""
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+        team.is_override = True
+        team.set_validation_errors([{"type": "too_few_women", "message": "Need 2"}])
+        assert team.is_override is True
+
+        # Now the team somehow passes (imagine roster was fixed)
+        team.set_validation_errors([])
+        assert team.status == "active"
+        assert team.is_override is False, "override auto-clears when no errors remain"
+
+    def test_override_survives_multiple_revalidations(self, db_session):
+        """Re-running validation many times must not erode the override."""
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+        team.is_override = True
+        errors = [{"type": "too_few_women", "message": "Need 2"}]
+
+        for _ in range(5):
+            team.set_validation_errors(errors)
+            assert team.is_override is True
+            assert team.status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests — override + revalidate + remove-override
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideTeamValidationRoute:
+    def _seed_invalid_team(self, db_session):
+        """Team with 5 men + 0 women — fails women-count validation."""
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+        for i in range(5):
+            make_college_competitor(db_session, t, team, f"Man{i}", gender="M")
+        # Manually run validator so set_validation_errors sees real errors
+        from services.excel_io import _validate_college_entry_constraints
+
+        errors = _validate_college_entry_constraints({team.id}).get(team.id, [])
+        team.set_validation_errors(errors)
+        assert team.status == "invalid"
+        db_session.flush()
+        return t, team
+
+    def test_override_route_flips_status_and_sets_flag(self, auth_client, db_session):
+        t, team = self._seed_invalid_team(db_session)
+        db_session.commit()
+
+        resp = auth_client.post(
+            f"/registration/{t.id}/college/team/{team.id}/override-validation",
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303)
+
+        db_session.expire_all()
+        from models.team import Team
+
+        team = Team.query.get(team.id)
+        assert team.is_override is True
+        assert team.status == "active"
+        assert len(team.get_validation_errors()) > 0, "errors preserved for display"
+
+    def test_revalidate_after_override_preserves_override(
+        self, auth_client, db_session
+    ):
+        t, team = self._seed_invalid_team(db_session)
+        team.is_override = True
+        team.set_validation_errors(
+            team.get_validation_errors()
+        )  # re-apply with override
+        db_session.commit()
+
+        resp = auth_client.post(
+            f"/registration/{t.id}/college/team/{team.id}/revalidate",
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303)
+
+        db_session.expire_all()
+        from models.team import Team
+
+        team = Team.query.get(team.id)
+        assert team.is_override is True, "revalidate must not clear override"
+        assert team.status == "active", "overridden team stays active after revalidate"
+
+    def test_remove_override_flips_back_to_invalid(self, auth_client, db_session):
+        t, team = self._seed_invalid_team(db_session)
+        team.is_override = True
+        team.set_validation_errors(team.get_validation_errors())
+        db_session.commit()
+
+        resp = auth_client.post(
+            f"/registration/{t.id}/college/team/{team.id}/remove-override",
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303)
+
+        db_session.expire_all()
+        from models.team import Team
+
+        team = Team.query.get(team.id)
+        assert team.is_override is False
+        assert (
+            team.status == "invalid"
+        ), "team flips back to invalid when override removed"
+
+    def test_remove_override_no_op_on_non_overridden_team(
+        self, auth_client, db_session
+    ):
+        t, team = self._seed_invalid_team(db_session)
+        assert team.is_override is False
+        db_session.commit()
+
+        resp = auth_client.post(
+            f"/registration/{t.id}/college/team/{team.id}/remove-override",
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303)
+
+        db_session.expire_all()
+        from models.team import Team
+
+        team = Team.query.get(team.id)
+        assert team.is_override is False
+        assert team.status == "invalid", "nothing should change"
+
+
+# ---------------------------------------------------------------------------
+# Excel re-import preservation — the whole reason this feature exists
+# ---------------------------------------------------------------------------
+
+
+class TestReimportPreservesOverride:
+    def test_reimport_path_preserves_override(self, db_session):
+        """Simulate what happens when excel_io.process_college_entry_form re-runs
+        on a team that has been overridden. The team's set_validation_errors
+        gets called with the (still-failing) errors list. Override must stay."""
+        t = make_tournament(db_session)
+        team = make_team(db_session, t)
+        team.is_override = True
+        errors = [{"type": "too_few_women", "message": "Need 2"}]
+        team.set_validation_errors(errors)
+        assert team.status == "active"
+        assert team.is_override is True
+
+        # Simulate the re-import path from services/excel_io.py:198-209 —
+        # touched_team_ids includes this team, errors_by_team still has errors,
+        # the loop calls team.set_validation_errors again.
+        team.set_validation_errors(errors)
+
+        assert (
+            team.status == "active"
+        ), "re-import must not flip overridden team to invalid"
+        assert team.is_override is True, "override must survive re-import"


### PR DESCRIPTION
## Summary

Bundles two features on top of the `team-override-persistence` work already on this branch:

1. **One-click Saturday show build.** New "Generate All Heats & Build Flights" button on the Pro Flights page runs heat generation, pro flight building, and college spillover integration in a single transaction.
2. **Friday Night Feature schedule.** FNF events (Pro 1-Board, 3-Board Jigger, Springboard when selected) are now excluded from Saturday pro flights and rendered as a heat-by-heat schedule on the Friday Showcase page. Includes a standalone printable view.

Both features were QA'd in the browser against the "Missoula Pro Am (flights test)" tournament. QA found 2 CSP violations (inline `onclick` / `onsubmit`) blocked by the app's strict CSP; both fixed by switching to `data-confirm` attributes and nonce-eligible `<script>` blocks.

## What changed

- **`services/flight_builder.py`**
  - Excludes events whose IDs are in `schedule_config.friday_pro_event_ids` from Saturday flight building. Their heats stay in the DB with `flight_id=NULL`.
  - Enforces `MIN_HEATS_PER_FLIGHT = 2` — a "flight" with one heat is just a heat.
- **`routes/scheduling/flights.py`**
  - New `POST /scheduling/<tid>/flights/one-click-generate` runs the full pipeline and redirects to Flights.
  - `build_flights` now clamps `num_flights` when it would produce <2 heats/flight, and warns when only one event has heats.
- **`routes/scheduling/friday_feature.py`**
  - `_build_fnf_schedule()` helper builds the heat list in Springboard → Pro 1-Board → 3-Board Jigger order.
  - New `GET /scheduling/<tid>/friday-night/print` route for the standalone print view.
- **`templates/pro/flights.html`** — One-click button in header + empty-state, CSP-compliant via `data-confirm`.
- **`templates/scheduling/friday_feature.html`** — Heat-by-heat schedule table with Score links, Print button wired to the new route.
- **`templates/scheduling/friday_feature_print.html`** — New print layout with event blocks, rowspan-merged heat cells, and a nonce-eligible Print button.

## QA (verified in browser)

| Flow | Result |
|---|---|
| Click one-click button → confirm modal renders | PASS |
| Click Confirm → 7 flights / 56 heats built from 13 pro events | PASS |
| Pro 1-Board (FNF) excluded from Saturday flights | PASS (3 heats with `flight_id=NULL`) |
| Friday Showcase page renders heat-by-heat schedule with stand assignments | PASS |
| FNF print view renders cleanly, Print button fires `window.print()` | PASS |
| Console on all three pages | 0 errors |
| Flight builder test suite | 78 / 78 |

Report + screenshots: `.gstack/qa-reports/qa-report-localhost-2026-04-21.md`

## Test plan

- [ ] Visit `/scheduling/<tid>/flights` on a test tournament with competitors registered. Verify the "Generate All Heats & Build Flights" button shows a Bootstrap confirm modal, not a native browser dialog.
- [ ] Click through the modal — heats generate for all events, flights build, page reloads with flash messages.
- [ ] Check `/scheduling/<tid>/friday-night` — if FNF events are selected, the schedule table renders with correct heats.
- [ ] Click "Print FNF Schedule" — a new tab opens with a printable layout. Click the Print button — print dialog appears.
- [ ] Confirm FNF event heats do NOT appear in any Saturday flight.
- [ ] Run `pytest tests/test_flight_builder*.py` — 78 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)