### PR TITLE
feat(scheduling): Current Schedule status panel on events.html

### DIFF
--- a/routes/scheduling/events.py
+++ b/routes/scheduling/events.py
@@ -164,6 +164,9 @@ def event_list(tournament_id):
     if build_diff:
         session.modified = True
 
+    from services.schedule_status import build_schedule_status
+    schedule_status = build_schedule_status(tournament)
+
     return render_template('scheduling/events.html',
                            tournament=tournament,
                            college_events=college_events,
@@ -176,7 +179,8 @@ def event_list(tournament_id):
                            pro_heats_exist=pro_heats_exist,
                            sat_spillover_count=sat_spillover_count,
                            fnf_count=fnf_count,
-                           build_diff=build_diff)
+                           build_diff=build_diff,
+                           schedule_status=schedule_status)
 
 
 @scheduling_bp.route('/<int:tournament_id>/events/setup', methods=['GET', 'POST'])

--- a/services/schedule_status.py
+++ b/services/schedule_status.py
@@ -1,0 +1,341 @@
+"""
+Aggregated schedule-state summary for the Events & Schedule page.
+
+Rendered as a "Current Schedule" card at the top of events.html so judges
+see the actual state of heats, flights, and warnings inline after every
+build/generate action — no round-trip to day_schedule / flights /
+show_day / per-event heats pages just to verify "did that work?".
+
+Design constraints:
+- Read-only. No mutations.
+- Fast enough to render on every GET of event_list. Avoid N+1.
+- Cross-links back to the detail pages when the judge needs more than
+  a count.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TypedDict
+
+from flask import url_for
+
+from database import db
+from models.event import Event
+from models.heat import Flight, Heat
+from models.tournament import Tournament
+
+
+class Warning_(TypedDict, total=False):
+    severity: str  # 'danger' | 'warning' | 'info'
+    title: str
+    detail: str
+    link: str | None
+    link_label: str | None
+
+
+class DayStatus(TypedDict):
+    events_configured: int
+    events_with_heats: int
+    heats_total: int
+    competitors_placed: int
+    detail_link: str
+    detail_label: str
+
+
+class ScheduleStatus(TypedDict):
+    friday: DayStatus
+    saturday: DayStatus
+    saturday_flights: int
+    saturday_heats_per_flight_avg: float
+    warnings: list[Warning_]
+    overall_label: str
+    overall_severity: str  # 'success' | 'warning' | 'danger' | 'info'
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def build_schedule_status(tournament: Tournament) -> ScheduleStatus:
+    """Aggregated day-by-day status for the Events page status panel."""
+    events = list(tournament.events.all())
+    college_events = [e for e in events if e.event_type == "college"]
+    pro_events = [e for e in events if e.event_type == "pro"]
+
+    heats_by_event = _heats_by_event(tournament.id)
+
+    friday = _day_status(
+        tournament_id=tournament.id,
+        events=college_events,
+        heats_by_event=heats_by_event,
+        detail_endpoint="scheduling.day_schedule",
+    )
+    saturday = _day_status(
+        tournament_id=tournament.id,
+        events=pro_events,
+        heats_by_event=heats_by_event,
+        detail_endpoint="scheduling.flight_list",
+    )
+
+    flight_count, avg_heats_per_flight = _flight_stats(tournament.id)
+
+    warnings = _build_warnings(
+        tournament=tournament,
+        college_events=college_events,
+        pro_events=pro_events,
+        heats_by_event=heats_by_event,
+        flight_count=flight_count,
+    )
+
+    overall_label, overall_severity = _overall(
+        friday=friday,
+        saturday=saturday,
+        flight_count=flight_count,
+        warnings=warnings,
+    )
+
+    return {
+        "friday": friday,
+        "saturday": saturday,
+        "saturday_flights": flight_count,
+        "saturday_heats_per_flight_avg": avg_heats_per_flight,
+        "warnings": warnings,
+        "overall_label": overall_label,
+        "overall_severity": overall_severity,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Heat + flight aggregation
+# ---------------------------------------------------------------------------
+
+
+def _heats_by_event(tournament_id: int) -> dict[int, list[Heat]]:
+    """One query, group heats by event_id. Avoids N+1 over events."""
+    heats = Heat.query.join(Event).filter(Event.tournament_id == tournament_id).all()
+    grouped: dict[int, list[Heat]] = defaultdict(list)
+    for h in heats:
+        grouped[h.event_id].append(h)
+    return grouped
+
+
+def _day_status(
+    tournament_id: int,
+    events: list[Event],
+    heats_by_event: dict[int, list[Heat]],
+    detail_endpoint: str,
+) -> DayStatus:
+    heats_total = 0
+    events_with_heats = 0
+    competitor_ids: set[tuple[str, int]] = set()
+
+    for ev in events:
+        ev_heats = heats_by_event.get(ev.id, [])
+        if ev_heats:
+            events_with_heats += 1
+            heats_total += len(ev_heats)
+            for h in ev_heats:
+                for cid in h.get_competitors():
+                    competitor_ids.add((ev.event_type, int(cid)))
+
+    return {
+        "events_configured": len(events),
+        "events_with_heats": events_with_heats,
+        "heats_total": heats_total,
+        "competitors_placed": len(competitor_ids),
+        "detail_link": url_for(detail_endpoint, tournament_id=tournament_id),
+        "detail_label": (
+            "Day schedule" if detail_endpoint.endswith("day_schedule") else "Flights"
+        ),
+    }
+
+
+def _flight_stats(tournament_id: int) -> tuple[int, float]:
+    """Return (flight_count, avg_heats_per_flight) for Saturday pro flights."""
+    flight_ids = [
+        row[0]
+        for row in db.session.query(Flight.id)
+        .filter(Flight.tournament_id == tournament_id)
+        .all()
+    ]
+    if not flight_ids:
+        return 0, 0.0
+    heat_count = (
+        db.session.query(db.func.count(Heat.id))
+        .filter(Heat.flight_id.in_(flight_ids))
+        .scalar()
+    ) or 0
+    return len(flight_ids), round(heat_count / len(flight_ids), 1)
+
+
+# ---------------------------------------------------------------------------
+# Warnings
+# ---------------------------------------------------------------------------
+
+
+def _build_warnings(
+    tournament: Tournament,
+    college_events: list[Event],
+    pro_events: list[Event],
+    heats_by_event: dict[int, list[Heat]],
+    flight_count: int,
+) -> list[Warning_]:
+    warnings: list[Warning_] = []
+    tid = tournament.id
+
+    # --- 1. Events configured but no heats yet ---
+    college_missing = [
+        e
+        for e in college_events
+        if not heats_by_event.get(e.id) and not _is_open_list_only(e)
+    ]
+    if college_missing:
+        warnings.append(
+            {
+                "severity": "warning",
+                "title": f"{len(college_missing)} college event(s) have no heats yet",
+                "detail": ", ".join(_display_event_name(e) for e in college_missing[:5])
+                + ("…" if len(college_missing) > 5 else ""),
+                "link": url_for("scheduling.event_list", tournament_id=tid),
+                "link_label": "Generate college heats",
+            }
+        )
+
+    pro_missing = [e for e in pro_events if not heats_by_event.get(e.id)]
+    if pro_missing:
+        warnings.append(
+            {
+                "severity": "warning",
+                "title": f"{len(pro_missing)} pro event(s) have no heats yet",
+                "detail": ", ".join(_display_event_name(e) for e in pro_missing[:5])
+                + ("…" if len(pro_missing) > 5 else ""),
+                "link": url_for("scheduling.event_list", tournament_id=tid),
+                "link_label": "Generate pro heats",
+            }
+        )
+
+    # --- 2. Pro heats generated but flights not built ---
+    pro_heats_exist = any(heats_by_event.get(e.id) for e in pro_events)
+    if pro_heats_exist and flight_count == 0:
+        warnings.append(
+            {
+                "severity": "warning",
+                "title": "Pro heats exist but flights are not built",
+                "detail": 'Click "Build Flights" or "One-click Saturday Show Build" to group heats into flights.',
+                "link": url_for("scheduling.event_list", tournament_id=tid),
+                "link_label": "Build flights",
+            }
+        )
+
+    # --- 3. Gear-sharing conflicts in existing heats ---
+    try:
+        from services.gear_sharing import build_gear_report
+
+        gear = build_gear_report(tournament)
+        pro_conflicts = gear.get("pro_conflicts", []) or []
+        if pro_conflicts:
+            warnings.append(
+                {
+                    "severity": "danger",
+                    "title": f"{len(pro_conflicts)} gear-sharing conflict(s) in pro heats",
+                    "detail": "Competitors who share equipment are in the same heat. Use auto-fix or the manager.",
+                    "link": url_for("registration.pro_gear_sharing", tournament_id=tid),
+                    "link_label": "Gear Sharing Manager",
+                }
+            )
+    except Exception:
+        # Gear report is best-effort; never block the status panel on it
+        pass
+
+    # --- 4. Cookie Stack + Standing Block simultaneous scheduling ---
+    #
+    # The flight builder already prevents this at build time, but surface
+    # any pre-existing conflict in already-built flights so they get
+    # cleaned up.
+    cookie_block_conflicts = _count_cookie_standing_simultaneous(tournament.id)
+    if cookie_block_conflicts:
+        warnings.append(
+            {
+                "severity": "danger",
+                "title": f"{cookie_block_conflicts} flight slot(s) schedule Cookie Stack and Standing Block simultaneously",
+                "detail": "These events share physical stands and must not run at the same time. Rebuild flights to resolve.",
+                "link": url_for("scheduling.event_list", tournament_id=tid),
+                "link_label": "Rebuild flights",
+            }
+        )
+
+    return warnings
+
+
+def _is_open_list_only(event: Event) -> bool:
+    """College OPEN events with no heats (sign-up-only) are not a warning."""
+    return event.event_type == "college" and bool(getattr(event, "is_open", False))
+
+
+def _display_event_name(e: Event) -> str:
+    base = e.name
+    gender = (getattr(e, "gender", None) or "").strip()
+    if gender:
+        return f"{base} ({gender})"
+    return base
+
+
+def _count_cookie_standing_simultaneous(tournament_id: int) -> int:
+    """Count flight slots that schedule Cookie Stack and Standing Block at the same time."""
+    flight_heats = (
+        db.session.query(Heat.flight_id, Heat.flight_position, Event.stand_type)
+        .join(Event, Event.id == Heat.event_id)
+        .filter(
+            Event.tournament_id == tournament_id,
+            Heat.flight_id.isnot(None),
+            Event.stand_type.in_(("cookie_stack", "standing_block")),
+        )
+        .all()
+    )
+    slot_stands: dict[tuple[int, int | None], set[str]] = defaultdict(set)
+    for flight_id, pos, stand_type in flight_heats:
+        slot_stands[(flight_id, pos)].add(stand_type)
+    return sum(
+        1
+        for stands in slot_stands.values()
+        if "cookie_stack" in stands and "standing_block" in stands
+    )
+
+
+# ---------------------------------------------------------------------------
+# Overall summary
+# ---------------------------------------------------------------------------
+
+
+def _overall(
+    friday: DayStatus,
+    saturday: DayStatus,
+    flight_count: int,
+    warnings: list[Warning_],
+) -> tuple[str, str]:
+    """One-liner for the card header + its Bootstrap severity class."""
+    if any(w.get("severity") == "danger" for w in warnings):
+        return "Schedule has conflicts — fix before race day", "danger"
+
+    any_college_configured = friday["events_configured"] > 0
+    any_pro_configured = saturday["events_configured"] > 0
+
+    if not any_college_configured and not any_pro_configured:
+        return "No events configured yet", "info"
+
+    friday_ready = (
+        friday["events_configured"] == 0
+        or friday["events_with_heats"] == friday["events_configured"]
+    )
+    saturday_ready = saturday["events_configured"] == 0 or (
+        saturday["events_with_heats"] == saturday["events_configured"]
+        and flight_count > 0
+    )
+
+    if friday_ready and saturday_ready:
+        return "Schedule ready", "success"
+    if warnings:
+        return "Schedule in progress — action needed", "warning"
+    return "Schedule in progress", "info"

--- a/templates/scheduling/events.html
+++ b/templates/scheduling/events.html
@@ -201,6 +201,100 @@
         ══════════════════════════════════════════════════════════════════ #}
         <div class="tab-pane fade" id="tab-build" role="tabpanel">
 
+            {# ── Current Schedule Status Panel ─────────────────────────────
+               Inline summary of heats, flights, and warnings so the judge
+               doesn't have to round-trip to day_schedule / flights / show_day
+               to verify every build action.
+            ───────────────────────────────────────────────────────────────── #}
+            {% if schedule_status %}
+            {% set sev = schedule_status.overall_severity %}
+            {% set sev_border = {'success':'#2da85e','warning':'#d39e00','danger':'#d7303e','info':'#3b8ee8'}[sev] %}
+            <div class="card mb-3" style="border-left:4px solid {{ sev_border }};">
+                <div class="card-header py-2 d-flex align-items-center justify-content-between flex-wrap gap-2">
+                    <span class="fw-bold" style="font-size:0.95rem;">
+                        <i class="bi bi-clipboard-data me-1"></i>
+                        Current Schedule — {{ schedule_status.overall_label }}
+                    </span>
+                    {% if schedule_status.warnings %}
+                    <span class="badge bg-{{ sev }}">
+                        {{ schedule_status.warnings|length }}
+                        action{% if schedule_status.warnings|length != 1 %}s{% endif %} needed
+                    </span>
+                    {% else %}
+                    <span class="badge bg-{{ sev }}"><i class="bi bi-check-circle me-1"></i>No issues</span>
+                    {% endif %}
+                </div>
+                <div class="card-body py-3">
+                    <div class="row g-3">
+                        {# Friday column #}
+                        <div class="col-md-6">
+                            <div class="small text-muted mb-2 fw-semibold">
+                                <i class="bi bi-mortarboard me-1"></i>Friday (College)
+                            </div>
+                            <div class="d-flex flex-wrap gap-3" style="font-size:0.88rem;">
+                                <div><span class="text-muted">Events:</span>
+                                    <strong>{{ schedule_status.friday.events_configured }}</strong></div>
+                                <div><span class="text-muted">With heats:</span>
+                                    <strong>{{ schedule_status.friday.events_with_heats }}</strong>
+                                    / {{ schedule_status.friday.events_configured }}</div>
+                                <div><span class="text-muted">Total heats:</span>
+                                    <strong>{{ schedule_status.friday.heats_total }}</strong></div>
+                                <div><span class="text-muted">Placed:</span>
+                                    <strong>{{ schedule_status.friday.competitors_placed }}</strong> competitors</div>
+                            </div>
+                            <a href="{{ schedule_status.friday.detail_link }}"
+                               class="small text-decoration-none mt-1 d-inline-block">
+                                <i class="bi bi-arrow-right-short"></i>{{ schedule_status.friday.detail_label }}
+                            </a>
+                        </div>
+                        {# Saturday column #}
+                        <div class="col-md-6">
+                            <div class="small text-muted mb-2 fw-semibold">
+                                <i class="bi bi-trophy me-1"></i>Saturday (Pro Flights)
+                            </div>
+                            <div class="d-flex flex-wrap gap-3" style="font-size:0.88rem;">
+                                <div><span class="text-muted">Events:</span>
+                                    <strong>{{ schedule_status.saturday.events_configured }}</strong></div>
+                                <div><span class="text-muted">Flights:</span>
+                                    <strong>{{ schedule_status.saturday_flights }}</strong>
+                                    {% if schedule_status.saturday_flights > 0 %}
+                                    <span class="text-muted">(avg {{ schedule_status.saturday_heats_per_flight_avg }} heats/flight)</span>
+                                    {% endif %}</div>
+                                <div><span class="text-muted">Total heats:</span>
+                                    <strong>{{ schedule_status.saturday.heats_total }}</strong></div>
+                                <div><span class="text-muted">Placed:</span>
+                                    <strong>{{ schedule_status.saturday.competitors_placed }}</strong> competitors</div>
+                            </div>
+                            <a href="{{ schedule_status.saturday.detail_link }}"
+                               class="small text-decoration-none mt-1 d-inline-block">
+                                <i class="bi bi-arrow-right-short"></i>{{ schedule_status.saturday.detail_label }}
+                            </a>
+                        </div>
+                    </div>
+                    {% if schedule_status.warnings %}
+                    <hr class="my-3">
+                    <div>
+                        {% for w in schedule_status.warnings %}
+                        <div class="alert alert-{{ w.severity }} py-2 mb-2 d-flex align-items-start gap-2"
+                             style="font-size:0.85rem;">
+                            <i class="bi bi-{% if w.severity == 'danger' %}exclamation-triangle-fill{% elif w.severity == 'warning' %}exclamation-circle{% else %}info-circle{% endif %} flex-shrink-0 mt-1"></i>
+                            <div class="flex-grow-1">
+                                <div class="fw-semibold">{{ w.title }}</div>
+                                {% if w.detail %}<div class="small text-muted">{{ w.detail }}</div>{% endif %}
+                            </div>
+                            {% if w.link %}
+                            <a href="{{ w.link }}" class="btn btn-sm btn-outline-{{ w.severity }} flex-shrink-0">
+                                {{ w.link_label or 'Open' }}
+                            </a>
+                            {% endif %}
+                        </div>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+
             {# Overall status banner #}
             {% if college_heats_total == 0 %}
             <div class="alert alert-info d-flex align-items-center gap-2 mb-4">

--- a/tests/test_schedule_status.py
+++ b/tests/test_schedule_status.py
@@ -1,0 +1,194 @@
+"""Tests for services/schedule_status.py — the Current Schedule panel aggregator."""
+
+import pytest
+
+from database import db
+from models.event import Event
+from models.heat import Flight, Heat
+from models.tournament import Tournament
+from services.schedule_status import build_schedule_status
+from tests.db_test_utils import create_test_app
+
+
+@pytest.fixture(scope="module")
+def app():
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        yield _app
+        db.session.remove()
+    import os
+
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def tournament(app):
+    with app.app_context():
+        t = Tournament(name="Status Test", year=2026, status="setup")
+        db.session.add(t)
+        db.session.commit()
+        tid = t.id
+        yield t
+        # Explicit cascade in FK dependency order: Heat → Flight → Event → Tournament.
+        # Flight.id is referenced by Heat.flight_id with no ON DELETE CASCADE,
+        # so we can't rely on Tournament cascade alone.
+        db.session.rollback()
+        event_ids = [e.id for e in Event.query.filter_by(tournament_id=tid).all()]
+        if event_ids:
+            Heat.query.filter(Heat.event_id.in_(event_ids)).delete(synchronize_session=False)
+        Flight.query.filter_by(tournament_id=tid).delete()
+        Event.query.filter_by(tournament_id=tid).delete()
+        Tournament.query.filter_by(id=tid).delete()
+        db.session.commit()
+
+
+class TestBuildScheduleStatus:
+    def test_empty_tournament_is_info(self, app, tournament):
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        assert s["overall_severity"] == "info"
+        assert s["overall_label"] == "No events configured yet"
+        assert s["friday"]["events_configured"] == 0
+        assert s["saturday"]["events_configured"] == 0
+        assert s["saturday_flights"] == 0
+        assert s["warnings"] == []
+
+    def test_events_without_heats_warns(self, app, tournament):
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Underhand",
+                event_type="college",
+                gender="M",
+                scoring_type="time",
+                stand_type="underhand",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.commit()
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        assert s["friday"]["events_configured"] == 1
+        assert s["friday"]["events_with_heats"] == 0
+        assert s["friday"]["heats_total"] == 0
+        assert any("no heats yet" in w["title"] for w in s["warnings"])
+        assert s["overall_severity"] in ("warning", "info")
+
+    def test_open_college_event_without_heats_not_warned(self, app, tournament):
+        """OPEN events (Axe Throw, Caber Toss, etc.) don't use heats — no warning."""
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Axe Throw",
+                event_type="college",
+                gender="M",
+                scoring_type="hits",
+                stand_type="axe_throw",
+                is_open=True,
+            )
+            db.session.add(ev)
+            db.session.commit()
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        # Open event counts as configured but no "missing heats" warning
+        assert s["friday"]["events_configured"] >= 1
+        assert not any(
+            "no heats" in w["title"] and "college" in w["title"] for w in s["warnings"]
+        )
+
+    def test_pro_heats_without_flights_warns(self, app, tournament):
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Springboard",
+                event_type="pro",
+                gender="M",
+                scoring_type="time",
+                stand_type="springboard",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.flush()
+            h = Heat(event_id=ev.id, heat_number=1, run_number=1, competitors="[]")
+            db.session.add(h)
+            db.session.commit()
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        assert s["saturday"]["heats_total"] >= 1
+        assert s["saturday_flights"] == 0
+        assert any("flights are not built" in w["title"] for w in s["warnings"])
+
+    def test_ready_schedule_shows_success(self, app, tournament):
+        """All events have heats and flights exist → success severity."""
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Hot Saw",
+                event_type="pro",
+                gender="M",
+                scoring_type="time",
+                stand_type="hot_saw",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.flush()
+
+            f = Flight(tournament_id=tournament.id, flight_number=1, name="A")
+            db.session.add(f)
+            db.session.flush()
+
+            h = Heat(
+                event_id=ev.id,
+                heat_number=1,
+                run_number=1,
+                competitors="[1]",
+                flight_id=f.id,
+                flight_position=1,
+            )
+            db.session.add(h)
+            db.session.commit()
+
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        assert s["saturday"]["events_with_heats"] == s["saturday"]["events_configured"]
+        assert s["saturday_flights"] == 1
+        assert s["saturday_heats_per_flight_avg"] == 1.0
+        assert s["overall_severity"] == "success"
+        assert s["overall_label"] == "Schedule ready"
+
+
+class TestEventListRouteRendersPanel:
+    def test_route_includes_current_schedule_card(self, app, client):
+        """GET /scheduling/<tid>/events renders the Current Schedule panel."""
+        with app.app_context():
+            t = Tournament(name="Render Test", year=2026, status="setup")
+            db.session.add(t)
+            db.session.commit()
+            tid = t.id
+
+            # Log in as a judge so the route returns 200
+            from models.user import User
+
+            u = User(username="panel_test_admin", role="admin")
+            u.set_password("testpass123")
+            db.session.add(u)
+            db.session.commit()
+            uid = u.id
+
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(uid)
+            sess["_fresh"] = True
+
+        r = client.get(f"/scheduling/{tid}/events")
+        assert r.status_code == 200
+        html = r.get_data(as_text=True)
+        assert "Current Schedule" in html, "status panel missing from events.html"
+        assert "No events configured yet" in html


### PR DESCRIPTION
## Summary

Adds an inline "Current Schedule" status panel at the top of `/scheduling/<tid>/events` so the judge sees **heats + flights + warnings inline** after any build/generate action. No more 5-page round-trip (`events.html` → `heats.html` → `day_schedule.html` → `flights.html` → `show_day.html`) just to verify "did that work?".

## Panel contents

**Counts** (two-column, Friday / Saturday):
- Events configured
- Events with heats (vs total)
- Total heats
- Competitors placed
- Saturday also: flight count + avg heats per flight
- Click-through links to `day_schedule` (Friday) and `flight_list` (Saturday)

**Warnings** (with severity + action button):
- Events configured but no heats yet (college + pro, separate) — OPEN events exempt
- Pro heats exist but flights not built → "Build flights" button
- Gear-sharing conflicts in pro heats → "Gear Sharing Manager" button
- Cookie Stack / Standing Block simultaneous slots (rare, dangerous) → "Rebuild flights"

**Overall severity badge**: success / warning / danger / info with a one-line summary.

## What it does NOT change
- No new routes
- No schema changes
- No existing behavior altered — the existing 3-state alert banner below stays as-is
- Panel is additive and purely read-only

## Files

| File | Change |
|---|---|
| `services/schedule_status.py` | **New** — `build_schedule_status(tournament)` returns TypedDict; one query for heats (no N+1); reads gear report with best-effort fallback |
| `routes/scheduling/events.py` | Passes `schedule_status` into template context |
| `templates/scheduling/events.html` | Adds panel block inside the existing "tab-build" tab, before the existing alert banner |
| `tests/test_schedule_status.py` | **New** — 6 tests: empty tournament, missing-heats warnings, open-event exemption, flights-not-built warning, full-ready success, route-renders-panel smoke |

## Test plan
- [x] `pytest tests/test_schedule_status.py` → 6 passed locally
- [ ] CI passes (lint + full test suite + postgres-smoke)
- [ ] Manual smoke on local: load `/scheduling/1/events` with 2 existing test tournaments — confirm panel shows real counts and relevant warnings
- [ ] Visual pass: severity colors (green / amber / red / blue) render correctly
- [ ] After merge: verify on prod (empty tournament → "No events configured yet" info state)

## Race-day safety
Zero risk to prod. Additive template content, read-only service, no migrations, no mutation paths touched. Can be reverted by removing the `{% if schedule_status %}` block from events.html with no side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)