### PR TITLE
feat: bundle — Russian i18n + ability-rankings dark-mode + gear-sharing USING-prefix fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -457,9 +457,12 @@ def _create_app_inner():
         body = response.get_data(as_text=True)
         changed = False
 
-        # 1. Optional Arapaho translation
-        if text.get_language() == 'arp':
-            translated = text.translate_html(body)
+        # 1. Full-page translation for any non-default language that has a
+        # phrase map (currently Arapaho and Russian). The DEFAULT_LANGUAGE
+        # ('en') is the source text — no translation pass needed for it.
+        active_lang = text.get_language()
+        if active_lang != text.DEFAULT_LANGUAGE and active_lang in text.TRANSLATIONS:
+            translated = text.translate_html(body, lang=active_lang)
             if translated != body:
                 body = translated
                 changed = True

--- a/docs/GEAR_SHARING_AUDIT.md
+++ b/docs/GEAR_SHARING_AUDIT.md
@@ -5,6 +5,16 @@ Date: 2026-04-18. Scope: source-of-truth review for the bug "OP Saw and Cookie S
 SHARING entries from the entry form are not appearing in the gear-sharing module," plus
 USING/SHARING vocabulary handling, name matching, Q27 interaction, and degenerate input.
 
+## Resolution log (update 2026-04-21)
+
+- **Finding #1 (USING vs SHARING conflation)** — RESOLVED across two releases:
+  - V2.9.1 (commit `9a4f1fb`, 2026-04-19) introduced the `using:` value prefix on `gear_sharing` entries and taught the heat builders (`competitors_share_gear_for_event`, `build_gear_conflict_pairs`, `_aggregate_gear_groups`) to skip them so partnered pairs stop getting split across heats.
+  - V2.12.x follow-up (2026-04-21) closed the display-side gap that V2.9.1 missed: `services/preflight.py` (the preflight-report scanner) was still normalizing raw `using:` values and mis-flagging every USING entry as an unknown partner, plus flagging legitimate SHARING entries as partner-mismatch noise. Fix + 6 regression tests in `tests/test_preflight.py`.
+  - Full write-up: [`docs/solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md`](solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md).
+  - Lesson captured there (Prevention rule #1): whenever a new value-prefix convention is added to a shared JSON field, grep every consumer across `services/` AND `routes/` AND `templates/` before declaring rollout complete. This audit itself is an example — the 828-line document below has zero mentions of `services/preflight.py` as a consumer of `gear_sharing`. That's the blind spot that let the preflight bug survive V2.9.1.
+
+Remaining Findings 2–25 (minus the two withdrawn ones, #9 and #17) retain their status below.
+
 Domain context already documented in
 `docs/Alex's Docs/GEAR_SHARING_DOMAIN.md` — that file enumerates per-event sharing
 constraints. This audit does not duplicate it; it documents the code that implements
@@ -761,7 +771,7 @@ text and skips parsing. The manager UI does not display Q27 anywhere.
 
 ## 8. Numbered bug / gap list
 
-1. **USING vs SHARING semantically conflated** — `services/gear_sharing.py:388`. The parser has zero handling of either keyword; `sharing` is only a strip target. USING entries (partnered-event confirmation) get written into `gear_sharing` JSON the same way SHARING entries do, then `build_gear_conflict_pairs` (`gear_sharing.py:905`) treats them as cross-competitor heat constraints, spreading legitimately partnered competitors across heats. Severity: HIGH. Confidence: 9.
+1. ~~**USING vs SHARING semantically conflated**~~ — **RESOLVED 2026-04-21.** V2.9.1 added a `using:` value prefix on `gear_sharing` entries (`services/gear_sharing.py:42`) and taught the heat-building consumers (`competitors_share_gear_for_event`, `build_gear_conflict_pairs`, `_aggregate_gear_groups`) to skip them. V2.12.x closed the display-facing gap V2.9.1 missed in `services/preflight.py`. See the Resolution log at the top of this file and [`solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md`](solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md). Severity was: HIGH. Confidence: 9.
 
 2. **`infer_equipment_categories` missing Cookie Stack, Obstacle Pole/OP, Speed Climb categories** — `services/gear_sharing.py:292`. Only emits `crosscut`, `chainsaw`, `springboard`. When the explicit per-event match fails, no category fallback exists for these events, so partner-detected entries with vague event language drop on the floor. Severity: HIGH. Confidence: 10.
 

--- a/docs/solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md
+++ b/docs/solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md
@@ -1,0 +1,202 @@
+---
+title: "Preflight gear-sharing false positives from USING prefix drift"
+date: 2026-04-21
+category: data-integrity
+module: missoula-pro-am-manager
+problem_type: logic_error
+component: service_object
+symptoms:
+  - "Preflight reported 30 unresolved gear-sharing partner names (all false positives)"
+  - "Preflight reported 32 gear-vs-partner mismatches (23 false positives, 9 SHARING-concept false positives, 4 real drift)"
+  - "Preflight reported 33 stale gear entries for unenrolled events with no cleanup UI"
+  - "Judges unable to trust preflight signal on live tournament four days before race day"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+related_components:
+  - service_object
+  - database
+  - frontend_stimulus
+tags:
+  - preflight
+  - gear-sharing
+  - using-vs-sharing
+  - json-field-drift
+  - v2.9.1-followup
+  - false-positive
+  - consumer-sweep
+---
+
+# Preflight gear-sharing false positives from USING prefix drift
+
+## Problem
+
+V2.9.1 (commit `9a4f1fb`, 2026-04-19) introduced a `using:` value prefix on the `gear_sharing` JSON dict to distinguish *partnered-event confirmation* from *cross-competitor gear dependency*, but only taught the heat-building services about the new format. The preflight scanner kept reading raw values through `normalize_person_name`, so every USING entry surfaced as a false-positive "unknown partner" warning on the judge-facing preflight page. A separate conceptual bug in the mismatch check was also flagging correct SHARING data as a disagreement, and a third warning about stale gear-for-unenrolled-events had no cleanup UI at all.
+
+On live tournament 2, four days before race day, the preflight page showed 6 high-severity + 4 medium-severity issues, most of which were noise. Judges could not tell real problems from artifacts.
+
+## Symptoms
+
+The preflight page at `/registration/<tid>/preflight-check` on `tournament_id=2` reported three warnings that the V2.9.1 changelog claimed were solved:
+
+- **`gear_unknown_partner_names`: 30 entries** listing Kate Page, Brianna Kvinge, Chrissy Marcellus, Emma Macon, Grace Shelton, + 17 more. Direct SQL against `instance/proam.db` showed all 30 were USING entries whose underlying names DO resolve against the roster — the `using:` prefix was short-circuiting the normalization lookup.
+- **`gear_partner_mismatch`: 32 entries.** SQL breakdown: 23 using-prefix false positives (same root cause as Warning 1, but via string comparison) + 9 SHARING-conceptual false positives on Double Buck / Jack & Jill pairs where a saw-sharer legitimately differed from the event partner (e.g., Ripley Orr partnered with Cody Labahn, shares saw with May Brown).
+- **`gear_non_enrolled_event`: 33 entries.** Stale `gear_sharing` keys pointing at events the competitor no longer entered (e.g., Chrissy Marcellus had 10 entries for events she wasn't in). Genuine data hygiene, but no cleanup route existed.
+
+## What Didn't Work
+
+- **Hypothesis: competitors had missing roster data.** First instinct was that Warning 1 was catching genuine typos or unregistered partner names. A standalone SQL probe against `instance/proam.db` counted genuine unknowns vs. prefix artifacts — 0 genuine, 30 prefix. Killed the hypothesis before touching code.
+- **False-alarm duplicate endpoint.** Misread a grep hit and initially claimed `move_competitor_between_heats` was registered in both `routes/scheduling/flights.py` and `routes/scheduling/heats.py`, blocking the test run. On re-inspection, `flights.py:346` was a different function named `drag_move_competitor`. The pytest collision was transient, likely a race with the `SessionStart: Cleared __pycache__` hook during test discovery; all 26 preflight tests passed on the next run. Correcting this required re-reading the grep output column-by-column rather than trusting the initial skim.
+- **V2.9.1's consumer sweep missed `services/preflight.py` entirely** (session history). The 828-line `docs/GEAR_SHARING_AUDIT.md` written during V2.9.1 contains zero mentions of preflight. A subagent saw the file once in a directory listing but never opened it. The explicit consumer list used by the V2.9.1 implementation was `competitors_share_gear_for_event`, `build_gear_conflict_pairs`, `_aggregate_gear_groups`, plus the manager-page display template — four hot-path consumers, no display-facing scanners.
+- **A later Codex audit also missed it** (session history). The 2026-04-19 Codex audit touched `routes/scheduling/preflight.py` (the HTTP route layer) and refactored background-job app-context, but never opened `services/preflight.py` (the report builder). Same failure-mode trap in a different file: two modules share a name but do entirely different things, and a dedicated second-opinion audit landed on the route-layer one without cross-checking the service-layer one.
+
+## Solution
+
+### 1) `services/preflight.py` — import the USING helpers
+
+```python
+# Before
+from services.gear_sharing import event_matches_gear_key, normalize_person_name
+
+# After
+from services.gear_sharing import (
+    event_matches_gear_key,
+    is_using_value,
+    normalize_person_name,
+    strip_using_prefix,
+)
+```
+
+### 2) Warning 1 (`gear_unknown_partner_names`) — strip the prefix before normalization
+
+```python
+# Before
+partner_text = str(partner or '').strip()
+partner_norm = normalize_person_name(partner_text)
+if not partner_text:
+    unknown_partner_rows += 1
+    ...
+
+# After
+partner_text = str(partner or '').strip()
+# USING entries carry a "using:" prefix to flag partnered-event
+# confirmation (see services/gear_sharing._USING_VALUE_PREFIX).
+# The underlying name must still resolve to a real competitor,
+# but the prefix itself is not part of the person's name.
+partner_name_only = strip_using_prefix(partner_text)
+partner_norm = normalize_person_name(partner_name_only)
+if not partner_name_only:
+    unknown_partner_rows += 1
+    ...
+```
+
+### 3) Warning 3 (`gear_partner_mismatch`) — only compare USING entries, strip prefix first
+
+```python
+# Before
+for key, gear_partner in gear.items():
+    gp = normalize_person_name(str(gear_partner or '').strip())
+    pp = normalize_person_name(str(partners.get(key, '') or '').strip())
+    if gp and pp and gp != pp:
+        partner_mismatch_rows += 1
+
+# After
+# Only USING entries claim to confirm the event partner — a mismatch there
+# is a genuine data bug (stale confirmation vs. new partner assignment).
+# SHARING entries (no "using:" prefix) are defined as cross-competitor gear
+# dependency OUTSIDE the event partnership, so gear_partner != event_partner
+# is the expected, correct shape — flagging it produced noise on every
+# Double Buck / Jack & Jill pair with a saw-sharer.
+for key, gear_partner in gear.items():
+    gear_text = str(gear_partner or '').strip()
+    if not is_using_value(gear_text):
+        continue
+    gp = normalize_person_name(strip_using_prefix(gear_text))
+    pp = normalize_person_name(str(partners.get(key, '') or '').strip())
+    if gp and pp and gp != pp:
+        partner_mismatch_rows += 1
+```
+
+### 4) `services/gear_sharing.py` — new `cleanup_non_enrolled_gear_entries()` service
+
+Walks every active pro + college competitor's `gear_sharing` dict and removes keys the competitor isn't enrolled in. Handles direct event-id keys (`"82"`) and category keys (`"category:crosscut"`) — category keys are kept when the competitor is enrolled in any event of that category (matching the resolution logic in `event_matches_gear_key`). Returns `{cleaned, affected: [names], pro_cleaned, college_cleaned}`; caller commits.
+
+### 5) `routes/registration.py` — new POST endpoint
+
+`POST /pro/gear-sharing/cleanup-non-enrolled` wired to `cleanup_non_enrolled_gear_entries()`, invalidates the competitor cache via `invalidate_tournament_caches`, audit-logs the row counts and affected names via `log_action('gear_cleanup_non_enrolled', ...)`, flashes the result.
+
+### 6) `templates/pro/gear_sharing.html` — "Cleanup Non-Enrolled" button
+
+Renders next to the existing "Cleanup Scratched" action with the standard `data-confirm` modal attribute (no inline `onsubmit` — CSP-compliant, matches the V2.11.0 FNF one-click-generate pattern).
+
+### 7) `tests/test_preflight.py` — 6 regression tests
+
+| Test | Asserts |
+|---|---|
+| `test_using_prefix_resolves_to_known_partner` | USING entry whose stripped name matches roster → no warning |
+| `test_sharing_entry_different_from_partner_is_not_flagged` | Ripley/Cody/May case: SHARING != event partner → no warning |
+| `test_using_entry_still_flagged_when_name_unknown` | `using:Ghost Competitor` → still flags `gear_unknown_partner_names` |
+| `test_using_mismatch_with_partners_still_flagged` | USING name drifted from `partners[key]` → still flags `gear_partner_mismatch` |
+| `test_removes_entries_for_non_enrolled_events` | Cleanup removes stale direct-id keys, keeps enrolled ones |
+| `test_keeps_category_entries_when_enrolled_in_matching_event` | `category:crosscut` preserved when competitor is in any crosscut event |
+
+### Before/after counts on live tournament 2
+
+| Warning | Before | After code fix | After clicking "Cleanup Non-Enrolled" |
+|---|---|---|---|
+| `gear_unknown_partner_names` | 30 | **0** | 0 |
+| `gear_partner_mismatch` | 32 | **4** (real USING drift) | 4 |
+| `gear_non_enrolled_event` | 33 | 33 | **0** |
+
+The 4 remaining `gear_partner_mismatch` entries are genuine data bugs the warning is supposed to catch — e.g., Iliana Castro's gear says `using:Karson Wilson` for Jack & Jill but her `partners` dict says `Jack Love`. Those stay flagged for human review in the Gear Sharing Manager.
+
+Test suite: 172/172 pass (146 gear-sharing unit tests + 26 preflight tests including the 6 new regressions).
+
+## Why This Works
+
+The `gear_sharing` JSON field carries two semantically different domain meanings that V2.9.1 distinguished with a value prefix:
+
+- **USING** (`"using:<name>"`) — *partnered-event confirmation.* "I confirm `<name>` is my registered partner for this event." Redundant with the `partners` dict; NOT a heat constraint. A mismatch between `strip_using_prefix(gear[key])` and `partners[key]` is a genuine data bug — the confirmation was entered against a now-stale partner assignment.
+- **SHARING** (`"<name>"`, no prefix) — *cross-competitor gear dependency.* "I share my cookie-stack saw with `<name>`, who competes separately from me." IS a heat constraint — the two competitors cannot be in the same heat. By definition, `gear[key] != partners[key]` because the whole point is a different person from the event partner.
+
+V2.9.1 correctly taught `competitors_share_gear_for_event` and `build_gear_conflict_pairs` to skip USING entries when building heat constraints — so the scheduling side was right. But `services/preflight.py` is a *display-facing scanner*, not a heat builder, and it still:
+
+1. Ran `normalize_person_name("using:Eric hoberg")` → `"usingerichoberg"` → never a roster hit → false Warning 1.
+2. Compared every gear key against `partners` regardless of prefix → SHARING entries are defined to differ → false Warning 3.
+
+Stripping the prefix before normalization makes Warning 1 ask the right question ("is the underlying name in the roster?"). Restricting the mismatch check to USING-only makes Warning 3 ask the right question ("is this confirmation stale relative to the current partner assignment?"). SHARING entries are now silent in both warnings — correct, because they're expressed through heat-building constraints, not preflight display.
+
+The cleanup service closes the orthogonal Warning 2 loop: stale keys accumulate as competitors drop events, and there was no UI to purge them. Category-key awareness prevents clobbering `"category:crosscut"` entries when a competitor is still enrolled in any crosscut event.
+
+## Prevention
+
+**Concrete rules for the next value-format change on a shared JSON field:**
+
+1. **Grep every consumer before declaring rollout complete.** When adding `_USING_VALUE_PREFIX` to `services/gear_sharing.py`, V2.9.1 updated the hot-path call sites and shipped. The mandatory follow-up is a repo-wide grep for the field name across `services/` AND `routes/` AND `templates/`, with an explicit audit note per hit: "does this consumer need to know about the new prefix?" Preflight would have been caught in 30 seconds. The useful grep for `gear_sharing` readers is `rg -l "get_gear_sharing|\.gear_sharing\b"` (session history).
+
+2. **Name the "fourth consumer" category** (session history). V2.9.1 handled three hot-path consumers plus the display template. Any file that reads `gear_sharing` dict values without going through `strip_using_prefix` / `is_using_value` is a latent false-positive source. The category worth naming in CLAUDE.md: *display-facing scanners and report builders* — the quiet consumers that don't affect scheduling but shape what judges see.
+
+3. **Prefer read-through helpers over raw dict access.** Any consumer that touches `gear_sharing[key]` should call a centralized accessor — e.g., `resolve_gear_partner(gear, key) -> (kind, name)` returning `('using', name)`, `('sharing', name)`, or `(None, '')`. The prefix becomes an implementation detail of the helper, not of every caller. This would have made the preflight fix a one-line call-site swap instead of two separate stanzas with copy-pasted prefix-stripping logic.
+
+4. **Add a lint/grep guard.** A cheap CI check: `rg "normalize_person_name" services/ routes/` and require every hit to also reference either `strip_using_prefix` or `is_using_value` (or be explicitly allowlisted). Any bare `normalize_person_name(gear[key])` is now a suspected prefix-unaware read.
+
+5. **Test the display path, not just the scheduling path.** V2.9.1 added regression tests for heat building (correct) but not for preflight (missed). When a data format changes, every *interpreter* of that format — UI warnings, reports, exports, audit logs — needs a test exercising the new shape. The 6 tests in `tests/test_preflight.py` are the template: USING-match, SHARING-mismatch, USING-unknown, USING-stale, plus the cleanup cases.
+
+6. **Two files can share a name and do entirely different things** (session history). `routes/scheduling/preflight.py` (HTTP route + async worker) and `services/preflight.py` (report builder) are a trap. The Codex audit walked the route-layer one and missed the service-layer one. Mitigation: CLAUDE.md should call out this kind of name-twin explicitly in the architecture section, and auditors should always cross-check for `services/<name>.py` when they find `routes/.../<name>.py` (and vice versa).
+
+7. **When a changelog claims "fixed X", verify X on live data before closing the loop.** The V2.9.1 entry said gear-sharing was fixed; the preflight page on tournament 2 said otherwise. A 5-line SQL probe against `instance/proam.db` distinguished "fix didn't ship" from "fix is incomplete" in under a minute. This should be the default first step when a user says "this should have been solved."
+
+## Related Issues
+
+- **PR #25** (merged 2026-04-19, commit `9a4f1fb`) — V2.9.1 race-day UI hardening. Introduced the `using:` prefix. Direct ancestor of this fix.
+- **PR #9** (merged 2026-04-08) — earlier gear-sharing hardening pass (G1-G8); context only.
+- **`docs/GEAR_SHARING_AUDIT.md`** — V2.9.1 audit artifact (828 lines, 25 numbered gaps). Finding #1 ("USING vs SHARING semantically conflated") is now fully resolved across V2.9.1 + this fix. Audit did not enumerate `services/preflight.py` as a consumer — the audit itself had the blind spot that produced this bug.
+- [`docs/solutions/data-integrity/events-entered-stores-names-not-ids.md`](events-entered-stores-names-not-ids.md) — sibling: same failure shape (one producer, multiple consumers, silent mis-resolution across services) on a different JSON field.
+- [`docs/solutions/architecture-decisions/json-fields-over-join-tables.md`](../architecture-decisions/json-fields-over-join-tables.md) — the tradeoff doc that warns about JSON-field consumer drift. This bug is a concrete instance of that warning.
+- [`docs/solutions/data-integrity/json-decode-errors-from-corrupt-fields.md`](json-decode-errors-from-corrupt-fields.md) — related only in that both touch `gear_sharing` integrity; different failure mode.
+
+## Auto memory cross-references
+
+(auto memory [claude]) MEMORY.md `V2.9.1 (2026-04-19)` patch note listed USING/SHARING fix as a "BLOCKER fix" because partnered pairs were being split across heats; the note did not mention preflight, consistent with V2.9.1's scope being the heat builders only.
+
+(auto memory [claude]) MEMORY.md "Never stash/restore/revert without approval" applied correctly in this session — uncommitted files from other in-progress work (flights.py additions, birling.py, ability_rankings.html) were observed and left untouched.

--- a/routes/registration.py
+++ b/routes/registration.py
@@ -1048,6 +1048,35 @@ def pro_gear_cleanup_scratched(tournament_id):
     return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
 
 
+@registration_bp.route('/<int:tournament_id>/pro/gear-sharing/cleanup-non-enrolled', methods=['POST'])
+def pro_gear_cleanup_non_enrolled(tournament_id):
+    """Remove gear-sharing entries pointing at events the competitor is not enrolled in."""
+    tournament = Tournament.query.get_or_404(tournament_id)
+    from services.gear_sharing import cleanup_non_enrolled_gear_entries
+    try:
+        result = cleanup_non_enrolled_gear_entries(tournament)
+        db.session.commit()
+        invalidate_tournament_caches(tournament_id)
+        log_action('gear_cleanup_non_enrolled', 'tournament', tournament_id, {
+            'cleaned': result['cleaned'],
+            'pro_cleaned': result['pro_cleaned'],
+            'college_cleaned': result['college_cleaned'],
+            'affected': result['affected'],
+        })
+        if result['cleaned']:
+            flash(
+                f'Removed {result["cleaned"]} stale gear entry(s) from'
+                f' {len(result["affected"])} competitor(s) — these referenced events they are not enrolled in.',
+                'success',
+            )
+        else:
+            flash('No stale gear entries for non-enrolled events.', 'info')
+    except Exception as e:
+        db.session.rollback()
+        flash(f'Error cleaning up non-enrolled gear entries: {e}', 'error')
+    return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
+
+
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/auto-partners', methods=['POST'])
 def pro_gear_auto_partners(tournament_id):
     """Copy gear_sharing entries into partners for partnered events."""

--- a/services/gear_sharing.py
+++ b/services/gear_sharing.py
@@ -882,6 +882,84 @@ def complete_one_sided_pairs(tournament) -> dict:
     return {'completed': completed}
 
 
+def cleanup_non_enrolled_gear_entries(tournament) -> dict:
+    """
+    Remove gear-sharing entries pointing at events the competitor is not
+    enrolled in. Handles both direct event-id keys (e.g. "82") and category
+    keys (e.g. "category:crosscut") — a category key is pruned only when the
+    competitor is enrolled in zero events of that category.
+
+    Does NOT touch USING-prefixed values on an event the competitor IS in;
+    the prefix is left as-is so partnered-confirmation semantics survive.
+
+    Caller must commit. Returns {cleaned, affected: [names], pro_cleaned,
+    college_cleaned}.
+    """
+    from models import Event
+    from models.competitor import CollegeCompetitor, ProCompetitor
+
+    all_events = Event.query.filter_by(tournament_id=tournament.id).all()
+    pro_events = [e for e in all_events if e.event_type == 'pro']
+    college_events = [e for e in all_events if e.event_type == 'college']
+
+    cleaned_total = 0
+    affected: list[str] = []
+
+    def _scan(rows, relevant_events):
+        nonlocal cleaned_total
+        local_cleaned = 0
+        for comp in rows:
+            gear = comp.get_gear_sharing() if hasattr(comp, 'get_gear_sharing') else {}
+            if not isinstance(gear, dict) or not gear:
+                continue
+            entered_vals = {
+                str(v or '').strip()
+                for v in comp.get_events_entered()
+                if str(v or '').strip()
+            }
+            kept: dict = {}
+            removed_any = False
+            for key, val in gear.items():
+                matching = [e for e in relevant_events if event_matches_gear_key(e, key)]
+                if not matching:
+                    removed_any = True
+                    continue
+                enrolled = any(
+                    str(e.id) in entered_vals
+                    or e.name in entered_vals
+                    or e.display_name in entered_vals
+                    for e in matching
+                )
+                if enrolled:
+                    kept[key] = val
+                else:
+                    removed_any = True
+            if removed_any:
+                diff = len(gear) - len(kept)
+                comp.gear_sharing = json.dumps(kept)
+                cleaned_total += diff
+                local_cleaned += diff
+                if comp.name not in affected:
+                    affected.append(comp.name)
+        return local_cleaned
+
+    pro_cleaned = _scan(
+        ProCompetitor.query.filter_by(tournament_id=tournament.id, status='active').all(),
+        pro_events,
+    )
+    college_cleaned = _scan(
+        CollegeCompetitor.query.filter_by(tournament_id=tournament.id, status='active').all(),
+        college_events,
+    )
+
+    return {
+        'cleaned': cleaned_total,
+        'affected': affected,
+        'pro_cleaned': pro_cleaned,
+        'college_cleaned': college_cleaned,
+    }
+
+
 def cleanup_scratched_gear_entries(tournament, scratched_competitor=None, competitor_type: str = 'pro') -> dict:
     """
     Remove gear-sharing entries from active competitors that reference scratched

--- a/services/preflight.py
+++ b/services/preflight.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 from models import Event, Flight, HeatAssignment, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
-from services.gear_sharing import event_matches_gear_key, normalize_person_name
+from services.gear_sharing import (
+    event_matches_gear_key,
+    is_using_value,
+    normalize_person_name,
+    strip_using_prefix,
+)
 
 
 def _signed_up_pro_count(event: Event) -> int:
@@ -121,8 +126,13 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
                             non_enrolled_gear_names.append(competitor.name)
 
                 partner_text = str(partner or '').strip()
-                partner_norm = normalize_person_name(partner_text)
-                if not partner_text:
+                # USING entries carry a "using:" prefix to flag partnered-event
+                # confirmation (see services/gear_sharing._USING_VALUE_PREFIX).
+                # The underlying name must still resolve to a real competitor,
+                # but the prefix itself is not part of the person's name.
+                partner_name_only = strip_using_prefix(partner_text)
+                partner_norm = normalize_person_name(partner_name_only)
+                if not partner_name_only:
                     unknown_partner_rows += 1
                     if competitor.name not in unknown_partner_names:
                         unknown_partner_names.append(competitor.name)
@@ -203,6 +213,12 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
         })
 
     # 2c) Gear vs. partner field mismatch (pro only)
+    # Only USING entries claim to confirm the event partner — a mismatch there
+    # is a genuine data bug (stale confirmation vs. new partner assignment).
+    # SHARING entries (no "using:" prefix) are defined as cross-competitor gear
+    # dependency OUTSIDE the event partnership, so gear_partner != event_partner
+    # is the expected, correct shape — flagging it produced noise on every
+    # Double Buck / Jack & Jill pair with a saw-sharer.
     partner_mismatch_rows = 0
     partner_mismatch_names: list[str] = []
     for comp in ProCompetitor.query.filter_by(tournament_id=tournament.id, status='active').all():
@@ -211,7 +227,10 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
         if not isinstance(gear, dict) or not isinstance(partners, dict):
             continue
         for key, gear_partner in gear.items():
-            gp = normalize_person_name(str(gear_partner or '').strip())
+            gear_text = str(gear_partner or '').strip()
+            if not is_using_value(gear_text):
+                continue
+            gp = normalize_person_name(strip_using_prefix(gear_text))
             pp = normalize_person_name(str(partners.get(key, '') or '').strip())
             if gp and pp and gp != pp:
                 partner_mismatch_rows += 1

--- a/templates/pro/gear_sharing.html
+++ b/templates/pro/gear_sharing.html
@@ -61,6 +61,14 @@
                 <button type="submit" class="btn btn-outline-secondary btn-sm">Cleanup Scratched</button>
             </form>
 
+            <!-- Cleanup gear entries for events competitor is not enrolled in -->
+            <form method="POST"
+                  action="{{ url_for('registration.pro_gear_cleanup_non_enrolled', tournament_id=tournament.id) }}"
+                  data-confirm="Remove gear-sharing entries pointing at events the competitor is not enrolled in?">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-outline-secondary btn-sm">Cleanup Non-Enrolled</button>
+            </form>
+
             <!-- Auto-assign heat partners -->
             <form method="POST"
                   action="{{ url_for('registration.auto_assign_pro_partners_route', tournament_id=tournament.id) }}"

--- a/templates/scheduling/ability_rankings.html
+++ b/templates/scheduling/ability_rankings.html
@@ -5,28 +5,40 @@
     .rank-list { list-style: none; padding: 0; margin: 0; min-height: 48px; }
     .rank-item {
         display: flex; align-items: center; gap: 0.5rem;
-        padding: 0.4rem 0.75rem; margin-bottom: 2px;
-        background: var(--bs-body-bg, #fff); border: 1px solid var(--bs-border-color, #dee2e6);
+        padding: 0.5rem 0.75rem; margin-bottom: 3px;
+        background: var(--sx-surface-2, #1b1f2a);
+        color: var(--sx-text, #ece8e0);
+        border: 1px solid var(--sx-border, #252a38);
         border-radius: 4px; cursor: grab; user-select: none;
-        font-size: 0.9rem;
+        font-size: 0.95rem;
     }
+    .rank-item:hover { background: var(--sx-surface-3, #222737); border-color: var(--sx-border-bright, #363e52); }
     .rank-item:active { cursor: grabbing; }
     .rank-item .rank-number {
-        min-width: 28px; text-align: center; font-weight: 600;
-        color: var(--bs-primary, #0d6efd); font-size: 0.85rem;
+        min-width: 28px; text-align: center; font-weight: 700;
+        color: var(--sx-gold-bright, #ffd94a); font-size: 0.9rem;
     }
-    .rank-item .comp-name { flex: 1; }
-    .rank-item .drag-handle { color: var(--bs-secondary, #6c757d); font-size: 1rem; }
-    .sortable-ghost { opacity: 0.35; background: #e9f0fb !important; }
-    .sortable-chosen { border-color: var(--bs-primary, #0d6efd) !important; }
+    .rank-item .comp-name { flex: 1; color: var(--sx-text, #ece8e0); }
+    .rank-item .drag-handle { color: var(--sx-text-2, #8c95aa); font-size: 1rem; }
+    .sortable-ghost { opacity: 0.45; background: var(--sx-fire-glow, rgba(239,43,22,0.34)) !important; }
+    .sortable-chosen { border-color: var(--sx-fire, #ef2b16) !important; }
     .rank-section { margin-bottom: 1rem; }
     .rank-section-header {
         display: flex; justify-content: space-between; align-items: center;
-        padding: 0.5rem 0.75rem; background: var(--bs-tertiary-bg, #f8f9fa);
-        border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+        padding: 0.5rem 0.75rem;
+        background: var(--sx-surface, #13161d);
+        color: var(--sx-text, #ece8e0);
+        border-bottom: 1px solid var(--sx-border, #252a38);
     }
-    .unranked-zone { border-top: 2px dashed var(--bs-border-color, #dee2e6); margin-top: 0.5rem; padding-top: 0.5rem; }
-    .unranked-label { font-size: 0.75rem; color: var(--bs-secondary); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.25rem; padding-left: 0.75rem; }
+    .rank-section-header h6 { color: var(--sx-text, #ece8e0) !important; }
+    .unranked-zone { border-top: 2px dashed var(--sx-border-bright, #363e52); margin-top: 0.5rem; padding-top: 0.5rem; }
+    .unranked-label {
+        font-size: 0.75rem;
+        color: var(--sx-text-2, #8c95aa);
+        text-transform: uppercase; letter-spacing: 0.05em;
+        margin-bottom: 0.35rem; padding-left: 0.75rem;
+        font-weight: 600;
+    }
 </style>
 
 <div class="container-fluid py-3">

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -480,3 +480,162 @@ class TestFullyValidTournament:
         assert 'has_autofixable' in report
         assert isinstance(report['issues'], list)
         assert isinstance(report['severity'], dict)
+
+
+# ---------------------------------------------------------------------------
+# Gear-sharing preflight — USING vs SHARING semantics (V2.9.1 + follow-up fix)
+# ---------------------------------------------------------------------------
+
+class TestGearSharingUsingPrefix:
+    """Regression tests for the gear-sharing preflight after V2.9.1 introduced
+    the ``using:`` value prefix. Prior to the follow-up fix, every legitimate
+    USING entry was reported as an unknown partner because the preflight
+    normalized the whole value (``using:Alice`` -> ``usingalice``) instead of
+    the underlying name."""
+
+    def _codes(self, report):
+        return {i['code'] for i in report['issues']}
+
+    def test_using_prefix_resolves_to_known_partner(self, db_session, tournament):
+        """A USING entry whose underlying name matches a roster competitor
+        must NOT be flagged as unknown."""
+        from services.preflight import build_preflight_report
+
+        jj = _make_event(db_session, tournament, 'Jack & Jill Sawing',
+                         stand_type='saw_hand', is_partnered=True)
+        alice = _make_pro(db_session, tournament, 'Alice Jones',
+                          gender='F', event_ids=[jj.id])
+        bob = _make_pro(db_session, tournament, 'Bob Smith',
+                        gender='M', event_ids=[jj.id])
+
+        alice.gear_sharing = json.dumps({str(jj.id): 'using:Bob Smith'})
+        alice.partners = json.dumps({str(jj.id): 'Bob Smith'})
+        bob.gear_sharing = json.dumps({str(jj.id): 'using:Alice Jones'})
+        bob.partners = json.dumps({str(jj.id): 'Alice Jones'})
+        db_session.flush()
+
+        report = build_preflight_report(tournament)
+        codes = self._codes(report)
+        assert 'gear_unknown_partner_names' not in codes
+        assert 'gear_partner_mismatch' not in codes
+
+    def test_sharing_entry_different_from_partner_is_not_flagged(
+            self, db_session, tournament):
+        """A SHARING entry intentionally names a DIFFERENT person than the
+        event partner — that is the entire point of cross-competitor gear
+        dependency outside a partnered pair. The preflight must not flag it
+        as a 'gear vs partner disagreement'."""
+        from services.preflight import build_preflight_report
+
+        db = _make_event(db_session, tournament, 'Double Buck', gender='M',
+                         stand_type='saw_hand', is_partnered=True)
+        ripley = _make_pro(db_session, tournament, 'Ripley Orr',
+                           gender='M', event_ids=[db.id])
+        cody = _make_pro(db_session, tournament, 'Cody Labahn',
+                         gender='M', event_ids=[db.id])
+        may = _make_pro(db_session, tournament, 'May Brown',
+                        gender='M', event_ids=[db.id])
+
+        # Ripley is partnered with Cody for Double Buck, but shares his saw
+        # with May (a cross-competitor SHARING dependency, no using: prefix).
+        ripley.gear_sharing = json.dumps({str(db.id): 'May Brown'})
+        ripley.partners = json.dumps({str(db.id): 'Cody Labahn'})
+        db_session.flush()
+
+        report = build_preflight_report(tournament)
+        codes = self._codes(report)
+        assert 'gear_partner_mismatch' not in codes
+
+    def test_using_entry_still_flagged_when_name_unknown(
+            self, db_session, tournament):
+        """The prefix fix must not mask a GENUINE unresolved partner — a
+        USING entry whose underlying name is not on the roster should still
+        trigger the unknown-partner warning."""
+        from services.preflight import build_preflight_report
+
+        jj = _make_event(db_session, tournament, 'Jack & Jill Sawing',
+                         stand_type='saw_hand', is_partnered=True)
+        alice = _make_pro(db_session, tournament, 'Alice Jones',
+                          gender='F', event_ids=[jj.id])
+
+        alice.gear_sharing = json.dumps({str(jj.id): 'using:Ghost Competitor'})
+        db_session.flush()
+
+        report = build_preflight_report(tournament)
+        codes = self._codes(report)
+        assert 'gear_unknown_partner_names' in codes
+
+    def test_using_mismatch_with_partners_still_flagged(
+            self, db_session, tournament):
+        """When a USING entry names a different person than the partners
+        dict, that IS a real inconsistency (confirmation drifted away from
+        the registered partner) and must still be flagged."""
+        from services.preflight import build_preflight_report
+
+        jj = _make_event(db_session, tournament, 'Jack & Jill Sawing',
+                         stand_type='saw_hand', is_partnered=True)
+        alice = _make_pro(db_session, tournament, 'Alice Jones',
+                          gender='F', event_ids=[jj.id])
+        _bob = _make_pro(db_session, tournament, 'Bob Smith',
+                         gender='M', event_ids=[jj.id])
+        _carol = _make_pro(db_session, tournament, 'Carol Vance',
+                           gender='F', event_ids=[jj.id])
+
+        alice.gear_sharing = json.dumps({str(jj.id): 'using:Bob Smith'})
+        alice.partners = json.dumps({str(jj.id): 'Carol Vance'})
+        db_session.flush()
+
+        report = build_preflight_report(tournament)
+        codes = self._codes(report)
+        assert 'gear_partner_mismatch' in codes
+
+
+class TestCleanupNonEnrolledGearEntries:
+    """Regression tests for services.gear_sharing.cleanup_non_enrolled_gear_entries."""
+
+    def test_removes_entries_for_non_enrolled_events(
+            self, db_session, tournament):
+        """Gear entries pointing at events the competitor is not enrolled in
+        should be removed; entries for events they ARE in stay."""
+        from services.gear_sharing import cleanup_non_enrolled_gear_entries
+
+        enrolled = _make_event(db_session, tournament, 'Single Buck',
+                               stand_type='saw_hand')
+        orphan = _make_event(db_session, tournament, 'Double Buck',
+                             stand_type='saw_hand', is_partnered=True)
+        chrissy = _make_pro(db_session, tournament, 'Chrissy Marcellus',
+                            gender='F', event_ids=[enrolled.id])
+
+        chrissy.gear_sharing = json.dumps({
+            str(enrolled.id): 'Alice Jones',
+            str(orphan.id): 'Cody Labahn',
+        })
+        db_session.flush()
+
+        result = cleanup_non_enrolled_gear_entries(tournament)
+
+        assert result['cleaned'] == 1
+        assert 'Chrissy Marcellus' in result['affected']
+        remaining = json.loads(chrissy.gear_sharing)
+        assert str(enrolled.id) in remaining
+        assert str(orphan.id) not in remaining
+
+    def test_keeps_category_entries_when_enrolled_in_matching_event(
+            self, db_session, tournament):
+        """A category key should be kept when the competitor is enrolled in
+        any event of that category, even if not all of them."""
+        from services.gear_sharing import cleanup_non_enrolled_gear_entries
+
+        sb = _make_event(db_session, tournament, 'Single Buck',
+                         stand_type='saw_hand')
+        alice = _make_pro(db_session, tournament, 'Alice Jones',
+                          gender='F', event_ids=[sb.id])
+
+        alice.gear_sharing = json.dumps({'category:crosscut': 'Bob Smith'})
+        db_session.flush()
+
+        result = cleanup_non_enrolled_gear_entries(tournament)
+
+        assert result['cleaned'] == 0
+        remaining = json.loads(alice.gear_sharing)
+        assert 'category:crosscut' in remaining

--- a/tests/test_russian_translation.py
+++ b/tests/test_russian_translation.py
@@ -1,0 +1,70 @@
+"""
+Regression tests for Russian language full-page HTML translation.
+
+A judge whose first language is Russian relies on this. The previous
+after_request hook in app.py translated only Arapaho — Russian was
+configured in strings.py but never invoked, so switching to Russian
+translated only the navbar labels and left every page body in English.
+"""
+
+import re
+
+import strings as text
+
+
+class TestRussianPhraseMap:
+    """strings.translate_html on its own."""
+
+    def test_phrase_map_loaded(self):
+        assert len(text._phrase_map("ru")) > 100
+
+    def test_translate_html_replaces_common_phrases(self):
+        html = "<p>Tournaments</p><p>Save</p><p>Cancel</p>"
+        out = text.translate_html(html, lang="ru")
+        assert "Турниры" in out
+        assert "Сохранить" in out
+        assert "Отмена" in out
+
+    def test_translate_html_preserves_tags(self):
+        html = '<a href="/x" class="btn">Save</a>'
+        out = text.translate_html(html, lang="ru")
+        assert 'href="/x"' in out
+        assert 'class="btn"' in out
+        assert "Сохранить" in out
+
+    def test_translate_html_skips_script_and_style(self):
+        html = "<style>body{color:#fff}</style><script>var Save=1;</script><p>Save</p>"
+        out = text.translate_html(html, lang="ru")
+        assert "var Save=1" in out
+        assert "body{color:#fff}" in out
+        assert "<p>Сохранить</p>" in out
+
+    def test_english_passes_through_unchanged(self):
+        html = "<p>Tournaments</p>"
+        assert text.translate_html(html, lang="en") == html
+
+
+class TestRussianAfterRequestHook:
+    """Full Flask round-trip: GET / with Russian session and check body."""
+
+    def test_root_page_translated_when_russian_active(self, client):
+        # Switch language by hitting the route (sets session['lang']='ru')
+        switch = client.get("/language/ru", follow_redirects=False)
+        assert switch.status_code in (200, 302)
+
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert re.search(r"[А-Яа-яЁё]", body), (
+            "No Cyrillic characters in response body — Russian translation "
+            "after_request hook is not running."
+        )
+
+    def test_root_page_english_when_no_language_set(self, client):
+        # Fresh client (default language)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.get_data(as_text=True)
+        assert (
+            not re.search(r"[А-Яа-яЁё]", body) or "Русский" in body
+        ), "English session leaked Cyrillic content unexpectedly."


### PR DESCRIPTION
## Summary

Three independent commits bundled onto one branch for review. These were work-in-progress commits that landed on the docs/flight-clumping-solution branch alongside documentation work; they've been cleanly separated out so the docs PR (#56) stays scoped to docs-only.

### Commits

1. **feat(i18n): full-page Russian translation + regression tests** (`3111730`) — Russian translation support with regression coverage
2. **style(design): dark-mode tokens on ability-rankings page** (`1e5342a`) — STRATHEX dark theme tokens applied to the ability rankings UI (previously had light-mode leakage)
3. **fix+feat(gear-sharing): preflight USING-prefix false positives + cleanup action** (`d57665c`) — gear-sharing preflight no longer flags USING-prefix entries as unresolved; new cleanup action for removing stale gear entries. Includes `docs/solutions/data-integrity/preflight-gear-sharing-using-prefix-false-positives-2026-04-21.md`

Note: a 4th commit (birling seed-bracket flash-message link fix) was cherry-picked and found empty — its changes were already in origin/main from a different path.

## Test plan

- [ ] Review each commit independently for scope + correctness
- [ ] Run the full local test suite (same ignore list as CI)
- [ ] Manual QA for: Russian translation rendering, ability rankings dark theme, gear-sharing preflight output

🤖 Generated with [Claude Code](https://claude.com/claude-code)