### PR TITLE
docs: compound learnings on test-to-prod isolation + Railway ops playbook

### DIFF
--- a/docs/POSTGRES_MIGRATION.md
+++ b/docs/POSTGRES_MIGRATION.md
@@ -60,8 +60,14 @@ export DATABASE_URL=postgresql://...
 flask db upgrade
 ```
 
-`railway.toml` already includes `releaseCommand = "flask db upgrade"`, so Railway
-runs this automatically on every deploy.
+`railway.toml` uses `preDeployCommand = "flask db upgrade"` so Railway runs
+migrations automatically on every deploy. `releaseCommand` was originally
+configured here but silently did not execute, leaving production schemaless
+for 2 weeks — see
+[`solutions/configuration-issues/railway-predeploy-command.md`](solutions/configuration-issues/railway-predeploy-command.md)
+for the failure mode and
+[`solutions/best-practices/railway-postgres-operational-playbook-2026-04-21.md`](solutions/best-practices/railway-postgres-operational-playbook-2026-04-21.md)
+for the broader operational context.
 
 ### 3.2 Migration chain (as of V2.3.0)
 
@@ -244,7 +250,7 @@ behavior in the operator runbook.
 - [ ] PostgreSQL add-on provisioned and `DATABASE_URL` set in Railway variables
 - [ ] `SECRET_KEY` set (strong random string, not 'dev' or 'test')
 - [ ] `FLASK_APP=app.py` set
-- [ ] `railway.toml` `releaseCommand = "flask db upgrade"` is present
+- [ ] `railway.toml` `preDeployCommand = "flask db upgrade"` is present (NOT `releaseCommand` — silently does not execute on Railway)
 - [ ] `postgres://` → `postgresql://` prefix fix applied in `config.py` if needed
 - [ ] First deploy: `flask db upgrade` runs automatically, creates all tables
 - [ ] Data migration script run (if moving existing data from SQLite)

--- a/docs/solutions/best-practices/railway-postgres-operational-playbook-2026-04-21.md
+++ b/docs/solutions/best-practices/railway-postgres-operational-playbook-2026-04-21.md
@@ -1,0 +1,230 @@
+---
+title: Railway + Postgres Operational Playbook (Missoula Pro-Am Manager)
+date: 2026-04-21
+category: best-practices
+module: deployment/railway
+problem_type: best_practice
+component: tooling
+severity: critical
+related_components:
+  - database
+  - development_workflow
+  - testing_framework
+applies_when:
+  - Deploying a Flask + SQLAlchemy app to Railway with managed Postgres
+  - Configuring Railway release or pre-deploy migration hooks
+  - Designing CI that must reflect production DB state, not a fresh container
+  - Recovering from a Railway volume detach or silent schemaless production
+  - Wiring health endpoints and backup strategy before a production event
+tags:
+  - railway
+  - postgres
+  - migrations
+  - operational-playbook
+  - ci-prod-parity
+  - backups
+  - incident-response
+  - health-monitoring
+---
+
+# Railway + Postgres Operational Playbook (Missoula Pro-Am Manager)
+
+## Context
+
+This project is a solo-developer Flask + Postgres application deployed on Railway (Hobby tier), approaching its first real production event (Missoula Pro-Am, race day 2026-04-25). Over ~49 sessions of incremental development, the platform accumulated a long tail of Railway-specific operational gotchas: silent `releaseCommand` failures, unexplained Postgres volume detaches, CI that stayed green while production ran schemaless for 14 days, non-existent backups, no monitoring, and a CLI auth surface that partially works but fails opaquely on account-level operations.
+
+Two incidents landed inside the race-day-week preparation window:
+
+1. **Undetected 2-week schemaless production DB** (2026-03-24 → 2026-04-08). `releaseCommand = "flask db upgrade"` was configured in `railway.toml` but never produced any visible log output on Railway. Production ran against an empty Postgres-HB8_ volume with no schema, returning HTTP 500 on `/` and `status: degraded` on `/health`. Nobody noticed.
+2. **11-hour volume-detach outage** (2026-04-08 06:35 UTC). Postgres volume `postgres-volume-XLeL` spontaneously detached from the Postgres service. Flask workers entered a gunicorn SIGKILL crash loop every ~30s, looping 5.5 hours before anyone noticed. A prior identical detach had occurred 14 days earlier (2026-03-24) — never root-caused.
+
+The detach happened **before** competitor data was entered. Had it occurred 17 days later on race-day morning with a full roster, it would have been an event-cancelling disaster with no rollback path. This document distills those incidents into operational guidance for the lone dev (and any future agents assisting) so the same mistakes do not repeat.
+
+## Guidance
+
+**1. The release command is not verified at deploy time.** Railway's build logs do not reliably surface `releaseCommand` output — `flask db upgrade` ran (or didn't) with no stdout, stderr, or release log entry for 2 weeks. Use `preDeployCommand` instead, and always hit `/health` after every deploy to verify `status: ok` and `migration_rev` matches the expected HEAD. See [`../configuration-issues/railway-predeploy-command.md`](../configuration-issues/railway-predeploy-command.md).
+
+**2. Every deploy must be verified by `/health`, not by the absence of a 502.** `/health` returns `status`, `db`, and `migration_rev`. A green deploy with `db: false` or `migration_rev: null` is a failed deploy, not a successful one. Bake this into the checklist:
+```bash
+curl -s https://missoula-pro-am-manager-production.up.railway.app/health | jq '.status, .db, .migration_rev'
+```
+Expect `"ok"`, `true`, and the current HEAD from the migration chain in MEMORY.md.
+
+**3. Postgres volumes can detach without warning on Railway Hobby tier.** Twice at this project (2026-03-24 and 2026-04-08), both unexplained. The app enters a gunicorn SIGKILL crash loop every ~30s. Reattachment is **dashboard-UI only** — the Railway MCP tools expose `updateServiceTool` (service-side `volumeMounts`) and `updateVolumeTool` (`sizeMB` only); no programmatic attach primitive exists. Know the reattach UI path before you need it; the first time you learn it should not be mid-outage.
+
+**4. Distinguish HTTP 502 from HTTP 000 when diagnosing prod.** Railway's build + release window produces 60-120 seconds of 502s at the edge — normal, not a crash. HTTP 000 (curl timeout, no response body at all) is a true crash loop. Mis-diagnosing 502-as-crash cost ~30 minutes during the 2026-04-08 incident.
+```bash
+curl -w "%{http_code}\n" -o /dev/null -s \
+  https://missoula-pro-am-manager-production.up.railway.app/health
+# 502 during deploy window = wait (60-120s)
+# 000 = crash loop, investigate now
+# 200 + status:ok = deployed
+```
+
+**5. CI passing is not production passing.** `.github/workflows/ci.yml` has 3 jobs (`lint`, `test` on SQLite in-memory, `postgres-smoke` on PG 15 fresh container). All three stayed green while production was schemaless. Each CI run creates a fresh DB and compares nothing to the deployed state. Until a post-deploy smoke step hits production `/health` and fails the workflow on `status != "ok"`, do it manually after every deploy.
+
+**6. Railway project tokens are scope-limited.** The project token can run `railway variables`, `railway run`, and `pg_dump` via the public proxy. It **cannot** create Railway storage buckets (returns "Bad Access" because bucket creation is account-scoped). Generate both token types if you need bucket-level operations, and revoke any token used for a recovery window once the window closes (the 2026-04-08 recovery token was revoked post-event).
+
+**7. Railway `DATABASE_URL` uses `postgres://`; SQLAlchemy 2.x requires `postgresql://`.** `config.py` has `_normalized_database_url()` that rewrites the scheme. Any new service, script, or worker that reads `DATABASE_URL` directly must apply the same rewrite or fail with an opaque dialect-registration error.
+
+**8. Know your public Postgres proxy URL before you need it.** Read it once and keep a local note:
+```bash
+railway variables --service Postgres-HB8_ | grep DATABASE_PUBLIC_URL
+# postgres://postgres:<password>@turntable.proxy.rlwy.net:48640/railway
+```
+This is the only way to run `flask db upgrade` or `pg_dump` against production from a local terminal. During the 2026-04-08 recovery, finding this URL was on the critical path.
+
+**9. Memorize (or file) the Railway resource identifiers.** Dashboard navigation is slow; copy-paste is fast. Keep these in MEMORY.md:
+
+| Resource | ID |
+|---|---|
+| Project (STRATHEX Pro-Am) | `a4f717c5-c813-4959-b719-b3e57e302975` |
+| Production env | `5e8a13c5-5384-416c-9f60-a9442c81ff24` |
+| Postgres-HB8_ service | `961a200c-a66c-48f1-b264-417143340306` |
+| App service | `4d6d4ddd-1341-42ff-84b4-9024d4bd4403` |
+| Volume mount | `/var/lib/postgresql/data` |
+| Postgres version / size | 18.3 / 5GB (~198MB used post-recovery) |
+
+**10. External uptime monitoring is not optional for race-day-week.** Production ran `status: degraded, db: false, migration_rev: null` for 14 days and nobody noticed. Wire an external pinger (UptimeRobot free tier, BetterUptime, or a GitHub Actions cron calling `/health`) that alerts on `status != "ok"` or non-200. Do this before any future deploy that touches migrations.
+
+**11. Backups must be wired to a scheduled caller, not just present as code.** `services/backup.py` exists with S3 upload logic, but the env vars (`BACKUP_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) are unset and no cron/admin route calls the function. That is not a backup — it is dead code. Railway automatic snapshots require Pro tier; on Hobby, run a manual `pg_dump` before every risky deploy and schedule a daily one via GitHub Actions cron against the public proxy. The first real backup this project ever had was `instance/backups/proam_recovery_20260408_115838.sql.gz`, taken during recovery, not before it.
+
+**12. Offline migration dry-runs are cheap diagnostics.** `flask db upgrade --sql` dumps the migration chain as raw SQL with no DB connection — use it to inspect what WOULD run before touching production, and to diff against the migration chain in MEMORY.md.
+
+**13. SQLite (dev) and Postgres (prod) diverge in migration patterns.** Seventeen migration files in this repo historically used SQLite-specific idioms (`batch_alter_table`, `server_default='0'` on booleans, `PRAGMA`) that silently failed or produced wrong schema on PG. `tests/test_pg_migration_safety.py` guards against regression. See [`../integration-issues/postgres-migration-compatibility.md`](../integration-issues/postgres-migration-compatibility.md) — do not re-document, but cross-reference before writing any new migration.
+
+**14. Optional integrations must fail gracefully, never block the release phase.** STRATHMARK, Twilio SMS, and S3 backup all need to degrade silently when their env vars are missing or their upstreams are unreachable. Hard-failing `validate_runtime()` on missing optional env vars once blocked a release and required a hotfix. Gate environment-specific hard-fails on `ENV_NAME == 'production'` and reserve them for core infra (DB, SECRET_KEY). See [`../configuration-issues/validate-runtime-hard-fail-blocks-deploy.md`](../configuration-issues/validate-runtime-hard-fail-blocks-deploy.md) and [`../architecture-decisions/non-blocking-external-integrations.md`](../architecture-decisions/non-blocking-external-integrations.md).
+
+**15. Local dev port 5000 collides with the UM contract portal; use 5001.** Codify this in `README.md` and provide a flag-free default in `run.py`. Do not lose a session per new contributor rediscovering this.
+
+**16. The user noticed the 2-week outage before monitoring did.** Assume all silent failure modes will be found by the user, not by tooling. Every change that touches DB, migrations, or deploy config must include an observable signal (log line, `/health` field, alert) so the failure surfaces to tooling before it surfaces to the user. (session history)
+
+## Why This Matters
+
+The costs are concrete:
+
+- **14 days of schemaless production** (2026-03-24 to 2026-04-08) — undetected by CI, undetected by Railway's own logs, found only when the user manually checked `/health` during unrelated work.
+- **11-hour outage on 2026-04-08** with gunicorn looping SIGKILL for 5.5 hours before anyone noticed.
+- **Zero backups until the recovery itself** — the only reason data loss was zero is that no competitor data had been entered yet.
+- **Near-miss with race-day**: the detach occurred 17 days before event day. Had it happened on 2026-04-25 morning with a full competitor roster, this would be an event-cancelling disaster with no rollback path.
+
+This is a solo-dev, solo-platform context. No on-call rotation, no SRE team, no dashboard-watcher. A single undetected failure mode stays undetected until it compounds into an outage, and the blast radius is the entire event. The lessons above are the minimum defense-in-depth for a stakes-mismatched deployment (Hobby-tier infrastructure carrying race-day-critical data).
+
+## When to Apply
+
+Consult this doc:
+
+- Before triggering any Railway deploy that includes a new migration.
+- When diagnosing a production 502, crash loop, or `/health` degraded response.
+- Before setting up backups, monitoring, or any new env-var-dependent service.
+- When a Postgres volume appears empty, detached, or returns connection-refused.
+- When migrating schema patterns between SQLite (dev) and Postgres (prod), or when adding a new Alembic migration.
+- Before race day, or before any production event where downtime translates to real-world consequences.
+- When onboarding a new contributor or handing context to a fresh Claude Code session.
+
+## Examples
+
+### Example 1 — Running a schema migration on production Postgres from local terminal
+
+```bash
+# 1. Read the public proxy URL (needs project token via `railway login`)
+railway variables --service Postgres-HB8_ | grep DATABASE_PUBLIC_URL
+
+# 2. Export with the postgresql:// scheme fix
+export DATABASE_URL="postgresql://postgres:<pass>@turntable.proxy.rlwy.net:48640/railway"
+
+# 3. Dry-run first
+flask db upgrade --sql > /tmp/pending.sql
+less /tmp/pending.sql
+
+# 4. Apply
+flask db upgrade
+
+# 5. Verify HEAD matches MEMORY.md
+flask db current
+# Expect: current HEAD from the Migration Chain entry in MEMORY.md
+```
+
+### Example 2 — Taking a manual backup before a risky deploy
+
+```bash
+# Requires pg_dump installed locally and DATABASE_URL exported as in Example 1
+TS=$(date -u +%Y%m%d_%H%M%S)
+pg_dump "$DATABASE_URL" | gzip > "instance/backups/proam_pre_deploy_${TS}.sql.gz"
+
+# Verify non-empty
+ls -lh "instance/backups/proam_pre_deploy_${TS}.sql.gz"
+# Expect > 100KB once there's real data; 4-5KB for empty DB
+
+# Restore path — DO NOT RUN unless recovering
+# gunzip -c instance/backups/proam_pre_deploy_<ts>.sql.gz | psql "$DATABASE_URL"
+```
+
+### Example 3 — Verifying a deploy actually applied migrations
+
+```bash
+# 1. Immediately after Railway reports "deployed"
+curl -s https://missoula-pro-am-manager-production.up.railway.app/health | jq
+# {
+#   "status": "ok",           <-- must be "ok", not "degraded"
+#   "db": true,                <-- must be true
+#   "migration_rev": "b1c2d3e4f5a6",  <-- must match HEAD in MEMORY.md
+#   "version": "2.11.2"
+# }
+
+# 2. Cross-check via railway run
+railway run --service App flask db current
+# Expect same revision as migration_rev above
+
+# 3. If they don't match: deploy did NOT run migrations. Apply manually per Example 1.
+```
+
+### Example 4 — Diagnosing a production crash loop
+
+```bash
+# Distinguish deploy-window 502 from real crash
+for i in 1 2 3 4 5; do
+  curl -w "%{http_code}\n" -o /dev/null -s \
+    https://missoula-pro-am-manager-production.up.railway.app/health
+  sleep 10
+done
+
+# 502 x 5-12 times = deploy in progress, wait
+# 000 x any = crash loop, check Railway logs:
+railway logs --service App --tail 200
+
+# Common signature: volume detach -> SIGKILL loop
+# psycopg2.OperationalError: could not connect to server
+# [gunicorn] Worker (pid:NNN) was sent SIGKILL!
+```
+
+## Related
+
+**Per-pattern canonical writeups** (read before taking action on that specific pattern):
+- [`../configuration-issues/railway-predeploy-command.md`](../configuration-issues/railway-predeploy-command.md) — lesson 1: `releaseCommand` silent failure; `preDeployCommand` fix
+- [`../integration-issues/postgres-migration-compatibility.md`](../integration-issues/postgres-migration-compatibility.md) — lesson 13: banned SQLite-specific migration patterns + `tests/test_pg_migration_safety.py`
+- [`../configuration-issues/validate-runtime-hard-fail-blocks-deploy.md`](../configuration-issues/validate-runtime-hard-fail-blocks-deploy.md) — lesson 14: `ENV_NAME=='production'` gating for optional env vars
+- [`../architecture-decisions/non-blocking-external-integrations.md`](../architecture-decisions/non-blocking-external-integrations.md) — lesson 14 architecture anchor: graceful no-op for STRATHMARK, Twilio, S3 backup
+
+**Strategic and procedural docs**:
+- [`../../ROOT_CAUSES_AND_CLEANUP_ORDER.md`](../../ROOT_CAUSES_AND_CLEANUP_ORDER.md) — strategic root-cause framing; this playbook is its tactical companion
+- [`../../POSTGRES_MIGRATION.md`](../../POSTGRES_MIGRATION.md) — one-time SQLite → PG migration runbook (used for initial production bring-up)
+- [`../../ROLLBACK_SOP.md`](../../ROLLBACK_SOP.md) — failure-classification SOP for deploy breakage
+- [`../../RELEASE_CHECKLIST.md`](../../RELEASE_CHECKLIST.md) — pre-merge/pre-deploy gates and required CI checks
+- [`../../GITHUB_REQUIRED_SETTINGS.md`](../../GITHUB_REQUIRED_SETTINGS.md) — branch protection + required status checks
+
+**Sibling solution docs** — silent DB-layer failure family:
+- [`../test-failures/test-data-polluting-production-sqlite-db-2026-04-21.md`](../test-failures/test-data-polluting-production-sqlite-db-2026-04-21.md) — the test-isolation defense. Both this playbook and that doc are about "DB-layer failures that stay silent for a long time because nothing is watching."
+
+**Incident and feedback memory** (auto memory, Claude Code):
+- `incident_2026-04-08_postgres_recovery.md` — primary incident narrative (schemaless DB + volume detach + recovery via public proxy)
+- `feedback_migration_protocol.md` — "Never skip review of auto-generated Alembic migrations"
+- `feedback_pg_migrations.md` — "Never use SQLite-specific patterns in migrations (PG production)"
+
+**Code paths referenced**:
+- `railway.toml` — current `preDeployCommand` config
+- `config.py` — `_normalized_database_url()` scheme rewriter; `validate_runtime()`
+- `services/backup.py` — S3 backup (currently dead code awaiting env vars + caller)
+- `instance/backup_now.sh` — manual backup script used during recovery (requires `RAILWAY_TOKEN`)
+- `.github/workflows/ci.yml` — 3-job CI (`lint`, `test`, `postgres-smoke`)
+- `routes/main.py` `/health` endpoint — `status`, `db`, `migration_rev`

--- a/docs/solutions/test-failures/test-data-polluting-production-sqlite-db-2026-04-21.md
+++ b/docs/solutions/test-failures/test-data-polluting-production-sqlite-db-2026-04-21.md
@@ -1,0 +1,237 @@
+---
+title: Test suite polluted production SQLite DB with fixture users and tournaments
+date: 2026-04-21
+category: test-failures
+module: tests/conftest.py
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - Production instance/proam.db contained 17 test users (rbac_admin, smoke_admin, tmpl_admin, h_admin, comp_admin, post_admin) and 80+ test tournaments ("Flight Test 2026", "Test Tournament 2026", "Points Test 2026", "Relay Test 2026")
+  - Real admin account missing from production DB, blocking login
+  - "Create a judge account" flow errored "one already exists" because a test fixture user already occupied the judge role
+  - Issue recurred across multiple dev sessions over weeks despite prior triage
+  - DATABASE_URL env var set by tests was ignored because config was resolved once at class-definition time
+root_cause: test_isolation
+resolution_type: test_fix
+severity: critical
+related_components:
+  - authentication
+  - database
+  - development_workflow
+tags:
+  - test-isolation
+  - production-db-pollution
+  - pytest-conftest
+  - flask-app-factory
+  - sqlite
+  - database-url
+  - fixture-leakage
+  - runtime-guard
+---
+
+# Test suite polluted production SQLite DB with fixture users and tournaments
+
+## Problem
+
+The dev test suite for the Missoula-Pro-Am-Manager Flask app was silently writing fixture users and tournaments into the real `instance/proam.db` production SQLite file instead of isolated temp DBs. The user's real admin account was never created because test-generated admins occupied the unique `username` slots, and the `/auth/bootstrap` "create judge" flow failed with "one already exists." This recurred across multiple dev sessions for weeks before a permanent fix landed.
+
+## Symptoms
+
+- Production `instance/proam.db` contained 17 test users with obvious prefixes: `rbac_admin`, `rbac_judge`, `rbac_scorer`, `rbac_registrar`, `rbac_competitor`, `rbac_spectator`, `rbac_viewer`, `smoke_admin`, `tmpl_admin`, `h_admin`, `h_competitor`, `h_spectator`, `h_scorer`, `post_admin`, `comp_admin`, `comp_user`, `spec_viewer`
+- 80+ test tournaments named "Flight Test 2026", "Test Tournament 2026", "Points Test 2026", "Relay Test 2026"
+- Real admin account missing — user could not log in
+- `/auth/bootstrap` "create a judge account" flow errored with `"one already exists"`
+- Pollution recurred across sessions even after manual cleanup (user reported "solving this same fucking issue in loops over and over")
+- Dev server process held a file lock on the polluted DB, surfacing as a misleading `Device or resource busy` error on `rm` until the server was killed
+
+## What Didn't Work
+
+Previous sessions attempted partial fixes. Each addressed only one failure mode and left the recurrence path open:
+
+- **Setting `DATABASE_URL` in individual test files** — worked for new tests that remembered the override, but legacy `test_rbac_*.py` / `test_smoke_*.py` / `test_h_*.py` files imported `app` with the default URL pointing at `instance/proam.db`.
+- **Relying on `TESTING=True` alone** — `TESTING` was set AFTER `create_app()` had already bound the engine to the production URI. The flag never got a chance to redirect the connection.
+- **Trusting `BaseConfig.SQLALCHEMY_DATABASE_URI`** — the class attribute was computed once at module import and cached. Tests that set `DATABASE_URL` *after* importing `config` saw no effect.
+- **Manual cleanup passes** (delete polluted rows between runs) — treated the symptom. The next `pytest` run re-polluted within minutes.
+- **Per-test-file tempfile fixtures that called `create_app()` without env override** — the app factory resolved `DATABASE_URL` from `os.environ` at call time, and without the override, fell through to the default production path.
+- **Debug skill step 3 "Check if production DB has test data"** (added 2026-04-05, `.claude/skills/debug/SKILL.md`) — documentation of awareness only, not code-level enforcement. Problem continued to recur for 16 days before this session's permanent fix. (session history)
+- **QA-against-production risk recognition** (2026-04-08 session) — user and assistant agreed `/qa` must run against a local Flask instance, never against `https://missoula-pro-am-manager-production.up.railway.app/`. But this addressed the *browser-driven* pollution path. The `pytest` path that actually caused the observed `rbac_*` / `smoke_*` rows was a separate failure mode left unguarded. (session history)
+
+None of these prior attempts installed a tripwire. Pollution was silent — there was no gate that failed loudly when a test wrote to the real DB.
+
+## Solution
+
+A four-layer defense-in-depth closes each distinct failure mode. The diagnose-cleanup-verify sequence used this session:
+
+1. **Diagnose** — queried `User` and `Tournament` tables, confirmed 17 fixture users and 80+ fixture tournaments.
+2. **Cleanup** — killed dev server PID holding the file lock (`taskkill //PID <pid> //F`), backed up `instance/proam.db` to `instance/proam.db.backup_testdata_2026-03-24`, deleted the polluted file, ran `flask db upgrade` to rebuild schema from migrations.
+3. **Verify safeguards** — audited and confirmed all four layers active in `tests/conftest.py`, `app.py`, `tests/db_test_utils.py`, and `config.py`.
+4. **Re-ran tests** — 2013 passed. Production DB byte count held constant at 167,936 bytes before and after the full session (fingerprint confirmed).
+
+### Layer 1 — `tests/conftest.py` fingerprint monitor
+
+Session-scoped autouse fixture + `pytest_unconfigure` hook that records `(exists, size, mtime)` of `instance/proam.db` at session start and compares at session end:
+
+```python
+_PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_PROD_DB_PATH = _PROJECT_ROOT / 'instance' / 'proam.db'
+
+
+def _prod_db_fingerprint():
+    if _PROD_DB_PATH.exists():
+        stat = _PROD_DB_PATH.stat()
+        return (True, stat.st_size, stat.st_mtime)
+    return (False, 0, 0)
+
+
+def pytest_configure(config):
+    config._prod_db_before = _prod_db_fingerprint()
+
+
+def pytest_unconfigure(config):
+    before = getattr(config, '_prod_db_before', None)
+    if before is None:
+        return
+    after = _prod_db_fingerprint()
+    if before != after:
+        import warnings
+        warnings.warn(
+            f'\n\n*** PRODUCTION DATABASE MODIFIED BY TESTS ***\n'
+            f'Before: exists={before[0]}, size={before[1]}, mtime={before[2]}\n'
+            f'After:  exists={after[0]}, size={after[1]}, mtime={after[2]}\n'
+            f'Path: {_PROD_DB_PATH}\nThis should NEVER happen.\n',
+            stacklevel=1,
+        )
+
+
+@pytest.fixture(autouse=True, scope='session')
+def _guard_production_db():
+    before = _prod_db_fingerprint()
+    yield
+    after = _prod_db_fingerprint()
+    if before != after:
+        pytest.fail(
+            f'FATAL: Tests modified the production database!\n'
+            f'Before: exists={before[0]}, size={before[1]}\n'
+            f'After:  exists={after[0]}, size={after[1]}\n'
+            f'Path: {_PROD_DB_PATH}\n'
+            f'All test data MUST use temporary databases via create_test_app().'
+        )
+```
+
+The redundancy is deliberate. `pytest_unconfigure` emits a warning; the autouse fixture calls `pytest.fail`. Pytest plugins can swallow warnings, but an autouse fixture fails the run.
+
+### Layer 2 — `app.py` runtime guard in `_create_app_inner()`
+
+```python
+# SAFEGUARD: Block tests from ever touching the production database.
+if app.config.get('TESTING'):
+    db_uri = app.config.get('SQLALCHEMY_DATABASE_URI', '')
+    if 'instance' in db_uri and 'proam.db' in db_uri:
+        raise RuntimeError(
+            'FATAL: Test is about to use the PRODUCTION database '
+            f'({db_uri}). Tests MUST use a temporary database. '
+            'Use create_test_app() from tests/db_test_utils.py.'
+        )
+```
+
+Stops pollution at engine creation, before any SQL runs. Catches the case where `TESTING=True` was set but DB URI was not overridden.
+
+### Layer 3 — `tests/db_test_utils.py::create_test_app()` sets env var BEFORE `create_app()`
+
+```python
+def create_test_app():
+    tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+    db_path = tmp.name
+    tmp.close()
+
+    # CRITICAL: Override DATABASE_URL BEFORE create_app() so config.py
+    # never resolves to the production instance/proam.db path.
+    old_db_url = os.environ.get('DATABASE_URL')
+    os.environ['DATABASE_URL'] = f'sqlite:///{db_path}'
+
+    try:
+        from flask_migrate import upgrade
+        from app import create_app
+
+        _app = create_app()
+        _app.config.update({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{db_path}',
+            'WTF_CSRF_ENABLED': False,
+        })
+
+        # Paranoia: double-check the app isn't pointing at prod
+        uri = _app.config.get('SQLALCHEMY_DATABASE_URI', '')
+        if 'instance' in uri and 'proam.db' in uri:
+            os.unlink(db_path)
+            raise RuntimeError(f'FATAL: Test app is using the production DB: {uri}.')
+
+        with _app.app_context():
+            _db.engine.dispose()
+            upgrade(directory=migrations_dir)
+
+        return _app, db_path
+    finally:
+        if old_db_url is None:
+            os.environ.pop('DATABASE_URL', None)
+        else:
+            os.environ['DATABASE_URL'] = old_db_url
+```
+
+Env-var-first is the only ordering that works with `create_app()`'s internal config resolution. Every test file must construct its app via this helper.
+
+### Layer 4 — `config.py` re-resolves `DATABASE_URL` at app creation time
+
+```python
+# In get_config():
+cfg.SQLALCHEMY_DATABASE_URI = _normalized_database_url()
+```
+
+Defeats the cached-class-attribute trap. Without this, `BaseConfig.SQLALCHEMY_DATABASE_URI` snapshots the URL at module import and ignores later env changes.
+
+## Why This Works
+
+The root cause was a chain: tests imported the Flask app without first overriding `DATABASE_URL`, so `config.py` resolved the default `sqlite:///instance/proam.db`. Once the engine was bound, all `db.session.commit()` calls wrote to the real file. Because the class-level attribute was cached, later attempts to set `DATABASE_URL` had no effect on the already-resolved config.
+
+Each layer closes a distinct failure mode:
+
+| Layer | Failure mode it closes |
+|-------|------------------------|
+| Layer 4 — `config.py` re-resolve | Cached-class-attribute trap. Config never goes stale. |
+| Layer 3 — `create_test_app()` env-first | Ordering failure. Helper encodes the only safe sequence. |
+| Layer 2 — `_create_app_inner` guard | Misconfigured-test-app failure. Factory refuses to return a prod-bound instance under `TESTING=True`. |
+| Layer 1 — conftest fingerprint | Unknown-unknown failure. Catches anything the other three missed by watching the file itself. |
+
+Together they convert a silent, recurring data-loss bug into a loud, immediate test failure. A test that tries to pollute will either raise `RuntimeError` at app creation (Layer 2), fail the session fingerprint check (Layer 1), or trip the verification check in Layer 3.
+
+This also addresses the decoupling pattern noted in the [2026-04-08 Postgres recovery incident](../../../C:/Users/Alex%20Kaper/.claude/projects/c--Users-Alex-Kaper-Desktop-John-Ruffato-Startup-Challenge-Python-Missoula-Pro-Am/memory/incident_2026-04-08_postgres_recovery.md): test infrastructure was so decoupled from production infrastructure that real problems were invisible. The fingerprint check explicitly couples them — the test suite now has eyes on the production file.
+
+## Prevention
+
+Concrete practices and tests to prevent recurrence:
+
+- **Always-on fingerprint check** in `tests/conftest.py` — redundant `pytest_unconfigure` warning AND session-scoped autouse fixture. Do not remove either half — they are layered for a reason.
+- **Runtime `TESTING`-flag guard** in `_create_app_inner()` — refuses any app built with `TESTING=True` and a prod-looking DB URI.
+- **`create_test_app()` is the single canonical entrypoint** for test app construction. Grep check for violations:
+  ```bash
+  grep -r "create_app()" tests/ | grep -v db_test_utils.py
+  ```
+  Any hit is a test file that should be refactored to use `create_test_app()`.
+- **`config.py` must re-resolve `DATABASE_URL`** at each `get_config()` call. Never revert to a cached `BaseConfig.SQLALCHEMY_DATABASE_URI`.
+- **CI runs the full test suite and fails on fingerprint mismatch.** Because Layer 1 calls `pytest.fail`, CI will exit non-zero. Do not suppress the warning in CI config.
+- **Dev-side diagnostic** to detect pollution before it snowballs:
+  ```bash
+  sqlite3 instance/proam.db "SELECT username FROM users"
+  ```
+  Any username matching `^(rbac|smoke|tmpl|post|h|comp|spec)_` means pollution is back. Run weekly and after any test session that crashed mid-run.
+- **Never call `db.create_all()` for schema changes.** Schema is managed exclusively by Flask-Migrate (project CLAUDE.md §6). `db.create_all()` against the prod DB outside migrations is another vector for state drift.
+- **Kill stale dev server processes before DB cleanup.** File locks from `flask run` block `os.unlink`, giving a misleading `Device or resource busy` error that masks the actual pollution. Windows: `taskkill //PID <pid> //F`.
+- **Backup before cleanup, always.** Back up `instance/proam.db` before `rm`, then `flask db upgrade` to rebuild. Treat the backup as disposable once verification passes, but never skip taking it.
+
+## Related
+
+- [docs/solutions/test-failures/tests-asserting-contradictory-behavior.md](tests-asserting-contradictory-behavior.md) — sibling doc: tests failing because they ignore the env flags the harness runs under. Same category of test-harness environment mismatch.
+- [docs/solutions/configuration-issues/railway-predeploy-command.md](../configuration-issues/railway-predeploy-command.md) — related Railway/DB incident: `releaseCommand` silently ignored on Railway; `preDeployCommand` needed. Different defect, same production-DB blast radius. Both are "silent DB-surface failures that only surface in production."
+- `CLAUDE.md` §6 "Test Isolation" — project-level principle this doc implements. Principle was present since project start; the 4-layer defense is the implementation.
+- Auto-memory entry `incident_2026-04-08_postgres_recovery.md` — production was schemaless for 2 weeks because the release command silently wasn't running; CI tests passed against in-memory SQLite while prod was broken. Precedent for why prod-DB defense matters here.
+- `tests/conftest.py` + `tests/db_test_utils.py` — Layers 1 and 3 of the defense. Do not refactor without reading this doc first.


### PR DESCRIPTION
## Summary
- Two compound-documentation passes landed as docs/solutions/ entries
- **Test isolation**: 4-layer defense documented (pytest fingerprint guard + app.py TESTING runtime guard + create_test_app env-var-first + config.py DATABASE_URL re-resolve). Captures the "17 test users and 80+ test tournaments in instance/proam.db" incident and the diagnostic commands to detect pollution
- **Railway ops playbook**: 16 numbered lessons synthesized from ~49 sessions — releaseCommand silent failure, /health verification, volume detach response, 502-vs-000 diagnosis, CI-vs-prod decoupling, CLI token scopes, URL scheme normalization, monitoring and backup gaps, command examples for prod migration and crash-loop diagnosis

Also refreshes stale `releaseCommand` references in `docs/POSTGRES_MIGRATION.md` to point to `preDeployCommand` and the two new solution docs.

Docs-only — no code, no migrations, no tests affected.

## Test plan
- [ ] CI passes (lint + test + postgres-smoke) — docs-only changes should have zero effect on any test
- [ ] Render both new markdown files on GitHub; verify cross-references resolve
- [ ] Verify `docs/POSTGRES_MIGRATION.md` no longer mentions `releaseCommand` except in the deprecation note

## Out of scope
- Does not close the operational gaps the playbook flags (external `/health` monitoring, scheduled backup caller, post-deploy CI gate, volume-detach auto-recovery). Separate follow-up.
- Does not touch the pre-existing woodboss working-tree changes or `SESSION_HANDOFF_2026-04-21.md` from the prior session — left untouched on `main` for the user to triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)