### PR TITLE
feat: FNF PDF export via WeasyPrint (V2.11.1)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,27 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.11.1)
+
+**Patch — Friday Night Feature PDF export**
+
+Adds a PDF download alongside the existing HTML-print view for the FNF schedule. Uses the shared `services/print_response.py::weasyprint_or_html` helper so the route returns a real PDF when WeasyPrint is installed, or falls back to HTML (with `Content-Type: text/html`) on environments without cairo/pango — which includes Railway.
+
+**New route — `routes/scheduling/friday_feature.py`:**
+- `GET /scheduling/<tid>/friday-night/pdf` renders the same `scheduling/friday_feature_print.html` template as `/friday-night/print` and pipes it through `weasyprint_or_html()`. Same schedule data, same template, just different response wrapping — print and PDF stay in sync automatically.
+- Download filename derived from tournament name + year: `{name}_{year}_friday_night_feature.pdf`.
+
+**Template — `templates/scheduling/friday_feature.html`:**
+- New "PDF" button next to the existing "Print FNF Schedule" button on the Friday Showcase page, visible only when `fnf_schedule` has content. Uses `bi-file-earmark-pdf` icon.
+
+**Tests — 2 new in `tests/test_one_click_and_fnf.py::TestFridayFeaturePdfRoute`:**
+- `test_pdf_route_renders_200` — asserts 200 with Content-Type either `application/pdf` or `text/html` (matches both the WeasyPrint branch and the fallback).
+- `test_pdf_route_pdf_branch_sets_download_header` — `monkeypatch`es a fake `weasyprint` module to force the PDF branch, then asserts `Content-Type: application/pdf`, `Content-Disposition: attachment; filename="..._friday_night_feature.pdf"`, and that the response body is the fake PDF bytes. This guarantees the PDF branch is actually exercised by CI even without WeasyPrint installed.
+
+**Data model:** No schema changes.
+
+---
+
 ### 2026-04-21 (V2.11.0)
 
 **Minor — one-click Saturday show build + Friday Night Feature schedule**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.11.0
+# Missoula Pro Am Manager — V2.11.1
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 
@@ -526,4 +526,4 @@ Operational docs:
 
 ---
 
-*Last updated: April 2026 — V2.11.0*
+*Last updated: April 2026 — V2.11.1*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.11.0"
+version = "2.11.1"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.11.0',
+        'version': '2.11.1',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.11.0',
+        'version': '2.11.1',
     })
 
 

--- a/routes/scheduling/friday_feature.py
+++ b/routes/scheduling/friday_feature.py
@@ -196,6 +196,37 @@ def friday_feature_print(tournament_id):
     )
 
 
+@scheduling_bp.route('/<int:tournament_id>/friday-night/pdf')
+def friday_feature_pdf(tournament_id):
+    """FNF schedule as a PDF download (WeasyPrint if installed, HTML fallback otherwise).
+
+    Reuses the same template as /friday-night/print so both surfaces stay in sync.
+    On Railway the fallback serves HTML with Content-Type text/html so the user
+    can still print via Ctrl-P without the deploy needing cairo/pango.
+    """
+    from datetime import datetime
+
+    from services.print_response import weasyprint_or_html
+
+    tournament = Tournament.query.get_or_404(tournament_id)
+    eligible_names = set(config.FRIDAY_NIGHT_EVENTS)
+    pro_events = tournament.events.filter_by(event_type='pro').order_by(Event.name, Event.gender).all()
+    eligible_events = [e for e in pro_events if e.name in eligible_names]
+
+    fnf_config = _load_fnf_config(tournament)
+    fnf_schedule = _build_fnf_schedule(tournament, eligible_events, fnf_config)
+
+    html = render_template(
+        'scheduling/friday_feature_print.html',
+        tournament=tournament,
+        fnf_schedule=fnf_schedule,
+        notes=fnf_config.get('notes', ''),
+        now=datetime.utcnow(),
+    )
+    safe_name = f"{tournament.name}_{tournament.year}_friday_night_feature".replace(' ', '_').replace('/', '-')
+    return weasyprint_or_html(html, safe_name)
+
+
 def _build_fnf_schedule(tournament, eligible_events, fnf_config):
     """Build the Friday Night Feature schedule: selected FNF events in run order,
     each with its heats (run_number, heat_number ordered) and competitor/stand data.

--- a/templates/scheduling/friday_feature.html
+++ b/templates/scheduling/friday_feature.html
@@ -11,6 +11,10 @@
                target="_blank">
                 <i class="bi bi-printer"></i> Print FNF Schedule
             </a>
+            <a class="btn btn-outline-warning btn-sm"
+               href="{{ url_for('scheduling.friday_feature_pdf', tournament_id=tournament.id) }}">
+                <i class="bi bi-file-earmark-pdf"></i> PDF
+            </a>
             {% endif %}
             <a class="btn btn-outline-secondary btn-sm"
                href="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}">Back to Events</a>

--- a/tests/test_one_click_and_fnf.py
+++ b/tests/test_one_click_and_fnf.py
@@ -421,3 +421,67 @@ class TestFridayFeaturePrintRoute:
         assert "onsubmit=" not in body, "Inline onsubmit= detected; CSP regression"
         # The CSP-compliant pattern (id + script with addEventListener)
         assert "fnf-print-btn" in body
+
+
+# ---------------------------------------------------------------------------
+# FNF PDF route — WeasyPrint if installed, HTML fallback on Railway
+# ---------------------------------------------------------------------------
+
+
+class TestFridayFeaturePdfRoute:
+    """GET /scheduling/<tid>/friday-night/pdf returns a PDF or HTML fallback."""
+
+    def test_pdf_route_renders_200(self, app, auth_client):
+        with app.app_context():
+            data = _seed_two_event_show(_db.session)
+            t = data["tournament"]
+            t.set_schedule_config({"friday_pro_event_ids": [data["p1b"].id]})
+            _db.session.commit()
+            tid = t.id
+
+        resp = auth_client.get(f"/scheduling/{tid}/friday-night/pdf")
+        assert resp.status_code == 200
+        ctype = resp.headers.get("Content-Type", "")
+        # Either the PDF path (WeasyPrint installed) or the HTML fallback.
+        # On Railway and in the test env, WeasyPrint is NOT installed, so we
+        # expect text/html. Both are valid.
+        assert ctype.startswith("application/pdf") or ctype.startswith("text/html"), (
+            f"unexpected Content-Type {ctype!r} — want application/pdf or text/html"
+        )
+
+    def test_pdf_route_pdf_branch_sets_download_header(self, app, auth_client, monkeypatch):
+        """Force the WeasyPrint branch to run and assert the Content-Disposition."""
+        # Stub weasyprint.HTML so the route takes the PDF branch without needing
+        # cairo/pango installed. Must stub BEFORE the import inside the helper
+        # fires, so patch the services.print_response module's lazy import target.
+        fake_pdf_bytes = b"%PDF-1.4 fake pdf for test\n"
+
+        class _FakeWP:
+            def __init__(self, string):
+                self.string = string
+
+            def write_pdf(self):
+                return fake_pdf_bytes
+
+        import sys as _sys
+        import types as _types
+
+        fake_module = _types.ModuleType("weasyprint")
+        fake_module.HTML = _FakeWP  # type: ignore[attr-defined]
+        monkeypatch.setitem(_sys.modules, "weasyprint", fake_module)
+
+        with app.app_context():
+            data = _seed_two_event_show(_db.session)
+            t = data["tournament"]
+            t.set_schedule_config({"friday_pro_event_ids": [data["p1b"].id]})
+            _db.session.commit()
+            tid = t.id
+
+        resp = auth_client.get(f"/scheduling/{tid}/friday-night/pdf")
+        assert resp.status_code == 200
+        assert resp.headers.get("Content-Type") == "application/pdf"
+        cd = resp.headers.get("Content-Disposition", "")
+        assert "attachment" in cd
+        assert "friday_night_feature" in cd
+        assert cd.endswith('.pdf"')
+        assert resp.data == fake_pdf_bytes


### PR DESCRIPTION
## Summary

Adds a real PDF download to the Friday Night Feature schedule, alongside the existing HTML-print view. Uses the shared [`services/print_response.py::weasyprint_or_html`](services/print_response.py) helper so WeasyPrint-equipped environments get a PDF and plain environments (including Railway) get HTML with `Content-Type: text/html`.

## New

- **`GET /scheduling/<tid>/friday-night/pdf`** ([routes/scheduling/friday_feature.py](routes/scheduling/friday_feature.py)) — renders the same `scheduling/friday_feature_print.html` template as `/friday-night/print`, wraps through `weasyprint_or_html()`. Both surfaces stay automatically in sync.
- Download filename: `{tournament_name}_{year}_friday_night_feature.pdf`.
- **PDF button** on Friday Showcase page ([templates/scheduling/friday_feature.html](templates/scheduling/friday_feature.html)), next to the existing Print button, visible only when `fnf_schedule` has content.

## Test Coverage

2 new tests in [`tests/test_one_click_and_fnf.py::TestFridayFeaturePdfRoute`](tests/test_one_click_and_fnf.py):

- `test_pdf_route_renders_200` — accepts both `application/pdf` and `text/html` Content-Types to cover both deployment realities.
- `test_pdf_route_pdf_branch_sets_download_header` — `monkeypatch`es a fake `weasyprint` module so CI exercises the PDF branch even without WeasyPrint installed. Asserts `Content-Type: application/pdf`, `Content-Disposition: attachment; filename="..._friday_night_feature.pdf"`, and that the response body is the fake PDF bytes.

**Tests:** 14/14 FNF tests pass. 198 surrounding smoke/reliability/infra tests pass (no regressions).

## Version

Bumped to V2.11.1 across `pyproject.toml`, `README.md` header + footer, `routes/main.py` `/health` payloads, `DEVELOPMENT.md` changelog.

## Test plan

- [x] `pytest tests/test_one_click_and_fnf.py` — 14 pass
- [x] Regression check: `pytest tests/test_routes_smoke.py tests/test_flask_reliability.py tests/test_infrastructure.py tests/test_csrf_error_handler.py` — 184 pass
- [x] PDF branch exercised in CI via monkeypatched weasyprint
- [x] HTML fallback branch exercised in real env

🤖 Generated with [Claude Code](https://claude.com/claude-code)