### PR TITLE
ops(backup): harden workflow + race-weekend hourly schedule

### DIFF
--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -18,8 +18,21 @@ name: Daily Production DB Backup
 
 on:
   schedule:
+    # Daily baseline: 08:00 UTC = 02:00 MDT / 01:00 MST — low-traffic window.
     - cron: '0 8 * * *'
+    # Race-weekend hourly coverage: every hour on April 24-26 (UTC), which
+    # covers Thursday 6 PM MDT through Sunday 5 PM MDT. Caps worst-case data
+    # loss at 1 hour during the event. Update these dates after each annual
+    # Missoula Pro-Am if the race weekend shifts.
+    - cron: '0 * 24-26 4 *'
   workflow_dispatch:
+
+# Serialize runs so the baseline + hourly + manual-dispatch schedules never
+# stampede the public Postgres proxy. Queue, don't cancel — backups mid-flight
+# should complete.
+concurrency:
+  group: daily-backup
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -54,8 +54,16 @@ jobs:
           RAILWAY_PG_PUBLIC_URL: ${{ secrets.RAILWAY_PG_PUBLIC_URL }}
         run: |
           set -euo pipefail
-          # Normalize postgres:// → postgresql:// if stored in the older form
-          NORMALIZED_URL="${RAILWAY_PG_PUBLIC_URL/#postgres:\/\//postgresql://}"
+          # Tolerate two common secret shapes:
+          #   postgres://... or postgresql://...  — URL only (preferred)
+          #   DATABASE_PUBLIC_URL=postgres://...  — raw paste from `railway variables --kv`
+          # Strip a leading `KEY=` if present (matches [A-Z0-9_]+= up to first =).
+          RAW_URL="${RAILWAY_PG_PUBLIC_URL}"
+          if [[ "$RAW_URL" =~ ^[A-Z0-9_]+= ]]; then
+            RAW_URL="${RAW_URL#*=}"
+          fi
+          # Normalize postgres:// → postgresql:// (SQLAlchemy 2.x + some tools require it).
+          NORMALIZED_URL="${RAW_URL/#postgres:\/\//postgresql://}"
           TS=$(date -u +%Y%m%d_%H%M%S)
           OUT="proam_backup_${TS}.sql.gz"
 

--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -37,6 +37,13 @@ jobs:
           sudo sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update
           sudo apt-get install -y postgresql-client-18
+          # Prepend PG 18's bin dir to PATH so the Debian pg_wrapper doesn't
+          # dispatch to an older pg_dump preinstalled on ubuntu-latest. The
+          # version mismatch error `aborting because of server version mismatch`
+          # comes from a client older than the PG 18.3 server.
+          echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"
+          # Verify we're picking up PG 18:
+          /usr/lib/postgresql/18/bin/pg_dump --version
 
       - name: Verify secret is set
         env:

--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -54,15 +54,15 @@ jobs:
           RAILWAY_PG_PUBLIC_URL: ${{ secrets.RAILWAY_PG_PUBLIC_URL }}
         run: |
           set -euo pipefail
-          # Tolerate two common secret shapes:
-          #   postgres://... or postgresql://...  — URL only (preferred)
-          #   DATABASE_PUBLIC_URL=postgres://...  — raw paste from `railway variables --kv`
-          # Strip a leading `KEY=` if present (matches [A-Z0-9_]+= up to first =).
-          RAW_URL="${RAILWAY_PG_PUBLIC_URL}"
+          # Tolerate three common secret-paste mishaps:
+          #   1. trailing whitespace / newline from copy-paste — strip all whitespace
+          #      (URLs cannot contain whitespace, so this is safe)
+          #   2. `KEY=URL` form — raw paste from `railway variables --kv`
+          #   3. `postgres://` (old scheme) instead of `postgresql://` — normalize
+          RAW_URL=$(printf '%s' "$RAILWAY_PG_PUBLIC_URL" | tr -d '[:space:]')
           if [[ "$RAW_URL" =~ ^[A-Z0-9_]+= ]]; then
             RAW_URL="${RAW_URL#*=}"
           fi
-          # Normalize postgres:// → postgresql:// (SQLAlchemy 2.x + some tools require it).
           NORMALIZED_URL="${RAW_URL/#postgres:\/\//postgresql://}"
           TS=$(date -u +%Y%m%d_%H%M%S)
           OUT="proam_backup_${TS}.sql.gz"

--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -93,9 +93,12 @@ jobs:
 
       - name: Sanity-check dump content
         run: |
-          set -euo pipefail
+          # Deliberately NOT using `set -o pipefail` — `gunzip | head` closes
+          # the pipe early (by design) and would raise SIGPIPE on gunzip,
+          # which pipefail then converts into a fatal step failure.
+          set -eu
           echo "--- First 20 lines of dump ---"
-          gunzip -c "$BACKUP_FILE" | head -20
+          gunzip -c "$BACKUP_FILE" | head -20 || true
 
           TABLE_COUNT=$(gunzip -c "$BACKUP_FILE" | grep -c "^CREATE TABLE" || true)
           echo "CREATE TABLE statements: $TABLE_COUNT"


### PR DESCRIPTION
## Summary
Gets the daily backup workflow actually working end-to-end, plus adds race-weekend hourly coverage.

### Bug fixes (workflow was broken in 4 different ways before)
- **KEY=URL prefix tolerance** — strips leading `DATABASE_PUBLIC_URL=` if someone pastes the full `railway variables --kv` line as the secret value
- **Whitespace strip** — strips all whitespace from the secret (URLs can't contain any), so trailing newlines from copy-paste don't break the connection
- **PG 18 pg_dump PATH** — prepends `/usr/lib/postgresql/18/bin` to `$GITHUB_PATH` so the Debian pg_wrapper doesn't dispatch to an older pg_dump preinstalled on ubuntu-latest. Fixes `pg_dump: error: aborting because of server version mismatch` against Railway's PG 18.3 server
- **pipefail off in sanity check** — `gunzip | head -20` fights `set -o pipefail` (head closes the pipe → SIGPIPE on gunzip → step fails). Use `set -eu` only in that step

### New: race-weekend hourly schedule
- Existing daily baseline stays at `0 8 * * *` (02:00 MDT, low-traffic)
- Added `0 * 24-26 4 *` — hourly dumps on April 24-26 UTC, which covers Thursday 6 PM MDT through Sunday 5 PM MDT
- Caps worst-case data loss at **1 hour** during the event (was 24 hours)
- Comment in the cron explains how to update dates annually after each Missoula Pro-Am

### New: concurrency guard
- Added `concurrency: { group: daily-backup, cancel-in-progress: false }` so daily + hourly + manual-dispatch schedules serialize on the public Postgres proxy — queue rather than stampede, and don't kill a backup mid-stream

## Evidence it works
- Branch run [24762982995](https://github.com/SquirmyWormy275/Missoula-Pro-Am-Manager/actions/runs/24762982995) — ✓ success, 30s, artifact `proam-db-backup-24762982995` uploaded

## Race-day safety
- The backup workflow is run-one-off infra; no runtime code changes; no migrations
- The hourly schedule only fires on April 24-26 UTC and can be reverted by deleting one line if it causes problems

🤖 Generated with [Claude Code](https://claude.com/claude-code)