### PR TITLE
fix: bump /health version string to 2.11.0 (follow-up to #47)

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.10.0',
+        'version': '2.11.0',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.10.0',
+        'version': '2.11.0',
     })
 
 


### PR DESCRIPTION
## Summary

PR #47 bumped the version in `pyproject.toml`, `README.md`, and `DEVELOPMENT.md` but missed a hardcoded `'version': '2.10.0'` literal in the `/health` JSON endpoint in `routes/main.py`. Railway deployed #47 cleanly; only this one string was stale.

## Evidence

- `curl -s /health` after #47 merged: `{..., "version": "2.10.0"}` — reports stale version despite new migration being applied (`migration_head: l2a3b4c5d6e7`).
- Grep across codebase: one occurrence at [routes/main.py:79](routes/main.py#L79), two matches counted because `/health` and `/health/diag` both reference it. Replace-all fixed both.

## Test plan

- [ ] After merge + Railway deploy, `curl -s https://missoula-pro-am-manager-production.up.railway.app/health | jq .version` returns `"2.11.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)