### PR TITLE
fix: clickable seed links in birling "not seeded" flash (V2.12.1)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,29 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-21 (V2.12.1)
+
+**Patch — clickable seed links in birling "not seeded" flash warning**
+
+When a judge clicked "Print Birling Brackets" on the tournament overview before any bracket was seeded, the flash warning listed which events still needed seeding but the names were plain text — the judge had to hunt through the sidebar and event list to find each event's seeding page. This patch turns each event name in the warning into a direct `<a>` link to its `scheduling.birling_manage` page.
+
+**`routes/scheduling/birling.py::birling_print_all`:**
+- Imports `markupsafe.Markup` + `escape` (first use of Markup in this codebase — no new dependency; markupsafe is already a Flask transitive dep).
+- `skipped` list now holds `Event` objects instead of pre-formatted display-name strings so we have access to `event.id` when building links. A `skipped_names` list is still assembled at the end solely for the `log_action` audit payload, preserving the existing contract.
+- Nested helper `_seed_links(evts)` builds `<a href="/scheduling/<tid>/event/<eid>/birling" class="text-white fw-semibold text-decoration-underline">{escaped name}</a>` fragments. All user-controllable values (`display_name`) pass through `markupsafe.escape` *before* being concatenated into the `Markup` wrapper — no XSS surface introduced.
+- Both branches emit a `Markup(...)` flash body: the "all ungenerated → 302" warning and the "some skipped alongside rendered" info flash.
+- `text-white` + underline inline classes ensure the link is visible against the amber warning-toast background rendered by `templates/base.html` (Bootstrap's `.alert-link` is scoped to `.alert` elements and wouldn't apply to toasts).
+
+**Tests — `tests/test_routes_birling_print.py::TestPrintAll` (+2):**
+- `test_all_ungenerated_flash_contains_seed_links`: both unseeded events' `href` attributes appear in the warning-category flash body.
+- `test_mixed_skip_flash_contains_seed_links`: the info-category skip flash (when at least one bracket IS seeded) also links the unseeded event's seeding page.
+- Existing 9 route tests in the file remain unchanged — none asserted on flash body content, so the Markup switch didn't perturb them.
+
+**Data model:** No schema changes.
+**Tests:** 2942 passed, 9 skipped, 1 xpassed (+2 new regression tests for clickable flash).
+
+---
+
 ### 2026-04-21 (V2.12.0)
 
 **Minor — even flight distribution + between-flights drag-drop + print polish**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Missoula Pro Am Manager — V2.12.0
+# Missoula Pro Am Manager — V2.12.1
 
 A web-based tournament management system for the Missoula Pro Am timbersports competition.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.12.0"
+version = "2.12.1"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.12.0',
+        'version': '2.12.1',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.12.0',
+        'version': '2.12.1',
     })
 
 

--- a/routes/scheduling/birling.py
+++ b/routes/scheduling/birling.py
@@ -6,6 +6,7 @@ Judges rank/seed competitors before generating the double-elimination bracket,
 then record match results to advance competitors through the bracket.
 """
 from flask import abort, flash, jsonify, redirect, render_template, request, url_for
+from markupsafe import Markup, escape
 
 from database import db
 from models import Event, EventResult, Tournament
@@ -446,29 +447,41 @@ def birling_print_all(tournament_id):
                                 tournament_id=tournament_id))
 
     rendered: list = []
-    skipped_names: list = []
+    skipped: list = []
     for event in events:
         ctx = build_birling_print_context(event)
         if ctx is None:
-            skipped_names.append(event.display_name)
+            skipped.append(event)
             continue
         rendered.append({'event': event, 'ctx': ctx})
 
+    def _seed_links(evts):
+        parts = []
+        for evt in evts:
+            href = url_for('scheduling.birling_manage',
+                           tournament_id=tournament_id, event_id=evt.id)
+            parts.append(
+                '<a href="{href}" class="text-white fw-semibold text-decoration-underline">{name}</a>'.format(
+                    href=escape(href), name=escape(evt.display_name))
+            )
+        return Markup(', '.join(parts))
+
     if not rendered:
         flash(
-            'No birling brackets have been seeded yet: {}.  Seed at least one to print.'
-            .format(', '.join(skipped_names)),
+            Markup('No birling brackets have been seeded yet: {}. Seed at least one to print.'
+                   .format(_seed_links(skipped))),
             'warning',
         )
         return redirect(url_for('main.tournament_detail',
                                 tournament_id=tournament_id))
 
-    if skipped_names:
+    if skipped:
         flash(
-            'Skipped {} birling event(s) without a generated bracket: {}.'
-            .format(len(skipped_names), ', '.join(skipped_names)),
+            Markup('Skipped {} birling event(s) without a generated bracket: {}.'
+                   .format(len(skipped), _seed_links(skipped))),
             'info',
         )
+    skipped_names = [evt.display_name for evt in skipped]
 
     html = render_template(
         'scoring/birling_bracket_print.html',

--- a/tests/test_routes_birling_print.py
+++ b/tests/test_routes_birling_print.py
@@ -252,3 +252,53 @@ class TestPrintAll:
     def test_missing_tournament_404(self, bp_auth_client):
         resp = bp_auth_client.get("/scheduling/99999/birling/print-all")
         assert resp.status_code == 404
+
+    def test_all_ungenerated_flash_contains_seed_links(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        """When every bracket is unseeded, the redirect flash must include a
+        clickable <a> link to each event's seeding page so the judge can
+        navigate directly instead of hunting for it."""
+        t = make_tournament(db_session)
+        men = _make_bracket_event(db_session, t, name="Birling", gender="M")
+        women = _make_bracket_event(db_session, t, name="Birling", gender="F")
+        db_session.flush()
+        men_id, women_id = men.id, women.id
+
+        resp = bp_auth_client.get(f"/scheduling/{t.id}/birling/print-all")
+        assert resp.status_code in (302, 303)
+
+        with bp_auth_client.session_transaction() as sess:
+            flashes = sess.get("_flashes", [])
+        assert flashes, "expected at least one flashed message"
+        warning_bodies = [msg for cat, msg in flashes if cat == "warning"]
+        assert warning_bodies, "expected a warning-category flash"
+        body = warning_bodies[-1]
+        assert f'href="/scheduling/{t.id}/event/{men_id}/birling"' in body
+        assert f'href="/scheduling/{t.id}/event/{women_id}/birling"' in body
+
+    def test_mixed_skip_flash_contains_seed_links(
+        self,
+        bp_auth_client,
+        db_session,
+    ):
+        """Partial seeding: the info-level skip flash must also carry the
+        seeding-page link for each unseeded event."""
+        t = make_tournament(db_session)
+        men = _make_bracket_event(db_session, t, name="Birling", gender="M")
+        women = _make_bracket_event(db_session, t, name="Birling", gender="F")
+        _seed_generated_bracket(men)
+        db_session.flush()
+        women_id = women.id
+
+        resp = bp_auth_client.get(f"/scheduling/{t.id}/birling/print-all")
+        assert resp.status_code == 200
+
+        with bp_auth_client.session_transaction() as sess:
+            flashes = sess.get("_flashes", [])
+        info_bodies = [msg for cat, msg in flashes if cat == "info"]
+        assert info_bodies, "expected an info-category skip flash"
+        body = info_bodies[-1]
+        assert f'href="/scheduling/{t.id}/event/{women_id}/birling"' in body


### PR DESCRIPTION
## Summary

- Turns each unseeded-event name in the "Print Birling Brackets → no brackets seeded" flash into an `<a>` link pointing at that event's seeding page (`scheduling.birling_manage`).
- Same treatment for the info-level "skipped N birling event(s)" flash when some brackets ARE seeded but others are not.
- Judge no longer has to hunt through the sidebar/events list to find the seeding page — one click from the warning.

## What changed

| File | Change |
|---|---|
| `routes/scheduling/birling.py` | `birling_print_all` — Markup-wrapped flash bodies with per-event `<a href="/scheduling/<tid>/event/<eid>/birling">` fragments. `display_name` escaped via `markupsafe.escape` before Markup wrap — no XSS. `log_action` audit payload unchanged (still gets plain `skipped_names` list). |
| `tests/test_routes_birling_print.py` | +2 regression tests assert the href appears in both the warning flash (all ungenerated) and the info flash (partial skip) bodies. Existing 9 route tests unchanged — none asserted on flash body content. |
| `pyproject.toml`, `README.md`, `routes/main.py` (×2 `/health`), `DEVELOPMENT.md` | Version bump 2.12.0 → 2.12.1. |

## Test plan

- [x] `pytest tests/test_routes_birling_print.py` — 11/11 pass (9 existing + 2 new)
- [x] Full CI-matching suite — 2942 passed, 9 skipped, 1 xpassed
- [x] `python -m py_compile routes/scheduling/birling.py` — clean
- [ ] Manual smoke: judge creates tournament with birling events, clicks "Print Birling Brackets" before seeding → confirms flash contains clickable event-name links that jump to seeding page

🤖 Generated with [Claude Code](https://claude.com/claude-code)