### PR TITLE
feat(flights): minutes-per-flight OR num_flights sizing toggle [Phase 3/5]

### DIFF
--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -120,6 +120,89 @@ def flight_list(tournament_id):
                            flight_data=flight_data)
 
 
+# ---------------------------------------------------------------------------
+# Flight sizing config (Phase 3) — persisted in Tournament.schedule_config.
+# Two modes: 'minutes' (derive num_flights from target duration) or 'count'
+# (operator picks num_flights directly). Defaults below are tuned for the
+# Missoula Pro Am's 60-min flight cadence and 5.5-min avg heat duration.
+# ---------------------------------------------------------------------------
+
+FLIGHT_SIZING_MODE_MINUTES = 'minutes'
+FLIGHT_SIZING_MODE_COUNT = 'count'
+VALID_FLIGHT_SIZING_MODES = {FLIGHT_SIZING_MODE_MINUTES, FLIGHT_SIZING_MODE_COUNT}
+
+FLIGHT_SIZING_DEFAULTS = {
+    'mode': FLIGHT_SIZING_MODE_MINUTES,
+    'target_minutes_per_flight': 60,
+    'minutes_per_heat': 5.5,
+    'num_flights': 4,
+}
+
+FLIGHT_COUNT_MIN = 2
+FLIGHT_COUNT_MAX = 10
+MINUTES_PER_FLIGHT_MIN = 30
+MINUTES_PER_FLIGHT_MAX = 180
+MINUTES_PER_HEAT_MIN = 1.0
+MINUTES_PER_HEAT_MAX = 15.0
+
+
+def _read_flight_sizing_config(tournament):
+    """Return saved flight-sizing config merged over defaults."""
+    cfg = tournament.get_schedule_config() or {}
+    mode = cfg.get('flight_sizing_mode', FLIGHT_SIZING_DEFAULTS['mode'])
+    if mode not in VALID_FLIGHT_SIZING_MODES:
+        mode = FLIGHT_SIZING_DEFAULTS['mode']
+    try:
+        target_minutes = int(cfg.get('target_minutes_per_flight',
+                                     FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']))
+    except (TypeError, ValueError):
+        target_minutes = FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']
+    try:
+        minutes_per_heat = float(cfg.get('minutes_per_heat',
+                                         FLIGHT_SIZING_DEFAULTS['minutes_per_heat']))
+    except (TypeError, ValueError):
+        minutes_per_heat = FLIGHT_SIZING_DEFAULTS['minutes_per_heat']
+    try:
+        saved_num_flights = int(cfg.get('num_flights', FLIGHT_SIZING_DEFAULTS['num_flights']))
+    except (TypeError, ValueError):
+        saved_num_flights = FLIGHT_SIZING_DEFAULTS['num_flights']
+    return {
+        'mode': mode,
+        'target_minutes_per_flight': max(
+            MINUTES_PER_FLIGHT_MIN, min(MINUTES_PER_FLIGHT_MAX, target_minutes),
+        ),
+        'minutes_per_heat': max(
+            MINUTES_PER_HEAT_MIN, min(MINUTES_PER_HEAT_MAX, minutes_per_heat),
+        ),
+        'num_flights': max(FLIGHT_COUNT_MIN, min(FLIGHT_COUNT_MAX, saved_num_flights)),
+    }
+
+
+def _persist_flight_sizing_config(tournament, mode, target_minutes, minutes_per_heat, num_flights):
+    """Persist operator's flight sizing choices to schedule_config."""
+    cfg = tournament.get_schedule_config() or {}
+    cfg['flight_sizing_mode'] = mode
+    cfg['target_minutes_per_flight'] = int(target_minutes)
+    cfg['minutes_per_heat'] = float(minutes_per_heat)
+    cfg['num_flights'] = int(num_flights)
+    tournament.set_schedule_config(cfg)
+
+
+def _compute_num_flights_from_duration(total_heats, minutes_per_heat, target_minutes_per_flight):
+    """Derive num_flights from target flight duration.
+
+    Returns a clamped value in [FLIGHT_COUNT_MIN, FLIGHT_COUNT_MAX]. A
+    ``clamped`` flag indicates the ideal calculation exceeded the range so
+    the caller can surface a warning.
+    """
+    import math as _math
+    if total_heats <= 0 or minutes_per_heat <= 0 or target_minutes_per_flight <= 0:
+        return FLIGHT_COUNT_MIN, False
+    ideal = _math.ceil((total_heats * minutes_per_heat) / target_minutes_per_flight)
+    clamped_value = max(FLIGHT_COUNT_MIN, min(FLIGHT_COUNT_MAX, ideal))
+    return clamped_value, clamped_value != ideal
+
+
 @scheduling_bp.route('/<int:tournament_id>/flights/build', methods=['GET', 'POST'])
 def build_flights(tournament_id):
     """Build flights for pro competition."""
@@ -128,12 +211,73 @@ def build_flights(tournament_id):
     if request.method == 'POST':
         from services.flight_builder import build_pro_flights
 
+        # Phase 3: accept either 'minutes' (duration-driven) or 'count'
+        # (operator-specified). Persist choices to schedule_config so the
+        # form pre-fills on the next visit.
+        sizing_mode_raw = (request.form.get('flight_sizing_mode') or '').strip().lower()
+        if sizing_mode_raw not in VALID_FLIGHT_SIZING_MODES:
+            sizing_mode_raw = FLIGHT_SIZING_DEFAULTS['mode']
+
         try:
-            num_flights = int(request.form.get('num_flights', 0))
-            if num_flights < 1:
-                num_flights = None
+            form_target_minutes = int(request.form.get('target_minutes_per_flight',
+                                                       FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']))
         except (TypeError, ValueError):
-            num_flights = None
+            form_target_minutes = FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']
+        form_target_minutes = max(
+            MINUTES_PER_FLIGHT_MIN, min(MINUTES_PER_FLIGHT_MAX, form_target_minutes),
+        )
+
+        try:
+            form_minutes_per_heat = float(request.form.get('minutes_per_heat',
+                                                           FLIGHT_SIZING_DEFAULTS['minutes_per_heat']))
+        except (TypeError, ValueError):
+            form_minutes_per_heat = FLIGHT_SIZING_DEFAULTS['minutes_per_heat']
+        form_minutes_per_heat = max(
+            MINUTES_PER_HEAT_MIN, min(MINUTES_PER_HEAT_MAX, form_minutes_per_heat),
+        )
+
+        try:
+            form_num_flights = int(request.form.get('num_flights', 0))
+        except (TypeError, ValueError):
+            form_num_flights = 0
+
+        # Total heats available for the duration calc (pro run_number=1 excluding axe).
+        pro_heats_for_calc = Heat.query.join(Event).filter(
+            Event.tournament_id == tournament_id,
+            Event.event_type == 'pro',
+            Event.name != 'Partnered Axe Throw',
+            Heat.run_number == 1,
+        ).count()
+
+        if sizing_mode_raw == FLIGHT_SIZING_MODE_MINUTES:
+            computed_num_flights, was_clamped = _compute_num_flights_from_duration(
+                pro_heats_for_calc, form_minutes_per_heat, form_target_minutes,
+            )
+            if was_clamped and pro_heats_for_calc > 0:
+                actual_flight_minutes = int(
+                    (pro_heats_for_calc * form_minutes_per_heat) / computed_num_flights,
+                )
+                flash(
+                    f'Target {form_target_minutes} min/flight would need more than '
+                    f'{FLIGHT_COUNT_MAX} or fewer than {FLIGHT_COUNT_MIN} flights. '
+                    f'Capped at {computed_num_flights} flights — actual duration '
+                    f'~{actual_flight_minutes} min/flight.',
+                    'info',
+                )
+            num_flights = computed_num_flights if computed_num_flights >= 1 else None
+        else:  # 'count' mode
+            num_flights = form_num_flights if form_num_flights >= 1 else None
+
+        # Persist the operator's sizing choices so the form pre-fills next visit.
+        try:
+            _persist_flight_sizing_config(
+                tournament, sizing_mode_raw,
+                form_target_minutes, form_minutes_per_heat,
+                form_num_flights if form_num_flights >= FLIGHT_COUNT_MIN else FLIGHT_SIZING_DEFAULTS['num_flights'],
+            )
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
 
         # Guard: abort if no pro heats have been generated yet
         pro_heat_count = Heat.query.join(Event).filter(
@@ -273,10 +417,19 @@ def build_flights(tournament_id):
         if e.name != 'Partnered Axe Throw'
     )
 
+    sizing = _read_flight_sizing_config(tournament)
+
     return render_template('pro/build_flights.html',
                            tournament=tournament,
                            events=pro_events,
-                           total_heats=total_heats)
+                           total_heats=total_heats,
+                           flight_sizing=sizing,
+                           flight_count_min=FLIGHT_COUNT_MIN,
+                           flight_count_max=FLIGHT_COUNT_MAX,
+                           minutes_per_flight_min=MINUTES_PER_FLIGHT_MIN,
+                           minutes_per_flight_max=MINUTES_PER_FLIGHT_MAX,
+                           minutes_per_heat_min=MINUTES_PER_HEAT_MIN,
+                           minutes_per_heat_max=MINUTES_PER_HEAT_MAX)
 
 
 # ---------------------------------------------------------------------------

--- a/templates/pro/build_flights.html
+++ b/templates/pro/build_flights.html
@@ -56,22 +56,87 @@
 
                     <form method="POST">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
                         <div class="mb-3">
-                            <label for="num_flights" class="form-label">Number of Flights</label>
+                            <label class="form-label fw-semibold">Flight Sizing</label>
+                            <div class="form-check">
+                                <input class="form-check-input" type="radio"
+                                       name="flight_sizing_mode"
+                                       id="mode_minutes"
+                                       value="minutes"
+                                       {% if flight_sizing.mode != 'count' %}checked{% endif %}>
+                                <label class="form-check-label" for="mode_minutes">
+                                    <strong>Target flight duration</strong>
+                                    <span class="text-muted d-block small">
+                                        Derive flight count from desired minutes-per-flight and average heat time.
+                                    </span>
+                                </label>
+                            </div>
+                            <div class="form-check mb-2">
+                                <input class="form-check-input" type="radio"
+                                       name="flight_sizing_mode"
+                                       id="mode_count"
+                                       value="count"
+                                       {% if flight_sizing.mode == 'count' %}checked{% endif %}>
+                                <label class="form-check-label" for="mode_count">
+                                    <strong>Fixed flight count</strong>
+                                    <span class="text-muted d-block small">
+                                        Pick a specific number of flights; heats distribute evenly.
+                                    </span>
+                                </label>
+                            </div>
+                        </div>
+
+                        {# Duration mode inputs #}
+                        <div id="duration_inputs" class="mb-3 ps-4 border-start">
+                            <div class="row g-2">
+                                <div class="col-sm-6">
+                                    <label for="target_minutes_per_flight" class="form-label small">
+                                        Minutes per flight
+                                    </label>
+                                    <input type="number" class="form-control"
+                                           id="target_minutes_per_flight"
+                                           name="target_minutes_per_flight"
+                                           value="{{ flight_sizing.target_minutes_per_flight }}"
+                                           min="{{ minutes_per_flight_min }}"
+                                           max="{{ minutes_per_flight_max }}"
+                                           step="5">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label for="minutes_per_heat" class="form-label small">
+                                        Minutes per heat (avg)
+                                    </label>
+                                    <input type="number" class="form-control"
+                                           id="minutes_per_heat"
+                                           name="minutes_per_heat"
+                                           value="{{ flight_sizing.minutes_per_heat }}"
+                                           min="{{ minutes_per_heat_min }}"
+                                           max="{{ minutes_per_heat_max }}"
+                                           step="0.5">
+                                </div>
+                            </div>
+                            <small class="text-muted d-block mt-1">
+                                Estimated result:
+                                <span id="duration_estimate_flights" class="fw-semibold">--</span> flights
+                                from <span class="fw-semibold">{{ total_heats }}</span> total heats.
+                            </small>
+                        </div>
+
+                        {# Count mode inputs #}
+                        <div id="count_inputs" class="mb-3 ps-4 border-start">
+                            <label for="num_flights" class="form-label small">Number of Flights</label>
                             <select class="form-select" id="num_flights" name="num_flights">
-                                {% for n in range(2, 11) %}
-                                <option value="{{ n }}" {% if n == 4 %}selected{% endif %}>{{ n }} flights</option>
+                                {% for n in range(flight_count_min, flight_count_max + 1) %}
+                                <option value="{{ n }}" {% if n == flight_sizing.num_flights %}selected{% endif %}>{{ n }} flights</option>
                                 {% endfor %}
                             </select>
-                            <div class="mt-2 p-2 rounded" style="background: var(--bs-secondary-bg, #f8f9fa);">
-                                <span class="text-muted small">Estimated heats per flight: </span>
-                                <strong id="heats_estimate">--</strong>
-                                <span class="text-muted small" id="total_heats_note">
-                                    {% if total_heats %}({{ total_heats }} total heats to distribute){% endif %}
-                                </span>
-                            </div>
-                            <small class="text-muted">Heats are distributed evenly. The system interleaves events for crowd variety.</small>
+                            <small class="text-muted d-block mt-1">
+                                Estimated:
+                                <span id="count_estimate_heats" class="fw-semibold">--</span> heats per flight,
+                                ~<span id="count_estimate_minutes" class="fw-semibold">--</span> minutes per flight.
+                            </small>
                         </div>
+
                         <div class="form-check mb-3">
                             <input class="form-check-input" type="checkbox" id="run_async" name="run_async" value="1">
                             <label class="form-check-label" for="run_async">
@@ -92,22 +157,68 @@
                     </form>
 
                     <script>
+                    // Nonce stamped by app.py:_inject_csp_nonce after_request hook.
                     (function () {
                         var totalHeats = {{ total_heats | default(0) }};
-                        var select = document.getElementById('num_flights');
-                        var estimate = document.getElementById('heats_estimate');
+                        var minFlights = {{ flight_count_min }};
+                        var maxFlights = {{ flight_count_max }};
 
-                        function update() {
-                            var n = parseInt(select.value, 10);
-                            if (!n || n < 1 || totalHeats === 0) {
-                                estimate.textContent = '--';
+                        var modeMinutes = document.getElementById('mode_minutes');
+                        var modeCount = document.getElementById('mode_count');
+                        var durationInputs = document.getElementById('duration_inputs');
+                        var countInputs = document.getElementById('count_inputs');
+                        var targetMinsEl = document.getElementById('target_minutes_per_flight');
+                        var minsPerHeatEl = document.getElementById('minutes_per_heat');
+                        var numFlightsEl = document.getElementById('num_flights');
+                        var durEstFlights = document.getElementById('duration_estimate_flights');
+                        var countEstHeats = document.getElementById('count_estimate_heats');
+                        var countEstMinutes = document.getElementById('count_estimate_minutes');
+
+                        function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+
+                        function updateDuration() {
+                            var tm = parseFloat(targetMinsEl.value);
+                            var mh = parseFloat(minsPerHeatEl.value);
+                            if (!totalHeats || !tm || !mh) {
+                                durEstFlights.textContent = '--';
+                                return;
+                            }
+                            var ideal = Math.ceil((totalHeats * mh) / tm);
+                            durEstFlights.textContent = clamp(ideal, minFlights, maxFlights);
+                        }
+
+                        function updateCount() {
+                            var n = parseInt(numFlightsEl.value, 10);
+                            var mh = parseFloat(minsPerHeatEl.value) || 5.5;
+                            if (!n || !totalHeats) {
+                                countEstHeats.textContent = '--';
+                                countEstMinutes.textContent = '--';
+                                return;
+                            }
+                            var heatsPerFlight = Math.ceil(totalHeats / n);
+                            countEstHeats.textContent = '~' + heatsPerFlight;
+                            countEstMinutes.textContent = Math.round(heatsPerFlight * mh);
+                        }
+
+                        function showMode() {
+                            if (modeCount.checked) {
+                                durationInputs.style.display = 'none';
+                                countInputs.style.display = '';
                             } else {
-                                estimate.textContent = '~' + Math.ceil(totalHeats / n);
+                                durationInputs.style.display = '';
+                                countInputs.style.display = 'none';
                             }
                         }
 
-                        select.addEventListener('change', update);
-                        update();
+                        modeMinutes.addEventListener('change', showMode);
+                        modeCount.addEventListener('change', showMode);
+                        targetMinsEl.addEventListener('input', updateDuration);
+                        minsPerHeatEl.addEventListener('input', function () { updateDuration(); updateCount(); });
+                        numFlightsEl.addEventListener('change', updateCount);
+
+                        showMode();
+                        updateDuration();
+                        updateCount();
                     })();
                     </script>
                     {% else %}

--- a/tests/test_flight_sizing_modes.py
+++ b/tests/test_flight_sizing_modes.py
@@ -1,0 +1,404 @@
+"""
+Phase 3: flight sizing form supports 'minutes' (duration-driven) and 'count'
+(operator-specified) modes. Operator choices persist to schedule_config.
+
+Covers what was originally proposed as 4 separate files:
+  * test_flight_sizing_mode_minutes.py
+  * test_flight_sizing_mode_count.py
+  * test_flight_sizing_config_persistence.py
+  * test_flight_sizing_clamp.py
+Consolidated into one file since every test uses the same seed + route client.
+
+Run:  pytest tests/test_flight_sizing_modes.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    import os
+
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        _seed_admin()
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+def _seed_admin():
+    """Create an admin user so the build_flights route (judge-gated) is reachable."""
+    from models.user import User
+
+    if not User.query.filter_by(username="sizing_admin").first():
+        u = User(username="sizing_admin", role="admin")
+        u.set_password("sizing_pass")
+        _db.session.add(u)
+        _db.session.commit()
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture
+def client(app):
+    """Authenticated test client (logged in as sizing_admin)."""
+    c = app.test_client()
+    c.post(
+        "/auth/login",
+        data={"username": "sizing_admin", "password": "sizing_pass"},
+        follow_redirects=True,
+    )
+    return c
+
+
+def _make_tournament(session, name="Flight Sizing Test 2026"):
+    from models import Tournament
+
+    t = Tournament(name=name, year=2026, status="pro_active")
+    session.add(t)
+    session.flush()
+    return t
+
+
+def _make_pro_event(session, tournament, name, stand_type, gender=None, max_stands=4):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type="pro",
+        gender=gender,
+        scoring_type="time",
+        scoring_order="lowest_wins",
+        stand_type=stand_type,
+        max_stands=max_stands,
+    )
+    session.add(e)
+    session.flush()
+    return e
+
+
+def _make_heat(session, event, heat_number, run_number=1):
+    from models import Heat
+
+    h = Heat(event_id=event.id, heat_number=heat_number, run_number=run_number)
+    h.set_competitors([])
+    session.add(h)
+    session.flush()
+    return h
+
+
+def _make_pro(session, tournament, name, gender="M"):
+    from models import ProCompetitor
+
+    c = ProCompetitor(
+        tournament_id=tournament.id, name=name, gender=gender, status="active"
+    )
+    session.add(c)
+    session.flush()
+    return c
+
+
+def _seed(session, pro_heat_count=60):
+    """Seed enough pro heats across several events so flight sizing math is meaningful."""
+    t = _make_tournament(session)
+    # Create competitors so heats aren't empty (not strictly required for sizing math).
+    pros = [_make_pro(session, t, f"P{i}") for i in range(1, 5)]  # noqa: F841
+    # Distribute heats across three events so the builder can actually make multi-event flights.
+    ev_sb = _make_pro_event(session, t, "Springboard", "springboard")
+    ev_uh = _make_pro_event(
+        session, t, "Underhand", "underhand", gender="M", max_stands=5
+    )
+    ev_op = _make_pro_event(session, t, "Obstacle Pole", "obstacle_pole")
+
+    heats_per_event = pro_heat_count // 3
+    for n in range(1, heats_per_event + 1):
+        _make_heat(session, ev_sb, n)
+        _make_heat(session, ev_uh, n)
+        _make_heat(session, ev_op, n)
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the compute function (unit-level, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeNumFlights:
+    def test_60_heats_at_5_5_over_60_min(self):
+        """60 heats × 5.5 min / 60 min target = 6 flights."""
+        from routes.scheduling.flights import _compute_num_flights_from_duration
+
+        result, clamped = _compute_num_flights_from_duration(60, 5.5, 60)
+        assert result == 6
+        assert not clamped
+
+    def test_30_heats_at_5_5_over_60_min(self):
+        """30 × 5.5 / 60 = 2.75 → ceil 3 flights."""
+        from routes.scheduling.flights import _compute_num_flights_from_duration
+
+        result, _ = _compute_num_flights_from_duration(30, 5.5, 60)
+        assert result == 3
+
+    def test_clamp_upper(self):
+        """200 × 5.5 / 30 = 36.67 → ceil 37 → clamped to 10."""
+        from routes.scheduling.flights import _compute_num_flights_from_duration
+
+        result, clamped = _compute_num_flights_from_duration(200, 5.5, 30)
+        assert result == 10
+        assert clamped
+
+    def test_clamp_lower(self):
+        """1 heat × 5.5 / 180 = 0.03 → ceil 1 → clamped to 2."""
+        from routes.scheduling.flights import _compute_num_flights_from_duration
+
+        result, clamped = _compute_num_flights_from_duration(1, 5.5, 180)
+        assert result == 2
+        assert clamped
+
+    def test_zero_heats_degrades_gracefully(self):
+        from routes.scheduling.flights import _compute_num_flights_from_duration
+
+        result, _ = _compute_num_flights_from_duration(0, 5.5, 60)
+        assert result == 2
+
+    def test_zero_minutes_per_heat_degrades_gracefully(self):
+        from routes.scheduling.flights import _compute_num_flights_from_duration
+
+        result, _ = _compute_num_flights_from_duration(60, 0, 60)
+        assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# Config persistence
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPersistence:
+    def test_roundtrip_writes_and_reads(self, db_session):
+        from routes.scheduling.flights import (
+            _persist_flight_sizing_config,
+            _read_flight_sizing_config,
+        )
+
+        t = _seed(db_session, pro_heat_count=30)
+
+        _persist_flight_sizing_config(t, "minutes", 90, 6.5, 5)
+        db_session.flush()
+
+        cfg = _read_flight_sizing_config(t)
+        assert cfg["mode"] == "minutes"
+        assert cfg["target_minutes_per_flight"] == 90
+        assert cfg["minutes_per_heat"] == 6.5
+        assert cfg["num_flights"] == 5
+
+    def test_defaults_when_missing(self, db_session):
+        from routes.scheduling.flights import (
+            FLIGHT_SIZING_DEFAULTS,
+            _read_flight_sizing_config,
+        )
+
+        t = _seed(db_session, pro_heat_count=30)
+        cfg = _read_flight_sizing_config(t)
+        assert cfg["mode"] == FLIGHT_SIZING_DEFAULTS["mode"]
+        assert (
+            cfg["target_minutes_per_flight"]
+            == FLIGHT_SIZING_DEFAULTS["target_minutes_per_flight"]
+        )
+        assert cfg["minutes_per_heat"] == FLIGHT_SIZING_DEFAULTS["minutes_per_heat"]
+
+    def test_clamps_out_of_range_persisted_values(self, db_session):
+        from routes.scheduling.flights import _read_flight_sizing_config
+
+        t = _seed(db_session, pro_heat_count=30)
+        t.set_schedule_config(
+            {
+                "flight_sizing_mode": "minutes",
+                "target_minutes_per_flight": 999,  # way over max
+                "minutes_per_heat": -5.0,  # under min
+                "num_flights": 99,  # over max
+            }
+        )
+        db_session.flush()
+
+        cfg = _read_flight_sizing_config(t)
+        assert 30 <= cfg["target_minutes_per_flight"] <= 180
+        assert 1.0 <= cfg["minutes_per_heat"] <= 15.0
+        assert 2 <= cfg["num_flights"] <= 10
+
+    def test_invalid_mode_falls_back(self, db_session):
+        from routes.scheduling.flights import _read_flight_sizing_config
+
+        t = _seed(db_session, pro_heat_count=30)
+        t.set_schedule_config({"flight_sizing_mode": "nonsense"})
+        db_session.flush()
+        cfg = _read_flight_sizing_config(t)
+        assert cfg["mode"] == "minutes"  # default
+
+
+# ---------------------------------------------------------------------------
+# HTTP — POST /scheduling/<tid>/flights/build
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFlightsRouteModes:
+    def _post_build(self, client, t_id, **form):
+        form.setdefault("csrf_token", "x")
+        return client.post(
+            f"/scheduling/{t_id}/flights/build",
+            data=form,
+            follow_redirects=False,
+        )
+
+    def test_minutes_mode_posts_and_persists(self, db_session, client):
+        from routes.scheduling.flights import _read_flight_sizing_config
+
+        t = _seed(db_session, pro_heat_count=30)
+        _db.session.commit()  # POST handler needs data visible on a fresh session
+
+        resp = self._post_build(
+            client,
+            t.id,
+            flight_sizing_mode="minutes",
+            target_minutes_per_flight="60",
+            minutes_per_heat="5.5",
+            num_flights="4",
+        )
+        assert resp.status_code in (302, 303), resp.data[:200]
+
+        from models import Tournament
+
+        t_reloaded = Tournament.query.get(t.id)
+        cfg = _read_flight_sizing_config(t_reloaded)
+        assert cfg["mode"] == "minutes"
+        assert cfg["target_minutes_per_flight"] == 60
+        assert cfg["minutes_per_heat"] == 5.5
+
+    def test_count_mode_posts_and_persists(self, db_session, client):
+        from routes.scheduling.flights import _read_flight_sizing_config
+
+        t = _seed(db_session, pro_heat_count=30)
+        _db.session.commit()
+
+        resp = self._post_build(
+            client,
+            t.id,
+            flight_sizing_mode="count",
+            num_flights="3",
+            target_minutes_per_flight="60",
+            minutes_per_heat="5.5",
+        )
+        assert resp.status_code in (302, 303)
+
+        from models import Tournament
+
+        t_reloaded = Tournament.query.get(t.id)
+        cfg = _read_flight_sizing_config(t_reloaded)
+        assert cfg["mode"] == "count"
+        assert cfg["num_flights"] == 3
+
+    def test_minutes_mode_produces_reasonable_flight_count(self, db_session, client):
+        """60-heat tournament, 60 min target, 5.5 min/heat → 6 flights built."""
+        from models import Flight
+
+        t = _seed(db_session, pro_heat_count=60)
+        _db.session.commit()
+
+        resp = self._post_build(
+            client,
+            t.id,
+            flight_sizing_mode="minutes",
+            target_minutes_per_flight="60",
+            minutes_per_heat="5.5",
+        )
+        assert resp.status_code in (302, 303)
+
+        built = Flight.query.filter_by(tournament_id=t.id).count()
+        # 60 * 5.5 / 60 = 5.5 → ceil 6. Builder may clamp to fewer if per-flight
+        # heat count constraint kicks in. Accept the clamped range.
+        assert 2 <= built <= 10, f"unexpected flight count {built}"
+        assert (
+            built == 6
+        ), f"expected 6 flights for 60-heat minute-mode calc, got {built}"
+
+    def test_count_mode_builds_exact_count(self, db_session, client):
+        from models import Flight
+
+        t = _seed(db_session, pro_heat_count=30)
+        _db.session.commit()
+
+        self._post_build(
+            client,
+            t.id,
+            flight_sizing_mode="count",
+            num_flights="3",
+            target_minutes_per_flight="60",
+            minutes_per_heat="5.5",
+        )
+        built = Flight.query.filter_by(tournament_id=t.id).count()
+        assert built == 3
+
+
+# ---------------------------------------------------------------------------
+# Clamp behaviour via HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestSizingClamp:
+    def test_extreme_duration_inputs_clamp_without_500(self, db_session, client):
+        t = _seed(db_session, pro_heat_count=20)
+        _db.session.commit()
+
+        # Target way too low — would compute 20*5.5/10 = 11 → clamp to 10.
+        resp = client.post(
+            f"/scheduling/{t.id}/flights/build",
+            data={
+                "csrf_token": "x",
+                "flight_sizing_mode": "minutes",
+                "target_minutes_per_flight": "10",
+                "minutes_per_heat": "5.5",
+                "num_flights": "4",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code in (302, 303), f"clamp path returned {resp.status_code}"
+
+    def test_negative_inputs_coerce_to_bounds(self, db_session, client):
+        from routes.scheduling.flights import _read_flight_sizing_config
+
+        t = _seed(db_session, pro_heat_count=20)
+        _db.session.commit()
+
+        client.post(
+            f"/scheduling/{t.id}/flights/build",
+            data={
+                "csrf_token": "x",
+                "flight_sizing_mode": "minutes",
+                "target_minutes_per_flight": "-999",
+                "minutes_per_heat": "-5",
+                "num_flights": "-3",
+            },
+            follow_redirects=False,
+        )
+        from models import Tournament
+
+        t_reloaded = Tournament.query.get(t.id)
+        cfg = _read_flight_sizing_config(t_reloaded)
+        assert 30 <= cfg["target_minutes_per_flight"] <= 180
+        assert 1.0 <= cfg["minutes_per_heat"] <= 15.0


### PR DESCRIPTION
## Phase 3 of 5 — flight fixes plan (see [docs/FLIGHT_FIXES_RECON.md](docs/FLIGHT_FIXES_RECON.md))

### Problem (Recon Issue 5)

Operators could only size Saturday flights by picking a fixed number from a 2-10 dropdown (default 4). The real constraint is target flight duration (~60 min), and translating that into a flight count was a mental-math chore. No per-tournament memory either — the dropdown reset to 4 every visit.

### Fix

Two modes on the build-flights form:
- **Target flight duration** (default): minutes-per-flight + avg minutes-per-heat → compute num_flights = ceil(total × minsPerHeat / target), clamped to [2, 10].
- **Fixed flight count**: pick num_flights directly (preserves pre-phase-3 behaviour).

Choices persist to `Tournament.schedule_config` (no new DB column) and pre-fill the form on every subsequent GET.

### Files

- `routes/scheduling/flights.py` — helpers `_read_flight_sizing_config`, `_persist_flight_sizing_config`, `_compute_num_flights_from_duration` + constants. POST handler re-wired to read mode + both input groups.
- `templates/pro/build_flights.html` — radio toggle + duration + count input groups. Live JS estimates (flights from duration, heats/minutes from count).
- `tests/test_flight_sizing_modes.py` — 16 tests across 4 classes, consolidated from 4 planned files.

### Acceptance

- 60 heats × 5.5 min / 60 min target = **6 flights** computed correctly.
- Count mode with `num_flights=3` still builds exactly 3 flights.
- Extreme inputs clamp to [2, 10] with a flash info, no 500s.
- Saved choices round-trip through schedule_config.

### Regression

- 3227 passed, 0 failed (16 new + all prior).
- Smoke test for `/scheduling/<tid>/flights/build` still renders (inline script relies on `_inject_csp_nonce` after_request hook — same pattern as friday_feature_print.html).

### Test plan

- [x] Unit + integration tests green locally
- [x] Ruff clean
- [ ] CI green (triggers on push)
- [ ] Manual verify on Tournament 2: load build page, toggle modes, change inputs, submit, reload to confirm pre-fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)