### PR TITLE
style(design): touch targets + print fonts + html font-family (V2.11.3)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,30 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.11.3)
+
+**Patch — design review fixes: touch targets, root font-family, print-mode brand fonts**
+
+Three findings from a `/design-review` pass against V2.11.2. No functional changes; CSS + one template edit.
+
+**F-001 — Touch targets below WCAG 2.2 SC 2.5.8 on secondary navbar + table buttons (HIGH):**
+- `static/css/theme.css`: new `min-height: 44px` + `inline-flex` centering on `.navbar-proam .btn` (covers Help / Language / Users / Logout rendered as `.btn-outline-light.btn-sm` at ~31px previously). Also `.table .btn.btn-sm, table .btn.btn-sm` for inline row actions (View buttons, etc.).
+- DESIGN.md §17.2 previously enforced 44px on `.btn-proam` and `.navbar-proam .nav-link` only. Product context §0 explicitly targets field-side tablets — the secondary toolbar buttons were outside that rule and failing on tablet taps. Six of seven flagged targets now at 44px; the seventh (Load Demo Data in dashboard card header) is an admin-only convenience, deferred.
+
+**F-003 — Print stylesheets fall back to browser default serif (MEDIUM):**
+- `static/css/theme.css` `@media print`: `body` font-family forced to Inter, `h1-h6` forced to Fraunces. DESIGN.md §18 reset the dark theme for print but left fonts unspecified, so printable outputs (heat sheets, schedules) rendered Times New Roman on judge/spectator handouts. Brand identity now carries into printed artifacts.
+- `templates/scheduling/friday_feature_print.html`: standalone template (not using base.html), gets its own `<link>` to Google Fonts for Fraunces + Inter. Arial kept as fallback when offline.
+
+**F-004 — `<html>` element inherited browser default serif (LOW):**
+- `static/css/theme.css`: `html { font-family: "Inter", ... }` added alongside the existing `body` rule. No rendered elements affected today, but closes a design-system purity gap and protects against future edge cases where text lands outside `<body>`.
+
+**Deferred to future work:** F-002 heading hierarchy sweep (H5 used for section headers across ~20 templates); F-005 `.data-label` bump in hero context; F-006 tournament detail stepper-vs-stats visual ambiguity.
+
+**Data model:** No schema changes.
+**Tests:** No tests added — CSS-only changes are caught by `/design-review` reruns per skill convention. Regression guard in `tests/test_css_modal_safety.py` continues to apply.
+
+---
+
 ### 2026-04-21 (V2.11.2)
 
 **Patch — Pro event fee configuration surfaced + tested**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.11.2
+# Missoula Pro Am Manager — V2.11.3
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 
@@ -526,4 +526,4 @@ Operational docs:
 
 ---
 
-*Last updated: April 2026 — V2.11.2*
+*Last updated: April 2026 — V2.11.3*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.11.2"
+version = "2.11.3"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.11.2',
+        'version': '2.11.3',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.11.2',
+        'version': '2.11.3',
     })
 
 

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -54,6 +54,11 @@
         html { color-scheme: dark; }
         *, *::before, *::after { box-sizing: border-box; }
 
+        /* Also apply the body font at the html level so non-rendered root elements
+           (<html>, <head>, etc.) don't inherit the browser's default serif.
+           Design review F-004 (2026-04-21). */
+        html { font-family: "Inter", "Segoe UI", sans-serif; }
+
         body {
             min-height: 100vh;
             font-family: "Inter", "Segoe UI", sans-serif;
@@ -609,6 +614,28 @@
             align-items: center;
             border-radius: 7px;
             transition: color 0.15s, background 0.15s;
+        }
+
+        /* WCAG 2.2 SC 2.5.8 for tablet field-side use.
+           Secondary toolbar buttons inside the navbar (Help, Language,
+           Users, Logout) rendered at ~31px as .btn-outline-light.btn-sm.
+           Enforce 44px on any .btn inside .navbar-proam regardless of
+           bootstrap size modifier. Design review F-001 (2026-04-21). */
+        .navbar-proam .btn {
+            min-height: 44px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+        }
+        /* Same guarantee for action buttons in data tables (View, Load Demo Data,
+           inline row actions) which are the primary tap targets on tournament
+           lists. */
+        .table .btn.btn-sm,
+        table .btn.btn-sm {
+            min-height: 44px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
         }
         .navbar-proam .nav-link:hover {
             color: var(--sx-text) !important;
@@ -1413,6 +1440,13 @@
                 color: #000 !important;
                 font-size: 11pt !important;
                 line-height: 1.35 !important;
+                font-family: "Inter", "Segoe UI", sans-serif !important;
+            }
+            /* Keep Fraunces for headings on printed artifacts so brand identity
+               carries into schedules/heat sheets judges and spectators hold.
+               Design review F-003 (2026-04-21). */
+            h1, h2, h3, h4, h5, h6 {
+                font-family: "Fraunces", Georgia, serif !important;
             }
             .container,
             .container-fluid {

--- a/templates/scheduling/friday_feature_print.html
+++ b/templates/scheduling/friday_feature_print.html
@@ -3,9 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <title>Friday Night Feature Schedule - {{ tournament.name }} {{ tournament.year }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fraunces:wght@500;700&family=Inter:wght@400;500;600;700&display=swap">
     <style>
+        /* Brand-consistent fonts for the printable schedule.
+           Fraunces for headings (warmth), Inter for body.
+           Design review F-003 (2026-04-21). */
         body {
-            font-family: Arial, sans-serif;
+            font-family: "Inter", "Segoe UI", Arial, sans-serif;
             font-size: 11pt;
             margin: 24px;
             color: #111;
@@ -14,11 +20,14 @@
             margin: 0 0 4px 0;
             font-size: 18pt;
             color: #000;
+            font-family: "Fraunces", Georgia, serif;
+            letter-spacing: 0.01em;
         }
         h2 {
             margin: 0 0 8px 0;
             font-size: 13pt;
             color: #000;
+            font-family: "Fraunces", Georgia, serif;
         }
         .muted {
             color: #555;


### PR DESCRIPTION
## Summary

Three findings from a `/design-review` full-site audit. Purely stylistic, no functional changes.

| # | Finding | Impact | Status |
|---|---------|--------|--------|
| F-001 | Touch targets below 44px on secondary navbar + table buttons (Help/Language/Users/Logout, View row actions) | HIGH | 6/7 fixed |
| F-003 | Print stylesheets fall back to Times New Roman (brand identity lost on printed schedules) | MEDIUM | Fixed |
| F-004 | `<html>` element inherited browser default serif | LOW | Fixed |

## What changed

### F-001 — 44px min-height for tablet field-side use

DESIGN.md §17.2 enforced 44px on `.btn-proam` and `.navbar-proam .nav-link` specifically. Secondary toolbar buttons (`.btn-outline-light.btn-sm` in the navbar, `.btn.btn-sm` in data tables) were outside that rule and rendered at ~31px.

Added to [static/css/theme.css](static/css/theme.css):
```css
.navbar-proam .btn { min-height: 44px; display: inline-flex; ... }
.table .btn.btn-sm, table .btn.btn-sm { min-height: 44px; ... }
```

Before/after counts (from `getBoundingClientRect`):
- Navbar: 4 buttons at 31px → 44px (Help, Language, Users, Logout)
- Data tables: View row actions at 31px → 44px
- 1 remaining button (Load Demo Data in dashboard card header, admin-only convenience) deferred

### F-003 — Fraunces/Inter in print media

[static/css/theme.css](static/css/theme.css) `@media print` block: force body to Inter, h1-h6 to Fraunces.

[templates/scheduling/friday_feature_print.html](templates/scheduling/friday_feature_print.html) is a standalone template (not using `base.html`); added `<link>` to Google Fonts for Fraunces + Inter with preconnect hints.

### F-004 — Defensive html font-family

`html { font-family: "Inter", ... }` matches the existing `body` rule.

## Deferred

- **F-002** heading hierarchy sweep (H5 used for section headers across ~20 templates) — requires systematic refactor
- **F-005** `.data-label` size bump in hero stat context — part of a typography sweep
- **F-006** tournament detail stepper-vs-stats visual ambiguity — needs product decision

## Test plan

- [x] `pytest tests/test_css_modal_safety.py` — 3/3 pass (compositor-promoting rule guard still clean)
- [x] Browser verification: navbar buttons now render at 44px (`getBoundingClientRect` confirms)
- [x] Browser verification: `html` font-family now resolves to Inter
- [x] Visual diff: judge dashboard before/after screenshots in `.gstack/design-reports/screenshots/`

Full audit report: [.gstack/design-reports/design-audit-localhost-2026-04-21.md](.gstack/design-reports/design-audit-localhost-2026-04-21.md)

**Design score: B+ → A- projected.**
**AI Slop score: A (unchanged — already excellent).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)