### PR TITLE
fix(ops): health-monitor needs GH_REPO env var without checkout

### DIFF
--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -28,6 +28,10 @@ jobs:
       HEALTH_URL: https://missoula-pro-am-manager-production.up.railway.app/health
       ALERT_LABEL: health-alert
       PLAYBOOK: docs/solutions/best-practices/railway-postgres-operational-playbook-2026-04-21.md
+      # GH_REPO tells `gh` which repo to target without needing a git checkout.
+      # Without this, gh shells out to `git` and fails with "not a git repository".
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Fetch /health
         id: health
@@ -73,8 +77,6 @@ jobs:
 
       - name: Ensure alert label exists
         if: steps.health.outputs.healthy == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           if ! gh label list --json name --jq '.[].name' | grep -qx "$ALERT_LABEL"; then
             gh label create "$ALERT_LABEL" --description "Automated production health check alert" --color d73a4a
@@ -83,7 +85,6 @@ jobs:
       - name: Open or comment on alert issue
         if: steps.health.outputs.healthy == 'false'
         env:
-          GH_TOKEN: ${{ github.token }}
           HTTP_CODE: ${{ steps.health.outputs.http_code }}
           STATUS: ${{ steps.health.outputs.status }}
           DB: ${{ steps.health.outputs.db }}
@@ -136,7 +137,6 @@ jobs:
       - name: Close alert issue on recovery
         if: steps.health.outputs.healthy == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           MIG_REV: ${{ steps.health.outputs.migration_rev }}
         run: |


### PR DESCRIPTION
## Summary
PR #61's health-monitor workflow fails on the `gh issue list` command because it has no `actions/checkout` step (intentional — the workflow only hits `/health` and calls the GitHub API, it doesn't need repo contents).

First live run ([#24755637093](https://github.com/SquirmyWormy275/Missoula-Pro-Am-Manager/actions/runs/24755637093)) failed with `fatal: not a git repository` even though production was healthy, because the "Close alert issue on recovery" step needs a repo context regardless of whether there's an issue to close.

Fix: set `GH_REPO: ${{ github.repository }}` at the job level. The `gh` CLI reads this env var and skips the `git` auto-detection path. Also promoted `GH_TOKEN` to the job level to deduplicate.

## Test plan
- [ ] Merge
- [ ] Trigger `workflow_dispatch` on `main`
- [ ] Confirm the run goes green (no alert issue opened — prod is healthy)
- [ ] Let scheduled run fire at the next `:00`/`:05`/`:10` mark and confirm it's also green

🤖 Generated with [Claude Code](https://claude.com/claude-code)