### PR TITLE
feat: surface + test Pro event fee configuration (V2.11.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,6 +432,7 @@ PayoutTemplate  (tournament-independent, standalone)
 - Handicap export helpers (`services/handicap_export.py`): chopping-event Excel export utilities
 - Gear Sharing Manager (`routes/registration.py`, `services/gear_sharing.py`, `templates/pro/gear_sharing.html`): comprehensive pro gear-sharing audit — verified pairs, unresolved entries, heat conflicts; free-text parse with review workflow; gear groups (multiple pairs sharing one saw); bidirectional sync; heat conflict auto-fix; auto-populate partners; cleanup scratched; college gear constraints view/edit; printable report
 - Fee Tracker (`routes/reporting.py`, `templates/reporting/fee_tracker.html`): entry fee collection checklist per pro competitor; per-event breakdown expandable rows; mark/unmark paid; outstanding-only filter; summary cards
+- Pro Event Fee Configuration (`GET/POST /reporting/<tid>/pro/event-fees`, `templates/reporting/event_fee_config.html`): set default fee per pro event; apply in bulk to all enrolled competitors; `overwrite` flag replaces existing non-zero fees; skips competitors not enrolled in the event; invalid fee input flashes error without crashing; sidebar link under Pro Operations. See `tests/test_pro_event_fees.py` for coverage.
 - Tournament Setup consolidated page (`routes/main.py`, `templates/tournament_setup.html`): single `/tournament/<tid>/setup` page with tabs for Events, Wood Specs, and Settings (name/year/dates); wood specs and copy-from now redirect back to setup when called from this page
 - Tournament Detail redesigned (`templates/tournament_detail.html`): 3-phase action panels (Before Show / Game Day / After Show); 6-step workflow stepper; contextual next-step banner per status; stats bar with actionable alerts; async validation status banner
 - Show Day Dashboard (`/scheduling/<tid>/show-day`, `templates/scheduling/show_day.html`): flight status cards (live/completed/pending), current heat CTA, upcoming heats, college event progress bars; 60s auto-refresh
@@ -497,8 +498,6 @@ PayoutTemplate  (tournament-independent, standalone)
 ### Known Gaps and Incomplete Features
 
 **Friday Night Feature schedule view (V2.11.0):** The Friday Night Feature now has a heat-by-heat schedule view on the Friday Showcase page plus a printable view at `/scheduling/<tid>/friday-night/print`. FNF events selected into `schedule_config['friday_pro_event_ids']` are excluded from Saturday pro flights (their heats exist in the DB with `flight_id=NULL`). Heats are ordered Springboard → Pro 1-Board → 3-Board Jigger via `_fnf_event_order()` in `routes/scheduling/friday_feature.py`. FNF still runs as a straight heat-by-heat schedule, not flights — intentional, matching college day format.
-
-**Pro event fee configuration UI:** No route or template exists for setting fee amounts per event per tournament. `entry_fees` and `fees_paid` fields exist on `ProCompetitor` but fees must currently be set directly in the database or via the edit competitor form.
 
 **Pro birling references:** `config.py` PRO_EVENTS correctly excludes birling. Verify that no templates, database records, or service code contain hardcoded references to a pro birling event that could create phantom data.
 
@@ -732,7 +731,6 @@ The broader vision: STRATHMARK calculates start marks and predicted times, feeds
 The following features remain as planned or implied by the codebase and requirements:
 
 **Remaining gaps (from Section 5):**
-- Pro event fee configuration UI
 - Pro entry form redesign (scope pending; current import handled by `registration_import.py` enhanced pipeline)
 
 **Technical debt:**

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,31 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.11.2)
+
+**Patch — Pro event fee configuration surfaced + tested**
+
+`GET/POST /reporting/<tid>/pro/event-fees` and its template `reporting/event_fee_config.html` were already implemented (bulk-apply default fees to enrolled pro competitors, `overwrite` flag, per-event enrollment count + suggested fee), but the route had no sidebar link and no real tests — just one smoke hit in `test_route_smoke_qa.py`. CLAUDE.md still listed it as a gap. Patch makes the existing feature discoverable and verified.
+
+**Sidebar — `templates/_sidebar.html`:**
+- New "Event Fees" entry under Pro Day section, positioned immediately above the existing "Fee Tracker" link. `bi-cash-stack` icon. Active-route highlighting via `request.endpoint == 'reporting.pro_event_fees'`.
+
+**Tests — 6 new in `tests/test_pro_event_fees.py`:**
+- GET renders with event names + enrollment UI visible
+- POST applies the fee to competitors enrolled in that event AND skips competitors not enrolled (even when their row would have received the form field)
+- Blank fee field is a no-op (doesn't wipe or zero-out existing fees)
+- Default behavior skips competitors who already have a non-zero fee for that event
+- `overwrite=on` replaces existing non-zero fees
+- Invalid fee input ("twenty bucks") flashes an error but returns 302 — no 500
+
+**Docs — CLAUDE.md:**
+- Moved Pro Event Fee Configuration from Section 5 "Known Gaps" to "Features Functionally Complete"
+- Dropped from Section 8 remaining-gaps list
+
+**Data model:** No schema changes.
+
+---
+
 ### 2026-04-21 (V2.11.1)
 
 **Patch — Friday Night Feature PDF export**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.11.1
+# Missoula Pro Am Manager — V2.11.2
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 
@@ -526,4 +526,4 @@ Operational docs:
 
 ---
 
-*Last updated: April 2026 — V2.11.1*
+*Last updated: April 2026 — V2.11.2*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.11.1"
+version = "2.11.2"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.11.1',
+        'version': '2.11.2',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.11.1',
+        'version': '2.11.2',
     })
 
 

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -101,6 +101,13 @@
                 <i class="bi bi-person-plus sb-icon"></i>
                 <span class="sb-text ms-2">Pro Operations</span>
             </a>
+            <a href="{{ url_for('reporting.pro_event_fees', tournament_id=tournament.id) }}"
+               class="nav-link sidebar-child {{ 'active' if request.endpoint == 'reporting.pro_event_fees' else '' }}"
+               {% if request.endpoint == 'reporting.pro_event_fees' %}aria-current="page"{% endif %}
+               title="Event Fees">
+                <i class="bi bi-cash-stack sb-icon"></i>
+                <span class="sb-text ms-2">Event Fees</span>
+            </a>
             <a href="{{ url_for('reporting.fee_tracker', tournament_id=tournament.id) }}"
                class="nav-link sidebar-child {{ 'active' if request.endpoint == 'reporting.fee_tracker' else '' }}"
                {% if request.endpoint == 'reporting.fee_tracker' %}aria-current="page"{% endif %}

--- a/tests/test_pro_event_fees.py
+++ b/tests/test_pro_event_fees.py
@@ -1,0 +1,280 @@
+"""
+Tests for Pro event fee configuration UI.
+
+Route: GET/POST /reporting/<tid>/pro/event-fees
+Template: templates/reporting/event_fee_config.html
+
+Covers:
+  - GET renders with event rows, enrolled counts, suggested fees
+  - POST sets entry_fees on competitors enrolled in each event
+  - POST skips competitors not enrolled in an event (even if the form posted a fee)
+  - POST skips blank form fields (no-op, doesn't wipe existing)
+  - POST respects the 'overwrite' flag: default skips existing non-zero, flag overwrites
+  - Invalid fee input flashes an error but doesn't crash
+
+Run:
+    pytest tests/test_pro_event_fees.py -v
+"""
+
+import json
+import os
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        _seed_admin()
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+def _seed_admin():
+    from models.user import User
+
+    if not User.query.filter_by(username="fees_admin").first():
+        u = User(username="fees_admin", role="admin")
+        u.set_password("fees_pass")
+        _db.session.add(u)
+        _db.session.commit()
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture()
+def auth_client(app):
+    c = app.test_client()
+    c.post(
+        "/auth/login",
+        data={"username": "fees_admin", "password": "fees_pass"},
+        follow_redirects=True,
+    )
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_tournament_with_events(session):
+    """Seed a tournament with 2 pro events and 3 pro competitors.
+
+    comps[0] enrolled in BOTH events
+    comps[1] enrolled in event A only
+    comps[2] enrolled in event B only
+    Nobody has any entry_fees set initially.
+    """
+    from models import Event, Tournament
+    from models.competitor import ProCompetitor
+
+    t = Tournament(name="Fee UI Test 2026", year=2026, status="setup")
+    session.add(t)
+    session.flush()
+
+    evt_a = Event(
+        tournament_id=t.id,
+        name="Springboard",
+        event_type="pro",
+        scoring_type="time",
+        scoring_order="lowest_wins",
+        stand_type="springboard",
+        max_stands=4,
+    )
+    evt_b = Event(
+        tournament_id=t.id,
+        name="Underhand",
+        event_type="pro",
+        scoring_type="time",
+        scoring_order="lowest_wins",
+        stand_type="underhand",
+        max_stands=5,
+    )
+    session.add_all([evt_a, evt_b])
+    session.flush()
+
+    c0 = ProCompetitor(
+        tournament_id=t.id, name="Both Events", gender="M", status="active"
+    )
+    c1 = ProCompetitor(
+        tournament_id=t.id, name="Springboard Only", gender="M", status="active"
+    )
+    c2 = ProCompetitor(
+        tournament_id=t.id, name="Underhand Only", gender="M", status="active"
+    )
+    session.add_all([c0, c1, c2])
+    session.flush()
+
+    c0.set_events_entered([evt_a.id, evt_b.id])
+    c1.set_events_entered([evt_a.id])
+    c2.set_events_entered([evt_b.id])
+    session.flush()
+
+    return {"t": t, "evt_a": evt_a, "evt_b": evt_b, "c0": c0, "c1": c1, "c2": c2}
+
+
+# ---------------------------------------------------------------------------
+# GET
+# ---------------------------------------------------------------------------
+
+
+class TestEventFeesGet:
+
+    def test_get_renders_with_event_rows(self, app, auth_client):
+        with app.app_context():
+            data = _seed_tournament_with_events(_db.session)
+            _db.session.commit()
+            tid = data["t"].id
+            evt_a_name = data["evt_a"].name
+            evt_b_name = data["evt_b"].name
+
+        resp = auth_client.get(f"/reporting/{tid}/pro/event-fees")
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert evt_a_name in body
+        assert evt_b_name in body
+        # Enrollment counts surfaced
+        assert "Enrolled" in body or "enrolled" in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST — fee application
+# ---------------------------------------------------------------------------
+
+
+class TestEventFeesPostSetsFees:
+
+    def test_post_applies_fee_to_enrolled_competitors_only(self, app, auth_client):
+        with app.app_context():
+            data = _seed_tournament_with_events(_db.session)
+            _db.session.commit()
+            tid = data["t"].id
+            evt_a_id = data["evt_a"].id
+            c0_id, c1_id, c2_id = data["c0"].id, data["c1"].id, data["c2"].id
+
+        resp = auth_client.post(
+            f"/reporting/{tid}/pro/event-fees",
+            data={f"fee_{evt_a_id}": "25"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        with app.app_context():
+            from models.competitor import ProCompetitor
+
+            c0 = ProCompetitor.query.get(c0_id)
+            c1 = ProCompetitor.query.get(c1_id)
+            c2 = ProCompetitor.query.get(c2_id)
+
+            # c0 and c1 are enrolled in evt_a → fee set
+            assert c0.get_entry_fees().get(str(evt_a_id)) == 25
+            assert c1.get_entry_fees().get(str(evt_a_id)) == 25
+            # c2 is NOT enrolled in evt_a → no fee set for evt_a
+            assert str(evt_a_id) not in c2.get_entry_fees()
+
+    def test_post_blank_fee_field_is_noop(self, app, auth_client):
+        """An empty fee input must not wipe, set zero, or otherwise disturb fees."""
+        with app.app_context():
+            data = _seed_tournament_with_events(_db.session)
+            # Pre-set c0's fee for evt_a so we can prove it wasn't touched
+            c0 = data["c0"]
+            c0.set_entry_fee(data["evt_a"].id, 15)
+            _db.session.commit()
+            tid = data["t"].id
+            evt_a_id = data["evt_a"].id
+            c0_id = c0.id
+
+        resp = auth_client.post(
+            f"/reporting/{tid}/pro/event-fees",
+            data={f"fee_{evt_a_id}": ""},  # blank
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        with app.app_context():
+            from models.competitor import ProCompetitor
+
+            c0 = ProCompetitor.query.get(c0_id)
+            assert c0.get_entry_fees().get(str(evt_a_id)) == 15  # untouched
+
+    def test_post_skips_existing_non_zero_fee_by_default(self, app, auth_client):
+        """Without overwrite flag, competitors with an existing fee are skipped."""
+        with app.app_context():
+            data = _seed_tournament_with_events(_db.session)
+            # c0 already has $15 for evt_a. c1 has nothing set yet.
+            data["c0"].set_entry_fee(data["evt_a"].id, 15)
+            _db.session.commit()
+            tid = data["t"].id
+            evt_a_id = data["evt_a"].id
+            c0_id, c1_id = data["c0"].id, data["c1"].id
+
+        resp = auth_client.post(
+            f"/reporting/{tid}/pro/event-fees",
+            data={f"fee_{evt_a_id}": "30"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        with app.app_context():
+            from models.competitor import ProCompetitor
+
+            c0 = ProCompetitor.query.get(c0_id)
+            c1 = ProCompetitor.query.get(c1_id)
+            # c0 kept the original 15 (existing, no overwrite)
+            assert c0.get_entry_fees().get(str(evt_a_id)) == 15
+            # c1 got the new 30 (no existing fee)
+            assert c1.get_entry_fees().get(str(evt_a_id)) == 30
+
+    def test_post_overwrite_flag_replaces_existing_fees(self, app, auth_client):
+        """With overwrite=on, existing non-zero fees ARE replaced."""
+        with app.app_context():
+            data = _seed_tournament_with_events(_db.session)
+            data["c0"].set_entry_fee(data["evt_a"].id, 15)
+            _db.session.commit()
+            tid = data["t"].id
+            evt_a_id = data["evt_a"].id
+            c0_id = data["c0"].id
+
+        resp = auth_client.post(
+            f"/reporting/{tid}/pro/event-fees",
+            data={f"fee_{evt_a_id}": "30", "overwrite": "on"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        with app.app_context():
+            from models.competitor import ProCompetitor
+
+            c0 = ProCompetitor.query.get(c0_id)
+            assert c0.get_entry_fees().get(str(evt_a_id)) == 30
+
+    def test_post_invalid_fee_does_not_crash(self, app, auth_client):
+        """Garbage in the fee field flashes an error but returns 302, not 500."""
+        with app.app_context():
+            data = _seed_tournament_with_events(_db.session)
+            _db.session.commit()
+            tid = data["t"].id
+            evt_a_id = data["evt_a"].id
+
+        resp = auth_client.post(
+            f"/reporting/{tid}/pro/event-fees",
+            data={f"fee_{evt_a_id}": "twenty bucks"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302  # no 500


### PR DESCRIPTION
## Summary

The route + template for setting default pro event fees already existed:
- `GET/POST /reporting/<tid>/pro/event-fees` ([routes/reporting.py:619](routes/reporting.py#L619))
- `templates/reporting/event_fee_config.html`
- Bulk-apply to enrolled competitors, `overwrite` flag, per-event enrollment count + suggested fee

But it had **no sidebar link** and **no real tests** (just one smoke hit in `test_route_smoke_qa.py`). CLAUDE.md still listed it as a gap. This PR makes the existing feature discoverable and verified.

## Changes

- **Sidebar** ([templates/_sidebar.html](templates/_sidebar.html)): new "Event Fees" entry under Pro Day, immediately above "Fee Tracker". `bi-cash-stack` icon. Active-route highlighting.
- **Tests** ([tests/test_pro_event_fees.py](tests/test_pro_event_fees.py), 6 new):
  1. GET renders event rows with enrollment UI
  2. POST applies fee to competitors enrolled in that event only (not to unenrolled pros)
  3. Blank fee field is a no-op (doesn't wipe existing)
  4. Default behavior skips competitors with existing non-zero fee
  5. `overwrite=on` flag replaces existing fees
  6. Invalid input ("twenty bucks") flashes error, returns 302 not 500
- **CLAUDE.md**: moved Pro Event Fee Configuration from Section 5 "Known Gaps" to "Features Functionally Complete"; dropped from Section 8 remaining-gaps list

## Test plan

- [x] `pytest tests/test_pro_event_fees.py` — 6/6 pass
- [x] Regression check across FNF + smoke + reliability + CSRF — 173 pass
- [x] Sidebar link renders and highlights active route

## Version

Bumped to V2.11.2 across pyproject.toml, README.md header + footer, routes/main.py `/health` payloads, DEVELOPMENT.md changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)