### PR TITLE
feat: V2.12.0 — even flight distribution + drag-drop + print polish

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,45 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.12.0)
+
+**Minor — even flight distribution + between-flights drag-drop + print polish**
+
+Saturday show building had two separate problems. The flight builder would stack all of one event's heats into one flight when their competitors didn't overlap with other events (reported as "all underhand in flight 1"), and there was no way to manually move a heat from one flight to another without rebuilding from scratch. Also, the printed heat-sheet borders were too faint to survive photocopy and the day schedule print leaked ink on decorative gray fills. This release fixes all three in one pass.
+
+**Flight builder — per-event per-flight cap (`services/flight_builder.py`):**
+- New `event_per_flight_cap = ceil(N_e / target_flights)` computed in `_optimize_heat_order`. Threaded through `_single_pass_optimize` (tracks `(block, event_id) → count` as heats are placed) and into `_calculate_heat_score` (applies `EVENT_FLIGHT_CAP_PENALTY = 2000` per heat over cap).
+- Penalty is large enough to dominate the +1000 "first appearance" bonus and +500 springboard opener bonus combined, so crowd-variety distribution wins over local spacing optimization when a heat's competitors never appear in any other event. Before: greedy front-loaded same-event-heats in a row whenever all their competitors were new, because +1000 first-appearance crushed the +30 recency bonus. After: each event's heats spread evenly across flights.
+- Mathematically `F × ceil(N_e / F) ≥ N_e` always, so a feasible distribution exists. Sequential heat-number order within each event is preserved (per-event queues remain FIFO).
+- `_score_ordering` gets a matching `EVENT_FLIGHT_CAP_SCORE_PENALTY = 500` per over-cap heat so the multi-pass best-of-N comparison favors the better-distributed ordering.
+- Verified on a 53-heat / 3-flight show mirroring the reported incident: every event at or under its cap, 18/18/17 flight sizes preserved, Women's UH distribution went from 4-0-0 to 1-1-2.
+
+**Between-flights drag-drop (`routes/scheduling/flights.py`, `templates/pro/flights.html`):**
+- New `POST /scheduling/<tid>/flights/bulk-reorder` endpoint. Accepts `{flights: [{flight_id, heat_ids}]}` — the full DOM snapshot. Server rewrites `flight_id` + `flight_position` atomically based on what the client sent. Refuses with 400 if the heat set in the payload doesn't exactly match the heats currently assigned to those flights (guards against a half-loaded DOM dropping heats).
+- Frontend: each heat tile gets a grip handle (`.heat-drag-handle`) via `<i class="bi-grip-vertical">`. All three flight grids share `group: 'flight-heats'` so SortableJS allows drag between flights, not just within. On drop, the JS snapshots every visible flight's current state and POSTs to the bulk endpoint. Failed responses trigger a page reload so server state always wins. CSP nonce auto-injected by `_inject_csp_nonce` (inline `<script>` block requires no manual nonce attribute).
+- Saw-block recompute hook fires automatically after the move (same pattern as the existing `reorder_flight_heats`), so saw heats rebalance their Block A/B assignments to the new sequence.
+- 2 new integration tests in `tests/test_saw_block_integration.py`: happy-path cross-flight move verifies `flight_id` + `flight_position` update correctly for all three affected heats; mismatched-heat-set test verifies the 400 guard rejects incomplete payloads.
+
+**Heat sheet print (`templates/scheduling/heat_sheets_print.html`):**
+- `@media print` block: `.heat-card` border bumped from `1.5px solid #444` to `2.5px solid #000`. `.heat-card-head` bottom border from `1.5px solid #555` to `2.5px solid #000`. Pro/college left color bands from 4px to 6px (still navy/mauve). Each heat is now unambiguous on paper and survives photocopy + fax.
+
+**Day schedule print (`templates/scheduling/day_schedule_print.html`):**
+- Removed gray fill on `.slot-header` (was `#f1f1f1`) and `.heat-table thead th` (was `#fafafa`) — pure ink savings on every printed page.
+- Section titles (Friday Day Show / Friday Showcase / Saturday Show) now use `3px solid #000` above + `1px solid #000` below + uppercase tracking. Unmistakable day break without filled banners.
+- `.slot` card gets `1px solid #000` + `2px solid #000` below slot-title. Table rows use bottom-only `1px solid #000` hairlines (no top rules, no colored fills). `Heat N` label only prints on the first competitor row per heat (uses `{% if loop.first %}`) so scanning a column of 5 competitors in the same heat doesn't repeat the label 5 times.
+- Bracket rosters bumped from 2 columns to 3 for tighter vertical use. Page-break rules: `.slot` avoids splitting, `.section-title` avoids orphaning.
+
+**Regression coverage — `tests/test_flight_builder_integration.py::test_even_event_distribution_across_flights`:**
+- 3 events × 4 heats × disjoint competitor pools × 3 flights. Asserts no flight exceeds `ceil(4/3) = 2` heats of any event. Would fail against the pre-fix greedy (Women's UH 4-0-0). Passes on the new algorithm (spread 1-1-2 or 2-1-1).
+
+**Docs:**
+- `FlightLogic.md` §3.4 rewritten: removed the "variety emerges naturally from competitor spacing" claim (only true when competitors overlap across events, which is exactly the case that broke), documented the new cap mechanic with constants and penalties.
+
+**Data model:** No schema changes.
+**Tests:** 2940 passed (+3 new regression guards). 98 flight-specific tests all green. 7 saw-block integration tests all green (2 new).
+
+---
+
 ### 2026-04-21 (V2.11.3)
 
 **Patch — design review fixes: touch targets, root font-family, print-mode brand fonts**

--- a/FlightLogic.md
+++ b/FlightLogic.md
@@ -115,12 +115,27 @@ the pair to `_CONFLICTING_STANDS` in `flight_builder.py` and update this documen
 
 ### 3.4 Event Order and Variety
 
-The flight builder does **not** explicitly enforce a minimum number of events per flight. Variety
-emerges naturally from the competitor spacing algorithm: because competitors appear in multiple
-events, spacing them out inherently mixes events across flights.
+**First principle: each event's heats spread across flights as evenly as possible.** No flight
+may be dominated by one event.
 
-If a tournament has very few competitors spread across many events, some flights may be
-event-heavy. This is acceptable and does not need to be corrected automatically.
+The flight builder enforces a per-event per-flight cap:
+
+| Quantity | Value |
+|---|---|
+| Cap per flight per event | `ceil(N_e / target_flights)` where `N_e` is that event's heat count |
+| Step penalty | `EVENT_FLIGHT_CAP_PENALTY = 2000` per heat that would exceed the cap, applied in `_calculate_heat_score` |
+| Ordering penalty | `EVENT_FLIGHT_CAP_SCORE_PENALTY = 500` per heat over cap, applied in `_score_ordering` for multi-pass comparison |
+
+The cap is large enough to override the `+1000` first-appearance bonus and `+500` springboard
+opener bonus — without it, a heat whose competitors appear in no other event always scored `1000`
+(nothing forces spacing), so the greedy stacked all same-event heats together. Observed 2026-04-21
+on a 3-flight show where all women's underhand + most of men's underhand landed in flight 1.
+
+`ceil(N_e / F)` satisfies `F * cap >= N_e` always, so a feasible distribution exists. The per-event
+queue still guarantees heats within an event appear in ascending `heat_number` order.
+
+Events whose heats don't saturate a flight (e.g. 1 heat, or `N_e < F`) will still appear in only
+some flights — the cap is an upper bound, not a floor. In that case there is nothing to spread.
 
 ### 3.5 Partnered Axe Throw
 
@@ -419,6 +434,8 @@ this document.
 | `MIN_HEAT_SPACING` | 4 | Absolute minimum heats between a competitor's appearances |
 | `TARGET_HEAT_SPACING` | 5 | Preferred spacing; bonus applied at this level |
 | `_STAND_CONFLICT_GAP` | 8 | Minimum heats between conflicting stand types (approx. one full flight) |
+| `EVENT_FLIGHT_CAP_PENALTY` | 2000 | Per-candidate penalty per heat over a flight's per-event cap |
+| `EVENT_FLIGHT_CAP_SCORE_PENALTY` | 500 | Per-ordering penalty per heat over cap (multi-pass comparison) |
 | `PARTNERED_AXE_SHOW_TEAM_COUNT` | 4 | Number of pairs that advance from prelims to the show |
 | Default `heats_per_flight` | 8 | Target heats per flight (passed as argument to `build_pro_flights`) |
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.11.3
+# Missoula Pro Am Manager — V2.12.0
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 
@@ -526,4 +526,4 @@ Operational docs:
 
 ---
 
-*Last updated: April 2026 — V2.11.3*
+*Last updated: April 2026 — V2.12.0*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.11.3"
+version = "2.12.0"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.11.3',
+        'version': '2.12.0',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.11.3',
+        'version': '2.12.0',
     })
 
 

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -233,6 +233,68 @@ def reorder_flight_heats(tournament_id, flight_id):
     return jsonify({'ok': True})
 
 
+@scheduling_bp.route('/<int:tournament_id>/flights/bulk-reorder', methods=['POST'])
+def bulk_reorder_flights(tournament_id):
+    """Apply a full DOM snapshot of flight heat order — handles both within-flight
+    reordering and cross-flight moves in one atomic update.
+
+    Expects JSON: {flights: [{flight_id: int, heat_ids: [int, ...]}, ...]}.
+    The union of all heat_ids across flights MUST equal the set of all heats
+    currently assigned to any of those flights — otherwise refuse to prevent
+    an incomplete drag from wiping state.
+    """
+    tournament = Tournament.query.get_or_404(tournament_id)
+
+    try:
+        data = request.get_json(force=True)
+        entries = data.get('flights', [])
+        payload: list[tuple[int, list[int]]] = []
+        for entry in entries:
+            fid = int(entry['flight_id'])
+            hids = [int(h) for h in entry.get('heat_ids', [])]
+            payload.append((fid, hids))
+    except (TypeError, ValueError, KeyError, AttributeError):
+        return jsonify({'ok': False, 'error': 'Invalid payload'}), 400
+
+    if not payload:
+        return jsonify({'ok': False, 'error': 'No flights in payload'}), 400
+
+    flight_ids = [fid for fid, _ in payload]
+    flights = Flight.query.filter(
+        Flight.id.in_(flight_ids),
+        Flight.tournament_id == tournament_id,
+    ).all()
+    if len(flights) != len(flight_ids):
+        return jsonify({'ok': False, 'error': 'Unknown flight id'}), 400
+
+    # Heat set check: every heat currently in these flights must still be
+    # present in the payload. Prevents a half-loaded DOM from dropping heats.
+    existing_heats = Heat.query.filter(Heat.flight_id.in_(flight_ids)).all()
+    existing_heat_ids = {h.id for h in existing_heats}
+    payload_heat_ids = {hid for _, hids in payload for hid in hids}
+    if existing_heat_ids != payload_heat_ids:
+        return jsonify({
+            'ok': False,
+            'error': 'Heat set mismatch — refresh and try again',
+        }), 400
+
+    heats_by_id = {h.id: h for h in existing_heats}
+    for fid, hids in payload:
+        for position, hid in enumerate(hids, start=1):
+            heat = heats_by_id[hid]
+            heat.flight_id = fid
+            heat.flight_position = position
+    db.session.commit()
+
+    log_action('flights_bulk_reordered', 'tournament', tournament_id,
+               {'flights': [{'flight_id': fid, 'count': len(hids)} for fid, hids in payload]})
+
+    from services.saw_block_assignment import trigger_saw_block_recompute
+    trigger_saw_block_recompute(tournament)
+
+    return jsonify({'ok': True})
+
+
 # ---------------------------------------------------------------------------
 # #2 — Flight start + SMS notification trigger
 # ---------------------------------------------------------------------------

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -49,6 +49,16 @@ _CONFLICTING_STANDS: dict[str, str] = {
 # Minimum gap between conflicting stand types (approximately one flight block)
 _STAND_CONFLICT_GAP = 8
 
+# Per-event per-flight distribution: each event's heats are targeted to spread
+# evenly across flights as ceil(N_e / target_flights) per flight. Penalty per
+# heat over that cap must outweigh first-appearance (+1000) and springboard
+# opener (+500) so crowd variety wins over local spacing optimization when a
+# heat's competitors never appear in any other event.
+EVENT_FLIGHT_CAP_PENALTY = 2000.0
+# Scoring-pass penalty is smaller (per-excess-heat) because it's summed across
+# the whole ordering rather than applied at a single candidate step.
+EVENT_FLIGHT_CAP_SCORE_PENALTY = 500.0
+
 
 def _get_spacing(event: Event | None) -> tuple[int, int]:
     """Return (min_spacing, target_spacing) for this event's stand type."""
@@ -395,6 +405,20 @@ def _optimize_heat_order(all_heats: list, heats_per_flight: int = 8,
         )
     event_ids = list(event_queues.keys())
 
+    # First principle: each event's heats spread evenly across flights.
+    # Cap = ceil(N_e / target_flights). Mathematically F * cap >= N_e always,
+    # so a feasible distribution exists. The algorithm still honors the
+    # sequential-heat-number guarantee because event queues are FIFO.
+    total_heats = len(all_heats)
+    target_flights = (
+        max(1, math.ceil(total_heats / heats_per_flight))
+        if heats_per_flight > 0 else 1
+    )
+    event_per_flight_cap: dict[int, int] = {
+        eid: max(1, math.ceil(len(queue) / target_flights))
+        for eid, queue in event_queues.items()
+    }
+
     best_ordered: list = []
     best_score = float('-inf')
 
@@ -402,10 +426,16 @@ def _optimize_heat_order(all_heats: list, heats_per_flight: int = 8,
     for pass_num in range(actual_passes):
         # Rotate event_ids to create different greedy starting conditions.
         rotated = event_ids[pass_num:] + event_ids[:pass_num]
-        candidate = _single_pass_optimize(event_queues, rotated, heats_per_flight,
-                                          gear_conflict_pairs=gear_conflict_pairs)
-        score = _score_ordering(candidate, heats_per_flight,
-                                gear_conflict_pairs=gear_conflict_pairs)
+        candidate = _single_pass_optimize(
+            event_queues, rotated, heats_per_flight,
+            gear_conflict_pairs=gear_conflict_pairs,
+            event_per_flight_cap=event_per_flight_cap,
+        )
+        score = _score_ordering(
+            candidate, heats_per_flight,
+            gear_conflict_pairs=gear_conflict_pairs,
+            event_per_flight_cap=event_per_flight_cap,
+        )
         if score > best_score:
             best_score = score
             best_ordered = candidate
@@ -415,7 +445,8 @@ def _optimize_heat_order(all_heats: list, heats_per_flight: int = 8,
 
 def _single_pass_optimize(event_queues: dict, event_id_order: list,
                            heats_per_flight: int,
-                           gear_conflict_pairs: dict[int, set[int]] | None = None) -> list:
+                           gear_conflict_pairs: dict[int, set[int]] | None = None,
+                           event_per_flight_cap: dict[int, int] | None = None) -> list:
     """
     Execute a single greedy pass through the event queues.
 
@@ -429,6 +460,9 @@ def _single_pass_optimize(event_queues: dict, event_id_order: list,
     stand_type_last_position: dict[str, int] = {}
     # Track which flight block each event last appeared in (for recency bonus).
     event_last_block: dict[int, int] = {}
+    # Count of this event's heats already placed in the current flight block,
+    # used to enforce the even-distribution cap. Key: (block, event_id).
+    event_heats_in_block: dict[tuple[int, int], int] = {}
 
     while True:
         candidates = [
@@ -458,6 +492,8 @@ def _single_pass_optimize(event_queues: dict, event_id_order: list,
                     event_last_block,
                     gear_conflict_pairs=gear_conflict_pairs,
                     previous_heat_comps=ordered[-1]['competitors'] if ordered else set(),
+                    event_per_flight_cap=event_per_flight_cap,
+                    event_heats_in_block=event_heats_in_block,
                 ),
                 remaining_counts[eid],   # tie-break: more remaining = preferred
                 eid,
@@ -480,6 +516,8 @@ def _single_pass_optimize(event_queues: dict, event_id_order: list,
                         None,  # disable stand conflict check
                         heats_per_flight,
                         event_last_block,
+                        event_per_flight_cap=event_per_flight_cap,
+                        event_heats_in_block=event_heats_in_block,
                     ),
                     remaining_counts[eid],
                     eid,
@@ -501,12 +539,16 @@ def _single_pass_optimize(event_queues: dict, event_id_order: list,
         event_id = best_heat_data['heat'].event_id
         current_block = pos // heats_per_flight if heats_per_flight > 0 else 0
         event_last_block[event_id] = current_block
+        event_heats_in_block[(current_block, event_id)] = (
+            event_heats_in_block.get((current_block, event_id), 0) + 1
+        )
 
     return ordered
 
 
 def _score_ordering(ordered: list, heats_per_flight: int,
-                    gear_conflict_pairs: dict[int, set[int]] | None = None) -> float:
+                    gear_conflict_pairs: dict[int, set[int]] | None = None,
+                    event_per_flight_cap: dict[int, int] | None = None) -> float:
     """
     Compute a quality score for a complete heat ordering. Higher is better.
 
@@ -572,6 +614,22 @@ def _score_ordering(ordered: list, heats_per_flight: int,
             if count > 1:
                 total -= 1000 * (count - 1)
 
+    # Per-event per-flight distribution penalty: mirrors the per-step cap
+    # used during greedy placement so multi-pass comparison rewards the
+    # pass that best spreads each event's heats across flights.
+    if event_per_flight_cap and heats_per_flight > 0:
+        event_heats_per_block: dict[tuple[int, int], int] = {}
+        for pos, hd in enumerate(ordered):
+            block = pos // heats_per_flight
+            eid = hd['heat'].event_id
+            event_heats_per_block[(block, eid)] = (
+                event_heats_per_block.get((block, eid), 0) + 1
+            )
+        for (_block, eid), count in event_heats_per_block.items():
+            cap = event_per_flight_cap.get(eid)
+            if cap is not None and count > cap:
+                total -= EVENT_FLIGHT_CAP_SCORE_PENALTY * (count - cap)
+
     return total
 
 
@@ -581,7 +639,9 @@ def _calculate_heat_score(competitors: set, competitor_last_heat: dict,
                            heats_per_flight: int = 8,
                            event_last_block: dict | None = None,
                            gear_conflict_pairs: dict[int, set[int]] | None = None,
-                           previous_heat_comps: set | None = None) -> float:
+                           previous_heat_comps: set | None = None,
+                           event_per_flight_cap: dict[int, int] | None = None,
+                           event_heats_in_block: dict | None = None) -> float:
     """
     Calculate a score for placing a heat at the current position.
 
@@ -679,6 +739,23 @@ def _calculate_heat_score(competitors: set, competitor_last_heat: dict,
                 overlap = partner_ids & previous_heat_comps
                 if overlap:
                     score -= 200 * len(overlap)
+
+    # Per-event per-flight distribution cap. Without this, heats whose
+    # competitors never appear in any other event all score 1000
+    # (first-appearance) and greedily stack into one flight — which is the
+    # opposite of the crowd-variety first principle flights exist to serve.
+    # Penalty scales with how far over the cap the placement would go and is
+    # large enough to override the first-appearance bonus.
+    if (event_per_flight_cap is not None and event_heats_in_block is not None
+            and heats_per_flight > 0):
+        event_id = getattr(event, 'id', None)
+        if event_id is not None:
+            current_block = current_position // heats_per_flight
+            cap = event_per_flight_cap.get(event_id)
+            if cap is not None:
+                already = event_heats_in_block.get((current_block, event_id), 0)
+                if already >= cap:
+                    score -= EVENT_FLIGHT_CAP_PENALTY * (already - cap + 1)
 
     return score
 

--- a/templates/pro/flights.html
+++ b/templates/pro/flights.html
@@ -149,6 +149,24 @@
 }
 .heat-tile.bg-light:hover { background: rgba(45,168,94,0.09) !important; }
 
+/* ── Drag-drop ────────────────────────────────────────────── */
+.heat-drag-handle {
+    cursor: grab;
+    color: var(--sx-text-2);
+    font-size: 0.9rem;
+    padding: 2px 4px;
+    margin-right: 2px;
+    border-radius: 3px;
+    user-select: none;
+}
+.heat-drag-handle:hover {
+    background: var(--sx-surface-3);
+    color: var(--sx-text);
+}
+.heat-tile.sortable-ghost { opacity: 0.3; }
+.heat-tile.sortable-drag { opacity: 0.9; box-shadow: 0 8px 24px rgba(0,0,0,0.5); }
+.heat-grid.drag-over { background: rgba(232,144,18,0.06); }
+
 /* ── Type labels ──────────────────────────────────────────── */
 .badge-college-label {
     display: inline-block;
@@ -273,13 +291,17 @@
             {% endif %}
         </div>
 
-        {# Heat tiles grid #}
-        <div class="heat-grid">
+        {# Heat tiles grid — drag-drop: within-flight reorder + cross-flight move #}
+        <div class="heat-grid flight-drag-grid" data-flight-id="{{ flight.id }}">
             {% for row in fd.heats %}
             {% set is_college = row.event.event_type == 'college' %}
-            <div class="heat-tile {{ 'heat-tile-college' if is_college else '' }} {% if row.heat.status == 'completed' %}bg-light{% endif %}">
+            <div class="heat-tile {{ 'heat-tile-college' if is_college else '' }} {% if row.heat.status == 'completed' %}bg-light{% endif %}"
+                 data-heat-id="{{ row.heat.id }}">
                 <div class="heat-tile-header">
                     <span class="heat-tile-event">
+                        <span class="heat-drag-handle" title="Drag to reorder or move to another flight">
+                            <i class="bi bi-grip-vertical"></i>
+                        </span>
                         {% if is_college %}
                         <span class="badge-college-label">COLLEGE</span>
                         {% else %}
@@ -349,4 +371,77 @@
     </div>
     {% endif %}
 </div>
+
+{% if flight_data %}
+<div class="d-none d-md-block text-muted small text-center mt-2 mb-4">
+    <i class="bi bi-grip-vertical"></i>
+    Drag heats by the handle to reorder within a flight, or drop into another flight to move.
+</div>
+{% endif %}
+{% endblock %}
+
+{% block extra_js %}
+{% if flight_data %}
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
+<script>
+(function () {
+    var tournamentId = {{ tournament.id }};
+    var csrfEl = document.querySelector('meta[name="csrf-token"]');
+    var csrfToken = csrfEl ? csrfEl.getAttribute('content') : '';
+
+    function snapshotAllFlights() {
+        var out = [];
+        document.querySelectorAll('.flight-drag-grid').forEach(function (grid) {
+            var fid = parseInt(grid.dataset.flightId, 10);
+            var ids = Array.from(grid.querySelectorAll('[data-heat-id]'))
+                .map(function (el) { return parseInt(el.dataset.heatId, 10); });
+            out.push({flight_id: fid, heat_ids: ids});
+        });
+        return out;
+    }
+
+    function persistChange() {
+        fetch('/scheduling/' + tournamentId + '/flights/bulk-reorder', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': csrfToken
+            },
+            body: JSON.stringify({flights: snapshotAllFlights()})
+        }).then(function (r) { return r.json(); }).then(function (data) {
+            if (!data || !data.ok) {
+                var msg = (data && data.error) || 'unknown error';
+                alert('Move failed: ' + msg + '. The page will refresh to show the saved order.');
+                window.location.reload();
+            }
+        }).catch(function () {
+            alert('Move request failed. Check your connection and refresh.');
+            window.location.reload();
+        });
+    }
+
+    document.querySelectorAll('.flight-drag-grid').forEach(function (grid) {
+        new Sortable(grid, {
+            group: 'flight-heats',
+            animation: 150,
+            handle: '.heat-drag-handle',
+            ghostClass: 'sortable-ghost',
+            dragClass: 'sortable-drag',
+            onAdd: function () { grid.classList.remove('drag-over'); },
+            onStart: function () {
+                document.querySelectorAll('.flight-drag-grid').forEach(function (g) {
+                    if (g !== grid) g.classList.add('drag-over');
+                });
+            },
+            onEnd: function () {
+                document.querySelectorAll('.flight-drag-grid').forEach(function (g) {
+                    g.classList.remove('drag-over');
+                });
+                persistChange();
+            }
+        });
+    });
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/templates/scheduling/day_schedule_print.html
+++ b/templates/scheduling/day_schedule_print.html
@@ -4,45 +4,76 @@
     <meta charset="UTF-8">
     <title>Day Schedule - {{ tournament.name }} {{ tournament.year }}</title>
     <style>
+        /* Day schedule — print-optimized layout.
+           Principles:
+           - Black ink only on structural lines (no gray fills, no tinted headers).
+           - Strong day-section separators (thick rule + all-caps banner).
+           - Slot cards: thin black border; title row gets its own thick bottom rule.
+           - Table rows: hairline bottom rules only, no shaded headers.
+           - Page-break-inside: avoid on section + slot so nothing splits awkwardly.
+        */
         body {
-            font-family: Arial, sans-serif;
-            font-size: 11pt;
-            margin: 24px;
-            color: #111;
-        }
-        h1, h2 {
-            margin: 0 0 8px 0;
+            font-family: Arial, Helvetica, sans-serif;
+            font-size: 10.5pt;
+            margin: 0.4in;
             color: #000;
+            background: #fff;
         }
-        .muted {
-            color: #555;
-            font-size: 10pt;
+        h1 {
+            margin: 0 0 2px 0;
+            color: #000;
+            font-size: 16pt;
+            letter-spacing: 0.01em;
         }
+        .header-meta {
+            font-size: 9pt;
+            color: #000;
+            margin-bottom: 14px;
+            padding-bottom: 6px;
+            border-bottom: 2px solid #000;
+        }
+        /* ── Day section — one band per day block ─────────────────── */
         .section {
-            margin-top: 22px;
-            page-break-inside: avoid;
+            margin-top: 18px;
+            page-break-inside: auto;
         }
+        .section + .section { margin-top: 22px; }
+        .section-title {
+            margin: 0 0 10px 0;
+            padding: 4px 0 3px 0;
+            font-size: 12pt;
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #000;
+            border-top: 3px solid #000;
+            border-bottom: 1px solid #000;
+        }
+        /* ── Slot card ────────────────────────────────────────────── */
         .slot {
-            margin: 12px 0;
-            border: 1px solid #bbb;
-            border-radius: 4px;
-            overflow: hidden;
+            margin: 0 0 8px 0;
+            border: 1px solid #000;
             page-break-inside: avoid;
+            break-inside: avoid;
         }
         .slot-header {
-            background: #f1f1f1;
-            border-bottom: 1px solid #bbb;
-            padding: 8px 10px;
+            padding: 4px 8px;
+            border-bottom: 2px solid #000;
         }
         .slot-title {
             font-weight: 700;
             font-size: 11pt;
+            color: #000;
         }
         .slot-meta {
-            margin-top: 2px;
-            font-size: 9.5pt;
-            color: #444;
+            display: inline;
+            margin-left: 8px;
+            font-size: 9pt;
+            color: #000;
+            font-weight: 500;
         }
+        .slot-meta::before { content: '— '; }
+        /* ── Heat table ──────────────────────────────────────────── */
         .heat-table {
             width: 100%;
             border-collapse: collapse;
@@ -50,64 +81,85 @@
         }
         .heat-table th,
         .heat-table td {
-            border-top: 1px solid #ddd;
-            padding: 6px 8px;
+            border-bottom: 1px solid #000;
+            padding: 3px 8px;
             vertical-align: top;
+            font-size: 9.5pt;
         }
+        .heat-table tbody tr:last-child td { border-bottom: none; }
         .heat-table thead th {
-            background: #fafafa;
-            font-size: 9pt;
+            font-size: 8pt;
+            font-weight: 700;
             text-transform: uppercase;
-            letter-spacing: 0.03em;
+            letter-spacing: 0.05em;
+            border-bottom: 1.5px solid #000;
+            color: #000;
+            text-align: left;
         }
-        .col-heat { width: 130px; }
-        .col-stand { width: 100px; text-align: center; }
+        .heat-table thead th.col-stand { text-align: center; }
+        /* Separator between heats within a slot table — solid rule above
+           each heat's first row (except the very first). Renders as a
+           visible heat divider without colored fills. */
+        .heat-table tbody tr.heat-first td { border-top: 1.5px solid #000; }
+        .heat-table tbody tr:first-child td { border-top: none; }
+
+        .col-heat  { width: 110px; font-weight: 600; }
+        .col-stand { width: 60px; text-align: center; font-weight: 700; }
         .stand-cell { text-align: center; font-weight: 700; }
         .no-data {
-            padding: 10px;
-            color: #666;
+            padding: 6px 10px;
+            color: #000;
             font-style: italic;
+            font-size: 9.5pt;
         }
+        /* ── Bracket slot ────────────────────────────────────────── */
         .bracket-notice {
-            padding: 10px;
-            color: #333;
+            padding: 4px 10px;
+            color: #000;
             font-style: italic;
-            border-top: 1px solid #ddd;
+            font-size: 9.5pt;
+            border-bottom: 1px solid #000;
         }
         .bracket-roster {
-            padding: 6px 10px;
-            columns: 2;
-            column-gap: 20px;
+            margin: 0;
+            padding: 4px 10px 4px 28px;
+            columns: 3;
+            column-gap: 18px;
+            font-size: 9.5pt;
         }
         .bracket-roster li {
-            margin-bottom: 2px;
+            margin-bottom: 1px;
+            break-inside: avoid;
         }
+
         @media print {
             .no-print { display: none !important; }
-            body { margin: 0.3in; }
+            body { margin: 0.35in; font-size: 10pt; }
+            .section { page-break-inside: auto; }
+            .slot { page-break-inside: avoid; break-inside: avoid; }
+            /* Keep the section-title with at least one following slot so a title
+               doesn't become the last thing on a page. */
+            .section-title { page-break-after: avoid; break-after: avoid-page; }
         }
     </style>
 </head>
 <body>
-    <h1>{{ tournament.name }} {{ tournament.year }} - Day Schedule</h1>
-    <div class="muted">Saturday source: {{ 'Flights' if schedule.saturday_source == 'flights' else 'Fallback Event Order' }}</div>
+    <h1>{{ tournament.name }} {{ tournament.year }} — Day Schedule</h1>
+    <div class="header-meta">
+        Saturday source: {{ 'Flights' if schedule.saturday_source == 'flights' else 'Fallback Event Order' }}
+    </div>
 
     {% macro render_schedule_block(items, block_title) %}
     <div class="section">
-        <h2>{{ block_title }}</h2>
+        <div class="section-title">{{ block_title }}</div>
         {% for item in items %}
             <div class="slot">
                 <div class="slot-header">
-                    <div class="slot-title">{{ item.slot }}. {{ item.label }}</div>
-                    <div class="slot-meta">
-                        {{ item.event_type|title }}
-                        {% if item.flight_number %} | Flight {{ item.flight_number }}{% endif %}
-                    </div>
+                    <span class="slot-title">{{ item.slot }}. {{ item.label }}</span>
+                    <span class="slot-meta">{{ item.event_type|title }}{% if item.flight_number %} · Flight {{ item.flight_number }}{% endif %}</span>
                 </div>
                 {% if item.is_bracket %}
-                    <div class="bracket-notice">
-                        Bracket event -- see bracket sheet for matchups and seedings.
-                    </div>
+                    <div class="bracket-notice">Bracket event — see bracket sheet for matchups and seedings.</div>
                     {% if item.bracket_competitors %}
                     <ol class="bracket-roster">
                         {% for name in item.bracket_competitors %}
@@ -119,7 +171,7 @@
                 <table class="heat-table">
                     <thead>
                         <tr>
-                            <th class="col-heat">Heat / Run</th>
+                            <th class="col-heat">Heat</th>
                             <th class="col-stand">Stand</th>
                             <th>Competitor</th>
                         </tr>
@@ -127,10 +179,8 @@
                     <tbody>
                         {% for heat in item.heats %}
                             {% for comp in heat.competitors %}
-                            <tr>
-                                <td>
-                                    Heat {{ heat.heat_number }}{% if heat.run_number > 1 %} - Run {{ heat.run_number }}{% endif %}
-                                </td>
+                            <tr{% if loop.first %} class="heat-first"{% endif %}>
+                                <td>{% if loop.first %}Heat {{ heat.heat_number }}{% if heat.run_number > 1 %} — Run {{ heat.run_number }}{% endif %}{% endif %}</td>
                                 <td class="stand-cell">{{ comp.stand_label if comp.stand_label is defined else (comp.stand if comp.stand is not none else '?') }}</td>
                                 <td>{{ comp.name }}</td>
                             </tr>
@@ -143,7 +193,7 @@
                 {% endif %}
             </div>
         {% else %}
-            <div class="muted">No events in this block.</div>
+            <div class="no-data">No events in this block.</div>
         {% endfor %}
     </div>
     {% endmacro %}

--- a/templates/scheduling/heat_sheets_print.html
+++ b/templates/scheduling/heat_sheets_print.html
@@ -142,16 +142,23 @@
         -webkit-print-color-adjust: exact;
         print-color-adjust: exact;
     }
-    .heat-card { border: 1.5px solid #444 !important; margin-bottom: 5px !important; }
+    /* Bold black borders around heat divisions — every heat card is an
+       unambiguous block on paper, survives photocopy + fax. */
+    .heat-card {
+        border: 2.5px solid #000 !important;
+        margin-bottom: 6px !important;
+        break-inside: avoid;
+        page-break-inside: avoid;
+    }
     .heat-card-head {
         background: #e4e4e4 !important;
-        border-bottom: 1.5px solid #555 !important;
+        border-bottom: 2.5px solid #000 !important;
         padding: 3px 8px !important;
         -webkit-print-color-adjust: exact;
         print-color-adjust: exact;
     }
-    .heat-card-head.head-pro     { border-left: 4px solid #1a3a5c !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-    .heat-card-head.head-college { border-left: 4px solid #8d3a6e !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .heat-card-head.head-pro     { border-left: 6px solid #1a3a5c !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .heat-card-head.head-college { border-left: 6px solid #8d3a6e !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
     .heat-card-event { color: #000 !important; font-size: 0.85rem !important; }
     .heat-card-sub   { color: #333 !important; }
     .heat-tbl { font-size: 0.80rem !important; }

--- a/tests/test_flight_builder_integration.py
+++ b/tests/test_flight_builder_integration.py
@@ -731,6 +731,65 @@ class TestFlightBuilderEdgeCases:
         flights = fb.build()
         assert flights > 0
 
+    def test_even_event_distribution_across_flights(self, db_session):
+        """Regression test (2026-04-21): heats of each event must be spread
+        across flights as evenly as possible, not stacked into one flight.
+
+        Prior behavior: when a heat's competitors appeared in no other event,
+        the greedy scored that heat at +1000 (first-appearance) and stacked
+        every same-event heat in a row. On a 3-flight, 53-heat show the whole
+        women's underhand field (4 heats) and most of men's underhand ended
+        up in flight 1, violating the crowd-variety first principle.
+
+        This test uses disjoint competitor pools per event so the pre-fix
+        algorithm is forced to clump. Per-flight-per-event cap = ceil(N_e/F).
+        """
+        from models import Flight, Heat
+        from services.flight_builder import FlightBuilder
+
+        t = _make_tournament(db_session)
+
+        # 3 events, each with 4 heats, each heat's 3 competitors unique across
+        # the whole show — no spacing pressure links the events. With 3 flights
+        # (12 heats, 4 per flight) the fair distribution is roughly 1-2 heats
+        # of each event per flight; cap = ceil(4/3) = 2.
+        event_specs = [
+            ("Women's Underhand", 'underhand', 'F'),
+            ("Men's Underhand", 'underhand', 'M'),
+            ('Obstacle Pole', 'obstacle_pole', None),
+        ]
+        next_comp = 1
+        events = []
+        for name, stand, gender in event_specs:
+            ev = _make_pro_event(db_session, t, name, stand, gender=gender, max_stands=5)
+            for hn in range(1, 5):
+                ids = [next_comp, next_comp + 1, next_comp + 2]
+                next_comp += 3
+                _make_heat(db_session, ev, hn, ids)
+            events.append(ev)
+
+        fb = FlightBuilder(t)
+        fb.build(num_flights=3)
+
+        flights = Flight.query.filter_by(tournament_id=t.id).order_by(
+            Flight.flight_number
+        ).all()
+        assert len(flights) == 3
+
+        import math as _math
+        cap = _math.ceil(4 / 3)  # 2 heats per event per flight
+
+        for ev in events:
+            counts_per_flight = []
+            for f in flights:
+                c = Heat.query.filter_by(flight_id=f.id, event_id=ev.id).count()
+                counts_per_flight.append(c)
+            assert max(counts_per_flight) <= cap, (
+                f'Event {ev.name} distribution across 3 flights was '
+                f'{counts_per_flight}; expected each flight <= {cap} heats. '
+                f'All-underhand-in-one-flight regression.'
+            )
+
     def test_run2_heats_excluded_from_flights(self, db_session):
         """Run 2 heats (dual-run events) should not be placed into flights."""
         from models import Heat

--- a/tests/test_saw_block_integration.py
+++ b/tests/test_saw_block_integration.py
@@ -383,6 +383,82 @@ def test_reorder_flight_heats_triggers_recompute(app, auth_client):
         assert _used_stands(h_a) == BLOCK_B
 
 
+def test_bulk_reorder_moves_heat_between_flights(app, auth_client):
+    """Bulk reorder endpoint moves a heat from one flight to another,
+    updates flight_id and flight_position correctly for every heat in the
+    payload."""
+    from database import db as _db
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck", event_type="pro")
+        f1 = _seed_flight(_db, t, flight_number=1)
+        f2 = _seed_flight(_db, t, flight_number=2)
+        h_a = _seed_heat(_db, sb, 1, competitors=[1, 2, 3, 4],
+                        stand_assignments={"1": 1, "2": 2, "3": 3, "4": 4},
+                        flight=f1, flight_position=1)
+        h_b = _seed_heat(_db, sb, 2, competitors=[5, 6, 7, 8],
+                        stand_assignments={"5": 5, "6": 6, "7": 7, "8": 8},
+                        flight=f1, flight_position=2)
+        h_c = _seed_heat(_db, sb, 3, competitors=[9, 10, 11, 12],
+                        stand_assignments={"9": 1, "10": 2, "11": 3, "12": 4},
+                        flight=f2, flight_position=1)
+        _db.session.commit()
+        tid, f1_id, f2_id = t.id, f1.id, f2.id
+        h_a_id, h_b_id, h_c_id = h_a.id, h_b.id, h_c.id
+
+    # Move h_b from flight 1 to flight 2, keep h_a alone in flight 1,
+    # put h_b at position 1 of flight 2 (before h_c).
+    resp = auth_client.post(
+        f"/scheduling/{tid}/flights/bulk-reorder",
+        json={
+            "flights": [
+                {"flight_id": f1_id, "heat_ids": [h_a_id]},
+                {"flight_id": f2_id, "heat_ids": [h_b_id, h_c_id]},
+            ]
+        },
+    )
+    assert resp.status_code == 200, resp.data
+    assert resp.get_json().get("ok") is True
+
+    with app.app_context():
+        from models import Heat
+        h_a = Heat.query.get(h_a_id)
+        h_b = Heat.query.get(h_b_id)
+        h_c = Heat.query.get(h_c_id)
+        assert h_a.flight_id == f1_id and h_a.flight_position == 1
+        assert h_b.flight_id == f2_id and h_b.flight_position == 1
+        assert h_c.flight_id == f2_id and h_c.flight_position == 2
+
+
+def test_bulk_reorder_rejects_mismatched_heat_set(app, auth_client):
+    """Bulk reorder must refuse a payload that drops or invents heats so a
+    half-loaded DOM can't wipe state."""
+    from database import db as _db
+
+    with app.app_context():
+        t = _seed_tournament(_db)
+        sb = _seed_saw_event(_db, t, name="Single Buck", event_type="pro")
+        f1 = _seed_flight(_db, t, flight_number=1)
+        h_a = _seed_heat(_db, sb, 1, competitors=[1, 2],
+                        stand_assignments={"1": 1, "2": 2},
+                        flight=f1, flight_position=1)
+        h_b = _seed_heat(_db, sb, 2, competitors=[3, 4],
+                        stand_assignments={"3": 1, "4": 2},
+                        flight=f1, flight_position=2)
+        _db.session.commit()
+        tid, f1_id = t.id, f1.id
+        h_a_id = h_a.id  # intentionally omit h_b from the payload
+
+    resp = auth_client.post(
+        f"/scheduling/{tid}/flights/bulk-reorder",
+        json={"flights": [{"flight_id": f1_id, "heat_ids": [h_a_id]}]},
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body and body.get("ok") is False
+
+
 def test_reorder_friday_events_triggers_recompute(app, auth_client):
     """Reordering Friday events reassigns blocks to match new event order."""
     from database import db as _db


### PR DESCRIPTION
## Summary

Three fixes shipped together on the flight builder and show-day print surfaces:

**Flight builder — even event distribution** (`services/flight_builder.py`)
- Saturday builds were stacking all of one event's heats into a single flight when the competitors didn't overlap with other events. Fixed with a per-event per-flight cap of `ceil(N_e / target_flights)`, enforced via a 2000-point penalty that dominates the first-appearance +1000 and springboard opener +500 bonuses.
- Before: Women's Underhand 4-0-0 across 3 flights, Men's Underhand 5-1-1. After: 1-1-2 and 3-2-2. Total flight sizes preserved (18/18/17). Regression test in `test_flight_builder_integration.py::test_even_event_distribution_across_flights`.
- `FlightLogic.md` §3.4 rewritten — removed the "variety emerges naturally" claim that was only true when competitors overlap across events.

**Between-flights drag-drop** (`routes/scheduling/flights.py`, `templates/pro/flights.html`)
- New `POST /scheduling/<tid>/flights/bulk-reorder` endpoint. Accepts a full DOM snapshot of all flight heat orders and rewrites `flight_id` + `flight_position` atomically. 400s on mismatched heat set to prevent half-loaded DOM from dropping heats.
- Each heat tile gets a grip handle. All three flight grids share `group: 'flight-heats'` so SortableJS allows drag between flights, not just within. Saw-block recompute fires automatically on any move.
- 2 new integration tests: happy-path cross-flight move + mismatched-payload refusal.

**Print polish** (`templates/scheduling/heat_sheets_print.html`, `templates/scheduling/day_schedule_print.html`)
- Heat sheet print: `.heat-card` border 1.5px→2.5px black, color bands 4px→6px. Survives photocopy.
- Day schedule print: dropped all gray fills (ink savings), section titles get 3px black rule above + uppercase tracking (unmistakable day breaks without filled banners), table rows use bottom-only hairlines, `Heat N` label only prints on first competitor row per heat (no 5x repetition in a 5-competitor heat), bracket rosters bumped from 2 cols to 3.

## Test Coverage

Before → After: 2937 → 2940 (+3 new regression guards)
- `test_flight_builder_integration.py::test_even_event_distribution_across_flights` — guards against the clumping bug
- `test_saw_block_integration.py::test_bulk_reorder_moves_heat_between_flights` — happy-path cross-flight move
- `test_saw_block_integration.py::test_bulk_reorder_rejects_mismatched_heat_set` — 400 refusal on incomplete DOM snapshot

All 98 flight-specific tests green. All 7 saw-block integration tests green. 2940 passed (full CI config) in 111s.

## Pre-Landing Review

No critical findings. One informational (race condition on drag-drop — same pattern as existing `reorder_flight_heats`, consistent sibling behavior, not a regression). Quality: 9.5/10.

## Verification Results

End-to-end browser QA against a seeded synthetic tournament matching the PDF scale (53 heats, 3 flights, 9 events):
- `/scheduling/1/flights` renders 200, zero console errors, SortableJS 1.15.2 loaded, 3 drag grids, 49 drag handles
- Cross-flight drag verified end-to-end: moved heat 1 from flight 1 to end of flight 2, re-fetched page confirms persistence
- Bulk-reorder endpoint guards verified: empty payload → 400 "No flights in payload", mismatched heat set → 400 "Heat set mismatch"
- Day schedule print + heat sheets print both render 200 with new CSS selectors present in source

Screenshots in `.gstack/qa-reports/screenshots/`.

## Test plan
- [x] `pytest` full suite (2940 passed, 9 skipped, 1 xpassed) with CI's ignore list + `-k "not (TestFetchStartMark)"`
- [x] Flight-builder-specific: 98 tests
- [x] Browser QA: flights page loads, drag-drop wiring verified, bulk-reorder endpoint exercised end-to-end, print templates render
- [ ] Post-merge: verify production `/health` reports `version: 2.12.0` after Railway deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)