### PR TITLE
fix: null-handling tests flushed through NOT NULL columns

### DIFF
--- a/tests/test_model_json_safety.py
+++ b/tests/test_model_json_safety.py
@@ -69,8 +69,11 @@ class TestCollegeCompetitorJsonSafety:
     def test_none_events_entered_returns_empty_list(self, db_session, tournament):
         team = make_team(db_session, tournament)
         c = make_college_competitor(db_session, tournament, team, 'NoneEvt', 'M')
+        # Set attribute to None in-memory only. The DB column is NOT NULL so
+        # flushing would fail, but the getter reads the Python attribute and
+        # must handle None (e.g. from a freshly-built instance before defaults
+        # kick in, or from legacy rows loaded before the constraint was added).
         c.events_entered = None
-        db_session.flush()
 
         assert c.get_events_entered() == []
 
@@ -120,8 +123,8 @@ class TestEventJsonSafety:
 
     def test_none_payouts(self, db_session, tournament):
         e = make_event(db_session, tournament, 'Null Payouts')
+        # In-memory only — DB column is NOT NULL. Getter must tolerate None.
         e.payouts = None
-        db_session.flush()
         assert e.get_payouts() == {}
 
 
@@ -145,8 +148,8 @@ class TestHeatJsonSafety:
     def test_none_competitors(self, db_session, tournament):
         e = make_event(db_session, tournament, 'None Comps')
         h = make_heat(db_session, e)
+        # In-memory only — DB column is NOT NULL. Getter must tolerate None.
         h.competitors = None
-        db_session.flush()
         assert h.get_competitors() == []
 
 


### PR DESCRIPTION
## Summary

Three tests in \`tests/test_model_json_safety.py\` were failing on main:

- \`TestCollegeCompetitorJsonSafety::test_none_events_entered_returns_empty_list\`
- \`TestEventJsonSafety::test_none_payouts\`
- \`TestHeatJsonSafety::test_none_competitors\`

All three set the column attribute to \`None\` and then called \`db_session.flush()\`. Recent DB integrity constraints (#32) tightened \`NOT NULL\` on \`events_entered\`, \`payouts\`, and \`heats.competitors\`, so flush raised \`IntegrityError\` and the assertion never ran.

## Fix

The intent of these tests is defensive-coding verification: the \`.get_*()\` methods must tolerate a \`None\` Python attribute value (freshly-built instances, legacy rows loaded before the constraint existed, mid-construction code paths). That contract is still valid, so the tests are worth keeping — they just shouldn't round-trip through the DB to exercise it.

Drop the \`db_session.flush()\` from the 3 None-value tests. The getters read the Python attribute directly; no flush needed. Corrupt-value tests are untouched — they still round-trip via flush because a garbled JSON string satisfies \`NOT NULL\`.

## Evidence

\`\`\`
$ pytest tests/test_model_json_safety.py
Before: 45 passed, 3 failed (IntegrityError on NULL)
After:  48 passed
\`\`\`

## Test plan

- [ ] \`pytest tests/test_model_json_safety.py\` → 48 passed, 0 failed
- [ ] \`pytest\` full suite — no new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)