### PR TITLE
feat(relay): place Pro-Am Relay at end of final flight + teams sheet [Phase 4/5]

### DIFF
--- a/routes/scheduling/events.py
+++ b/routes/scheduling/events.py
@@ -50,6 +50,8 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
     action = request.form.get('action', '')
     tournament_id = tournament.id
 
+    from services.flight_builder import integrate_proam_relay_into_final_flight
+
     if action == 'generate_all':
         try:
             _generate_all_heats(tournament, generate_event_heats)
@@ -57,6 +59,10 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
             flights = _build_pro_flights_if_possible(tournament, build_pro_flights)
             if flights is not None:
                 flash(f'Built {flights} pro flight(s).', 'success')
+                # Phase 4: relay BEFORE spillover so Chokerman Run 2 closes.
+                relay_result = integrate_proam_relay_into_final_flight(tournament)
+                if relay_result.get('placed'):
+                    flash('Pro-Am Relay placed in the final flight.', 'success')
                 integration = integrate_college_spillover_into_flights(tournament, saturday_college_event_ids)
                 if integration['integrated_heats'] > 0:
                     db.session.commit()
@@ -79,6 +85,9 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
             flights = _build_pro_flights_if_possible(tournament, build_pro_flights)
             if flights is not None:
                 flash(f'Rebuilt {flights} pro flight(s).', 'success')
+                relay_result = integrate_proam_relay_into_final_flight(tournament)
+                if relay_result.get('placed'):
+                    flash('Pro-Am Relay placed in the final flight.', 'success')
                 integration = integrate_college_spillover_into_flights(tournament, saturday_college_event_ids)
                 if integration['integrated_heats'] > 0:
                     db.session.commit()
@@ -97,6 +106,9 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
 
     elif action == 'integrate_spillover':
         try:
+            relay_result = integrate_proam_relay_into_final_flight(tournament)
+            if relay_result.get('placed'):
+                flash('Pro-Am Relay placed in the final flight.', 'success')
             integration = integrate_college_spillover_into_flights(tournament, saturday_college_event_ids)
             db.session.commit()
             flash(integration['message'], 'info')

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -25,6 +25,7 @@ def one_click_generate(tournament_id):
     from services.flight_builder import (
         build_pro_flights,
         integrate_college_spillover_into_flights,
+        integrate_proam_relay_into_final_flight,
     )
     from services.heat_generator import generate_event_heats
     from services.saw_block_assignment import trigger_saw_block_recompute
@@ -39,6 +40,10 @@ def one_click_generate(tournament_id):
         flights_built = _build_pro_flights_if_possible(tournament, build_pro_flights)
         if flights_built is not None:
             flash(f'Built {flights_built} pro flight(s).', 'success')
+            # Phase 4: Relay BEFORE spillover so Chokerman Run 2 still closes.
+            relay_result = integrate_proam_relay_into_final_flight(tournament)
+            if relay_result.get('placed'):
+                flash('Pro-Am Relay placed in the final flight.', 'success')
             integration = integrate_college_spillover_into_flights(
                 tournament, saturday_college_event_ids,
             )
@@ -324,14 +329,21 @@ def build_flights(tournament_id):
 
         if request.form.get('run_async') == '1':
             def _build_flights_async(target_tournament_id: int, requested_num_flights: int | None):
-                """Build pro flights AND chain spillover integration atomically.
+                """Build pro flights + relay + spillover atomically.
 
-                Both operations run with commit=False; a single db.session.commit()
-                at the end makes the pair atomic. If spillover integration raises,
-                the entire flight build rolls back — no orphaned Chokerman Run 2
-                or selected saturday spillover heats with flight_id=NULL.
+                All three operations run with commit=False; a single db.session.commit()
+                at the end makes the chain atomic. If any step raises, the entire
+                build rolls back — no orphaned relay heat, no orphaned Chokerman
+                Run 2, no orphaned saturday_college_event_ids heats.
+
+                Order: build → relay → spillover. Relay lands first at the end of
+                the last flight; Chokerman Run 2 then appends AFTER the relay so
+                the show closes with Chokerman (FlightLogic.md §4.1).
                 """
-                from services.flight_builder import integrate_college_spillover_into_flights
+                from services.flight_builder import (
+                    integrate_college_spillover_into_flights,
+                    integrate_proam_relay_into_final_flight,
+                )
                 target = Tournament.query.get(target_tournament_id)
                 if not target:
                     raise RuntimeError(f'Tournament {target_tournament_id} not found.')
@@ -340,6 +352,9 @@ def build_flights(tournament_id):
                         target,
                         num_flights=requested_num_flights,
                         commit=False,
+                    )
+                    relay_result = integrate_proam_relay_into_final_flight(
+                        target, commit=False,
                     )
                     saturday_college_event_ids = [
                         int(i) for i in
@@ -356,6 +371,11 @@ def build_flights(tournament_id):
                     raise
                 return {
                     'flights_built': flights_built,
+                    'relay': {
+                        'placed': relay_result.get('placed', False),
+                        'reason': relay_result.get('reason'),
+                        'team_count': relay_result.get('team_count', 0),
+                    },
                     'spillover': {
                         'integrated_heats': integration.get('integrated_heats', 0),
                         'events': integration.get('events', 0),
@@ -382,10 +402,17 @@ def build_flights(tournament_id):
             flash(text.FLASH['flights_built'].format(num_flights=built), 'success')
 
             # build_pro_flights wipes every Heat.flight_id (including college
-            # spillover that was previously integrated). Chain the spillover
-            # integration so "Rebuild Flights Only" doesn't silently orphan
-            # Saturday-spillover heats. Mirrors one_click_generate.
-            from services.flight_builder import integrate_college_spillover_into_flights
+            # spillover that was previously integrated). Chain the relay + spillover
+            # so "Rebuild Flights Only" doesn't silently orphan them.
+            # Order: relay BEFORE spillover so Chokerman Run 2 lands last.
+            from services.flight_builder import (
+                integrate_college_spillover_into_flights,
+                integrate_proam_relay_into_final_flight,
+            )
+            relay_result = integrate_proam_relay_into_final_flight(tournament)
+            if relay_result.get('placed'):
+                flash('Pro-Am Relay placed in the final flight.', 'success')
+
             db_config = tournament.get_schedule_config() or {}
             saturday_college_event_ids = [
                 int(i) for i in db_config.get('saturday_college_event_ids', [])

--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -329,6 +329,46 @@ def heat_sheets(tournament_id):
     )
 
 
+@scheduling_bp.route("/<int:tournament_id>/relay-teams-sheet")
+@record_print("relay_teams_sheet")
+def relay_teams_sheet(tournament_id):
+    """Printable Pro-Am Relay drawn-teams sheet.
+
+    Phase 4 addition: the relay is placed in the final flight as a pseudo-heat
+    (see services.flight_builder.integrate_proam_relay_into_final_flight).
+    The teams themselves live in Event.event_state / payouts JSON. This route
+    renders the drawn teams in a landscape, large-font, one-team-per-row
+    layout suitable for taping to a wall on show day.
+
+    Uses services.print_response.weasyprint_or_html so Railway deploys without
+    cairo/pango fall back to HTML (Content-Type: text/html) while still showing
+    a PDF filename hint.
+    """
+    from datetime import datetime
+
+    from services.print_response import weasyprint_or_html
+    from services.proam_relay import ProAmRelay
+
+    tournament = Tournament.query.get_or_404(tournament_id)
+    relay = ProAmRelay(tournament)
+    state = relay.relay_data or {}
+    teams = state.get("teams") or []
+    drawn = state.get("status") == "drawn" and bool(teams)
+
+    html = render_template(
+        "scheduling/relay_teams_sheet_print.html",
+        tournament=tournament,
+        teams=teams,
+        drawn=drawn,
+        now=datetime.utcnow(),
+    )
+    safe_name = (
+        f"{tournament.name}_{tournament.year}_relay_teams"
+        .replace(" ", "_").replace("/", "-")
+    )
+    return weasyprint_or_html(html, safe_name)
+
+
 @scheduling_bp.route("/<int:tournament_id>/day-schedule/print")
 @record_print("day_schedule")
 def day_schedule_print(tournament_id):

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -1323,6 +1323,99 @@ def integrate_college_spillover_into_flights(
     }
 
 
+def integrate_proam_relay_into_final_flight(tournament: Tournament, commit: bool = True) -> dict:
+    """
+    Place a single pseudo-Heat representing Pro-Am Relay at the end of the
+    final flight.
+
+    Phase 4 of the flight-fixes plan. Pro-Am Relay has no snake-draft heats —
+    state lives in Event.event_state / Event.payouts as a JSON blob managed
+    by services.proam_relay.ProAmRelay. This function synthesises a single
+    Heat row so heat-sheet rendering can show a "PRO-AM RELAY" card in the
+    final flight without inventing new rendering plumbing.
+
+    Ordering: chain BEFORE integrate_college_spillover_into_flights so the
+    Chokerman Run 2 closer lands AFTER the relay block — preserving
+    FlightLogic.md §4.1 (Chokerman as show climax).
+
+    Idempotent: wipes any existing Heat rows for the relay event before
+    inserting a fresh pseudo-heat, so repeated calls don't duplicate.
+
+    Args:
+        tournament: Tournament to place the relay into.
+        commit: When True (default), commit the transaction. When False,
+            flush only — used inside the async-chain atomic sequence.
+
+    Returns:
+        dict with:
+            placed (bool), heat_id (int | None), flight_id (int | None),
+            team_count (int), reason (str, only when placed=False).
+    """
+    from services.proam_relay import ProAmRelay
+
+    relay_event = Event.query.filter_by(
+        tournament_id=tournament.id, name='Pro-Am Relay',
+    ).first()
+    if not relay_event:
+        return {'placed': False, 'reason': 'no_relay_event', 'team_count': 0}
+
+    # ProAmRelay.__init__(self, tournament) — takes Tournament, not Event.
+    # State is loaded into self.relay_data during __init__ (no public get_state()).
+    relay = ProAmRelay(tournament)
+    state = relay.relay_data or {}
+    teams = state.get('teams') or []
+    status = state.get('status')
+    if status != 'drawn' or not teams:
+        return {'placed': False, 'reason': 'not_drawn', 'team_count': 0}
+
+    # Idempotency: wipe any existing relay Heat rows + their HeatAssignments
+    # so repeated rebuilds don't duplicate the pseudo-heat.
+    existing_heat_ids = [
+        h.id for h in Heat.query
+        .filter_by(event_id=relay_event.id)
+        .with_entities(Heat.id)
+        .all()
+    ]
+    if existing_heat_ids:
+        HeatAssignment.query.filter(
+            HeatAssignment.heat_id.in_(existing_heat_ids),
+        ).delete(synchronize_session=False)
+        Heat.query.filter(Heat.id.in_(existing_heat_ids)).delete(
+            synchronize_session=False,
+        )
+        db.session.flush()
+
+    flights = Flight.query.filter_by(tournament_id=tournament.id).order_by(
+        Flight.flight_number,
+    ).all()
+    if not flights:
+        return {'placed': False, 'reason': 'no_flights', 'team_count': len(teams)}
+    last_flight = flights[-1]
+
+    heat = Heat(
+        event_id=relay_event.id,
+        heat_number=1,
+        run_number=1,
+        flight_id=last_flight.id,
+        flight_position=_next_flight_position(last_flight.id),
+        status='pending',
+    )
+    heat.set_competitors([])
+    db.session.add(heat)
+
+    if commit:
+        db.session.commit()
+    else:
+        db.session.flush()
+
+    return {
+        'placed': True,
+        'heat_id': heat.id,
+        'flight_id': last_flight.id,
+        'team_count': len(teams),
+    }
+
+
 # ---------------------------------------------------------------------------
 # FlightBuilder class — thin, testable wrapper around the module functions (#12)
 # ---------------------------------------------------------------------------

--- a/services/print_catalog.py
+++ b/services/print_catalog.py
@@ -225,6 +225,36 @@ def _fp_fnf(tournament, entity=None):
     return _sha1(parts)
 
 
+# --- Pro-Am Relay Teams Sheet (Phase 4) ----------------------------------
+
+
+def _status_relay_teams(tournament, entity=None):
+    """Status: relay is draw-complete iff ProAmRelay.relay_data shows drawn."""
+    from services.proam_relay import ProAmRelay
+
+    relay = ProAmRelay(tournament)
+    state = relay.relay_data or {}
+    teams = state.get("teams") or []
+    if state.get("status") == "drawn" and teams:
+        return _ok()
+    return _not_configured("Relay not drawn yet.")
+
+
+def _fp_relay_teams(tournament, entity=None):
+    """Fingerprint: relay status + member count + member IDs per team."""
+    from services.proam_relay import ProAmRelay
+
+    relay = ProAmRelay(tournament)
+    state = relay.relay_data or {}
+    teams = state.get("teams") or []
+    parts = [state.get("status") or "-"]
+    for idx, team in enumerate(teams):
+        members = team.get("members") or []
+        member_ids = ",".join(str(m.get("id", "?")) for m in members)
+        parts.append(f"t{idx}:{member_ids}")
+    return _sha1(parts)
+
+
 # --- Birling (blank bracket + seeded all) --------------------------------
 
 
@@ -521,6 +551,18 @@ PRINT_DOCUMENTS: list[PrintDoc] = [
         status_fn=_status_fnf,
         fingerprint_fn=_fp_fnf,
         description="FNF schedule as PDF download.",
+    ),
+    PrintDoc(
+        key="relay_teams_sheet",
+        label="Pro-Am Relay Teams Sheet",
+        section=SECTION_RUN_SHOW,
+        route_endpoint="scheduling.relay_teams_sheet",
+        status_fn=_status_relay_teams,
+        fingerprint_fn=_fp_relay_teams,
+        description=(
+            "Landscape roster of the drawn Pro-Am Relay teams — one team per "
+            "row for wall posting. Print after the lottery runs."
+        ),
     ),
     # --- Run Show --------------------------------------------------------
     PrintDoc(

--- a/services/schedule_generation.py
+++ b/services/schedule_generation.py
@@ -7,12 +7,21 @@ from models import Event, HeatAssignment, Tournament
 
 def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None = None) -> dict:
     """Apply the one-click preflight autofix workflow and return a summary."""
-    from services.flight_builder import integrate_college_spillover_into_flights
+    from services.flight_builder import (
+        integrate_college_spillover_into_flights,
+        integrate_proam_relay_into_final_flight,
+    )
     from services.gear_sharing import complete_one_sided_pairs, parse_all_gear_details
     from services.partner_matching import auto_assign_pro_partners
 
     heats_fixed = 0
     for event in tournament.events.all():
+        # Skip Pro-Am Relay: its pseudo-heats are synthesized by
+        # integrate_proam_relay_into_final_flight and have no HeatAssignment
+        # rows to sync. Walking them here creates empty no-op HeatAssignment
+        # writes that churn the DB for no effect.
+        if event.name == 'Pro-Am Relay':
+            continue
         for heat in event.heats.all():
             json_ids = heat.get_competitors()
             HeatAssignment.query.filter_by(heat_id=heat.id).delete()
@@ -29,6 +38,8 @@ def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None
     gear_parse_result = parse_all_gear_details(tournament)
     pairs_result = complete_one_sided_pairs(tournament)
     partner_summary = auto_assign_pro_partners(tournament)
+    # Phase 4: relay BEFORE spillover so Chokerman Run 2 still closes the show.
+    relay_result = integrate_proam_relay_into_final_flight(tournament)
     integration = integrate_college_spillover_into_flights(tournament, saturday_ids or [])
 
     return {
@@ -37,6 +48,7 @@ def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None
         'gear_pairs_completed': pairs_result['completed'],
         'partner_summary': partner_summary,
         'spillover': integration,
+        'relay': relay_result,
     }
 
 

--- a/templates/pro/flights.html
+++ b/templates/pro/flights.html
@@ -382,14 +382,17 @@
         <div class="heat-grid flight-drag-grid" data-flight-id="{{ flight.id }}">
             {% for row in fd.heats %}
             {% set is_college = row.event.event_type == 'college' %}
-            <div class="heat-tile {{ 'heat-tile-college' if is_college else '' }} {% if row.heat.status == 'completed' %}bg-light{% endif %}"
+            {% set is_relay = row.event.name == 'Pro-Am Relay' %}
+            <div class="heat-tile {{ 'heat-tile-college' if is_college else '' }} {{ 'heat-tile-relay' if is_relay else '' }} {% if row.heat.status == 'completed' %}bg-light{% endif %}"
                  data-heat-id="{{ row.heat.id }}">
                 <div class="heat-tile-header">
                     <span class="heat-tile-event">
                         <span class="heat-drag-handle" title="Drag to reorder or move to another flight">
                             <i class="bi bi-grip-vertical"></i>
                         </span>
-                        {% if is_college %}
+                        {% if is_relay %}
+                        <span class="badge-pro-label" style="background:var(--sx-amber); color:#000;">PRO-AM RELAY</span>
+                        {% elif is_college %}
                         <span class="badge-college-label">COLLEGE</span>
                         {% else %}
                         <span class="badge-pro-label">PRO</span>
@@ -398,11 +401,20 @@
                         {% if row.event.gender %}<small class="text-muted fw-normal"> ({{ 'M' if row.event.gender == 'M' else 'F' }})</small>{% endif %}
                     </span>
                     <span class="heat-tile-num">
+                        {% if not is_relay %}
                         Heat {{ row.heat.heat_number }}
                         {% if row.heat.run_number > 1 %}&nbsp;·&nbsp;Run {{ row.heat.run_number }}{% endif %}
+                        {% endif %}
                         {% if row.heat.status == 'completed' %}<i class="bi bi-check-circle-fill text-success ms-1"></i>{% endif %}
                     </span>
                 </div>
+                {% if is_relay %}
+                <div class="small text-muted" style="padding:4px 0 2px;">
+                    <i class="bi bi-people-fill text-warning me-1"></i>
+                    See the <a href="{{ url_for('scheduling.relay_teams_sheet', tournament_id=tournament.id) }}"
+                       target="_blank" rel="noopener">Relay Teams Sheet</a> for the drawn teams.
+                </div>
+                {% endif %}
                 <table class="comp-sortable"
                        data-heat-id="{{ row.heat.id }}"
                        data-event-id="{{ row.event.id }}"

--- a/templates/scheduling/relay_teams_sheet_print.html
+++ b/templates/scheduling/relay_teams_sheet_print.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Pro-Am Relay Teams — {{ tournament.name }} {{ tournament.year }}</title>
+    <style>
+        @page { size: landscape; margin: 0.5in; }
+        body {
+            font-family: "Helvetica Neue", Arial, sans-serif;
+            color: #000;
+            margin: 0;
+            padding: 0.25in;
+        }
+        h1 {
+            font-size: 34pt;
+            margin: 0 0 8pt;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+        .subtitle {
+            font-size: 13pt;
+            color: #444;
+            margin-bottom: 20pt;
+        }
+        table.teams {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 12pt;
+        }
+        table.teams td, table.teams th {
+            padding: 12pt 14pt;
+            border: 2pt solid #000;
+            vertical-align: top;
+        }
+        table.teams th {
+            background: #000;
+            color: #fff;
+            font-size: 18pt;
+            text-align: left;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+        }
+        table.teams .team-label {
+            font-weight: 800;
+            font-size: 22pt;
+            width: 18%;
+            background: #f1e7d4;
+        }
+        table.teams .members ul {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 4pt 24pt;
+            font-size: 17pt;
+        }
+        table.teams .members li {
+            padding: 2pt 0;
+        }
+        .role {
+            display: inline-block;
+            min-width: 82pt;
+            color: #666;
+            font-size: 12pt;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+        }
+        .empty-note {
+            background: #fff6e0;
+            border: 2pt dashed #c28b1a;
+            padding: 24pt;
+            margin-top: 40pt;
+            font-size: 18pt;
+            text-align: center;
+        }
+        .footer {
+            margin-top: 28pt;
+            font-size: 10pt;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+    <h1>Pro-Am Relay — Drawn Teams</h1>
+    <div class="subtitle">
+        {{ tournament.name }} &middot; {{ tournament.year }}
+        {% if drawn %}&middot; Teams drawn{% else %}&middot; Draw not complete{% endif %}
+    </div>
+
+    {% if drawn %}
+    <table class="teams">
+        <thead>
+            <tr>
+                <th style="width:18%;">Team</th>
+                <th>Members</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for team in teams %}
+            <tr>
+                <td class="team-label">Team {{ loop.index }}</td>
+                <td class="members">
+                    <ul>
+                        {% for member in team.get('members', []) %}
+                        <li>
+                            <span class="role">
+                                {% if member.get('division') == 'pro' %}PRO{% else %}COLLEGE{% endif %}
+                                {% if member.get('gender') == 'M' %}M{% elif member.get('gender') == 'F' %}F{% endif %}
+                            </span>
+                            {{ member.get('name', '—') }}
+                            {% if member.get('team_code') %}
+                            <small style="color:#666;">({{ member.get('team_code') }})</small>
+                            {% endif %}
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <div class="empty-note">
+        Pro-Am Relay teams have not been drawn yet.
+        Run the lottery from the Pro-Am Relay page, then reprint this sheet.
+    </div>
+    {% endif %}
+
+    <div class="footer">
+        Printed {{ now.strftime('%Y-%m-%d %H:%M UTC') }} &middot;
+        Teams arrange their own internal order — Partnered Sawing,
+        Standing Butcher Block, Underhand Butcher Block, Team Axe Throw.
+    </div>
+</body>
+</html>

--- a/tests/test_print_catalog.py
+++ b/tests/test_print_catalog.py
@@ -23,6 +23,7 @@ def test_catalog_has_expected_docs():
         "birling_blank",
         "gear_sharing_print",
         "pro_checkout",
+        "relay_teams_sheet",
         "college_standings",
         "all_results",
         "pro_payouts",

--- a/tests/test_proam_relay_placement.py
+++ b/tests/test_proam_relay_placement.py
@@ -1,0 +1,393 @@
+"""
+Phase 4: Pro-Am Relay placement in final flight + printable teams sheet.
+
+Consolidates the originally-planned 4 files into one:
+  * test_proam_relay_placement.py (drawn relay → one pseudo-heat in final flight)
+  * test_proam_relay_no_teams.py (undrawn → placed=False, no heat)
+  * test_proam_relay_rebuild_idempotent.py (re-run doesn't duplicate)
+  * test_relay_teams_sheet.py (print route renders with team names)
+
+Run:  pytest tests/test_proam_relay_placement.py -v
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    import os
+
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        _seed_admin()
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+def _seed_admin():
+    from models.user import User
+
+    if not User.query.filter_by(username="relay_admin").first():
+        u = User(username="relay_admin", role="admin")
+        u.set_password("relay_pass")
+        _db.session.add(u)
+        _db.session.commit()
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture
+def client(app):
+    c = app.test_client()
+    c.post(
+        "/auth/login",
+        data={"username": "relay_admin", "password": "relay_pass"},
+        follow_redirects=True,
+    )
+    return c
+
+
+def _make_tournament(session, name="Relay Placement 2026"):
+    from models import Tournament
+
+    t = Tournament(name=name, year=2026, status="pro_active")
+    session.add(t)
+    session.flush()
+    return t
+
+
+def _make_pro_event(session, tournament, name, stand_type, gender=None, max_stands=4):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type="pro",
+        gender=gender,
+        scoring_type="time",
+        scoring_order="lowest_wins",
+        stand_type=stand_type,
+        max_stands=max_stands,
+    )
+    session.add(e)
+    session.flush()
+    return e
+
+
+def _make_heat(session, event, heat_number, run_number=1):
+    from models import Heat
+
+    h = Heat(event_id=event.id, heat_number=heat_number, run_number=run_number)
+    h.set_competitors([])
+    session.add(h)
+    session.flush()
+    return h
+
+
+def _make_pro(session, tournament, name, gender="M"):
+    from models import ProCompetitor
+
+    c = ProCompetitor(
+        tournament_id=tournament.id, name=name, gender=gender, status="active"
+    )
+    session.add(c)
+    session.flush()
+    return c
+
+
+def _seed_with_flights(session, with_relay_event=True, with_teams=False):
+    """Tournament with 2 pro flights and (optionally) a drawn Pro-Am Relay."""
+    from models import Event
+    from services.flight_builder import build_pro_flights
+
+    t = _make_tournament(session)
+    pros = [_make_pro(session, t, f"Pro {i}") for i in range(1, 7)]
+    ev_sb = _make_pro_event(session, t, "Springboard", "springboard")
+    ev_uh = _make_pro_event(
+        session, t, "Underhand", "underhand", gender="M", max_stands=5
+    )
+    for n in range(1, 3):
+        _make_heat(session, ev_sb, n)
+        _make_heat(session, ev_uh, n)
+
+    build_pro_flights(t, num_flights=2, commit=False)
+
+    if with_relay_event:
+        relay = Event(
+            tournament_id=t.id,
+            name="Pro-Am Relay",
+            event_type="pro",
+            scoring_type="time",
+            is_partnered=True,
+            status="pending",
+        )
+        if with_teams:
+            relay_data = {
+                "status": "drawn",
+                "teams": [
+                    {
+                        "team_number": 1,
+                        "members": [
+                            {
+                                "id": pros[0].id,
+                                "name": pros[0].name,
+                                "gender": "M",
+                                "division": "pro",
+                            },
+                            {
+                                "id": pros[1].id,
+                                "name": pros[1].name,
+                                "gender": "M",
+                                "division": "pro",
+                            },
+                        ],
+                    },
+                    {
+                        "team_number": 2,
+                        "members": [
+                            {
+                                "id": pros[2].id,
+                                "name": pros[2].name,
+                                "gender": "M",
+                                "division": "pro",
+                            },
+                            {
+                                "id": pros[3].id,
+                                "name": pros[3].name,
+                                "gender": "M",
+                                "division": "pro",
+                            },
+                        ],
+                    },
+                ],
+            }
+            relay.event_state = json.dumps(relay_data)
+        else:
+            relay.event_state = json.dumps({"status": "not_drawn", "teams": []})
+        session.add(relay)
+        session.flush()
+
+    return t, pros
+
+
+# ---------------------------------------------------------------------------
+# Placement behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRelayPlacement:
+    def test_drawn_relay_places_pseudo_heat_in_final_flight(self, db_session):
+        from models import Flight, Heat
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(db_session, with_relay_event=True, with_teams=True)
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+
+        assert result["placed"] is True
+        assert result["team_count"] == 2
+        assert result["heat_id"] is not None
+
+        flights = (
+            Flight.query.filter_by(tournament_id=t.id)
+            .order_by(Flight.flight_number)
+            .all()
+        )
+        last = flights[-1]
+        assert result["flight_id"] == last.id
+
+        relay_heats = Heat.query.filter_by(id=result["heat_id"]).all()
+        assert len(relay_heats) == 1
+        assert relay_heats[0].flight_id == last.id
+        assert relay_heats[0].flight_position == (
+            Heat.query.filter_by(flight_id=last.id).count()
+        )
+
+    def test_undrawn_relay_returns_placed_false(self, db_session):
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(db_session, with_relay_event=True, with_teams=False)
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert result["placed"] is False
+        assert result["reason"] == "not_drawn"
+
+    def test_no_relay_event_returns_placed_false(self, db_session):
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(db_session, with_relay_event=False)
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert result["placed"] is False
+        assert result["reason"] == "no_relay_event"
+
+    def test_no_flights_returns_placed_false(self, db_session):
+        from models import Event
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t = _make_tournament(db_session)
+        relay = Event(
+            tournament_id=t.id,
+            name="Pro-Am Relay",
+            event_type="pro",
+            scoring_type="time",
+            is_partnered=True,
+            status="pending",
+            event_state=json.dumps(
+                {
+                    "status": "drawn",
+                    "teams": [{"team_number": 1, "members": []}],
+                }
+            ),
+        )
+        db_session.add(relay)
+        db_session.flush()
+
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert result["placed"] is False
+        assert result["reason"] == "no_flights"
+
+    def test_rebuild_is_idempotent(self, db_session):
+        """Running twice must not produce two relay heats."""
+        from models import Event, Heat
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(db_session, with_relay_event=True, with_teams=True)
+        integrate_proam_relay_into_final_flight(t, commit=False)
+        integrate_proam_relay_into_final_flight(t, commit=False)
+
+        relay_event = Event.query.filter_by(
+            tournament_id=t.id, name="Pro-Am Relay"
+        ).first()
+        relay_heats = Heat.query.filter_by(event_id=relay_event.id).all()
+        assert len(relay_heats) == 1, (
+            f"idempotency regression: got {len(relay_heats)} relay heats after "
+            "2 invocations"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Chain ordering — relay lands BEFORE Chokerman (locked decision #4)
+# ---------------------------------------------------------------------------
+
+
+class TestRelayVsChokermanOrdering:
+    def test_relay_is_before_chokerman_run2_in_last_flight(self, db_session):
+        """Chokerman Run 2 must run AFTER the relay pseudo-heat."""
+        from models import Flight, Heat
+        from services.flight_builder import (
+            integrate_college_spillover_into_flights,
+            integrate_proam_relay_into_final_flight,
+        )
+
+        t, _ = _seed_with_flights(db_session, with_relay_event=True, with_teams=True)
+
+        # Add a Chokerman college event with Run 2 heats.
+        from models import Event
+
+        chokerman = Event(
+            tournament_id=t.id,
+            name="Chokerman's Race",
+            event_type="college",
+            gender="M",
+            scoring_type="time",
+            scoring_order="lowest_wins",
+            stand_type="chokerman",
+            requires_dual_runs=True,
+        )
+        db_session.add(chokerman)
+        db_session.flush()
+        for n in range(1, 3):
+            _make_heat(db_session, chokerman, n, run_number=1)
+            _make_heat(db_session, chokerman, n, run_number=2)
+
+        # Relay FIRST, then spillover — same order as production chain.
+        integrate_proam_relay_into_final_flight(t, commit=False)
+        integrate_college_spillover_into_flights(t, college_event_ids=[], commit=False)
+
+        flights = (
+            Flight.query.filter_by(tournament_id=t.id)
+            .order_by(Flight.flight_number)
+            .all()
+        )
+        last = flights[-1]
+
+        last_flight_heats = (
+            Heat.query.filter_by(flight_id=last.id)
+            .order_by(
+                Heat.flight_position,
+            )
+            .all()
+        )
+        relay_positions = [
+            h.flight_position
+            for h in last_flight_heats
+            if h.event_id != chokerman.id
+            and Event.query.get(h.event_id).name == "Pro-Am Relay"
+        ]
+        chokerman_positions = [
+            h.flight_position for h in last_flight_heats if h.event_id == chokerman.id
+        ]
+
+        assert relay_positions, "relay heat should be in the last flight"
+        assert chokerman_positions, "chokerman run 2 heats should be in the last flight"
+        assert max(relay_positions) < min(chokerman_positions), (
+            f"Chokerman must close the show. Got relay positions {relay_positions}, "
+            f"chokerman positions {chokerman_positions}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Printable teams sheet
+# ---------------------------------------------------------------------------
+
+
+class TestRelayTeamsSheetRoute:
+    def test_renders_200_when_drawn(self, db_session, client):
+        t, pros = _seed_with_flights(db_session, with_relay_event=True, with_teams=True)
+        _db.session.commit()
+
+        resp = client.get(f"/scheduling/{t.id}/relay-teams-sheet")
+        assert resp.status_code == 200
+        assert resp.content_type.startswith(
+            ("application/pdf", "text/html")
+        ), f"unexpected content-type {resp.content_type}"
+        # If HTML fallback, team names should be in the body.
+        if "text/html" in resp.content_type:
+            body = resp.data.decode("utf-8", errors="ignore")
+            assert "Pro 1" in body
+            assert "Pro 2" in body
+            assert "Team 1" in body or "Team" in body
+
+    def test_renders_200_when_undrawn(self, db_session, client):
+        """Sheet still renders with an 'undrawn' note rather than 500."""
+        t, _ = _seed_with_flights(db_session, with_relay_event=True, with_teams=False)
+        _db.session.commit()
+
+        resp = client.get(f"/scheduling/{t.id}/relay-teams-sheet")
+        assert resp.status_code == 200
+        if "text/html" in resp.content_type:
+            body = resp.data.decode("utf-8", errors="ignore")
+            assert "not been drawn" in body.lower() or "not drawn" in body.lower()
+
+    def test_renders_200_without_relay_event(self, db_session, client):
+        t, _ = _seed_with_flights(db_session, with_relay_event=False)
+        _db.session.commit()
+
+        resp = client.get(f"/scheduling/{t.id}/relay-teams-sheet")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Phase 4 of 5 — flight fixes plan (see [docs/FLIGHT_FIXES_RECON.md](docs/FLIGHT_FIXES_RECON.md))

### Problem (Recon Issue 3)

Pro-Am Relay has no snake-draft heats — state lives in `Event.event_state` as a JSON blob. Result: it was invisible on flight sheets, with no way to see where in the show it ran or which teams were drawn.

### Fix

- Synthesised single pseudo-Heat row placed at the end of the final flight via new `integrate_proam_relay_into_final_flight()`.
- Chained BEFORE `integrate_college_spillover_into_flights` in all 5 call sites — this is **locked decision #4**: Chokerman Run 2 still closes the show (FlightLogic.md §4.1), relay runs just before it.
- New printable route `/scheduling/<tid>/relay-teams-sheet` — landscape WeasyPrint roster, one team per row, with HTML fallback for Railway.
- Distinct "PRO-AM RELAY" heat tile on the flights page (amber badge) with inline link to the teams sheet.
- Registered in the Print Hub catalog under Run Show.

### Known bugs in the original plan fixed in this PR

- `ProAmRelay(relay_event)` → `ProAmRelay(tournament)` (constructor takes Tournament).
- `relay.get_state()` → `relay.relay_data` (no public `get_state` method).
- Orphan HeatAssignment cleanup now explicitly clears HeatAssignment rows on rebuild (matches existing partnered-axe pattern).

### Test coverage

9 tests in `tests/test_proam_relay_placement.py` (consolidated from 4 planned files):

- Placement: drawn → placed, undrawn → placed=False, no event/flights → placed=False, idempotent rebuild.
- Ordering: relay `flight_position` strictly less than Chokerman Run 2 positions.
- Print route: 200 in drawn/undrawn/no-event cases via authenticated test client.

### Regression

- 3237 passed, 0 failed (9 new + all prior).
- Ruff clean.
- Print catalog registry test updated to include `relay_teams_sheet` key.

### Test plan

- [x] Unit + integration tests green locally
- [x] Ruff clean
- [ ] CI green (triggers on push)
- [ ] Manual verify: draw relay teams, rebuild flights, relay pseudo-heat appears in final flight BEFORE Chokerman Run 2; click teams-sheet link, PDF/HTML renders with drawn pairings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)