### PR TITLE
feat(springboard): LH cutter always on Stand 4 + flight contention flash [Phase 5/5]

### DIFF
--- a/FlightLogic.md
+++ b/FlightLogic.md
@@ -291,14 +291,16 @@ and one for Run 2 (`run_number=2`).
 - The scoring system records `run1_value` and `run2_value`; the best (lowest) time counts as
   `result_value`.
 
-### 5.3 Springboard Left-Hand Grouping
+### 5.3 Springboard Left-Hand Dummy (Stand 4)
 
-Left-handed springboard cutters require assignment to the same dummy. To prevent conflicts:
+Only one physical left-handed springboard dummy exists on site. The rule:
 
+- **Stand 4 is the LH dummy** (hard-coded convention — `Dummy 4` in `STAND_CONFIGS.springboard.labels`).
 - Left-handed cutters are identified via `ProCompetitor.is_left_handed_springboard`.
-- All left-handed cutters are grouped into a dedicated heat whenever capacity allows.
-- Right-handed cutters fill remaining spots using snake draft.
-- If there are no left-handed cutters, standard snake draft applies.
+- **Each heat can contain at most one LH cutter.** The heat generator spreads LH cutters one per heat (heats `0..N-1`); if `LH_count > heat_count`, overflow is placed in the final heat with an `lh_overflow` warning.
+- **Stand-4 assignment rule (Phase 5, 2026-04-22):** inside a springboard heat, an LH cutter is always assigned `stand_number=4`. The remaining cutters fill stands 1-3 in competitor-list order. If the heat has zero LH cutters, stands 1-4 are filled by list order (stand 4 is still used — it's just not LH-configured).
+- **Flight distribution:** at most one LH-containing heat per flight is preferred. The greedy flight builder penalises multiple LH heats in the same flight (`_score_ordering`). If `LH_count > flight_count`, overflow is allowed and surfaced via `get_last_lh_flight_warnings()` → operator flash: "LH SPRINGBOARD CONTENTION: Flight N contains M left-handed cutters. Consider increasing flight count — LH dummy setup cannot be shared within one flight block."
+- If there are no left-handed cutters, standard snake draft applies and stand 4 is just another RH stand.
 
 ### 5.4 Saw Stand Groups
 

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -401,6 +401,17 @@ def build_flights(tournament_id):
             db.session.commit()
             flash(text.FLASH['flights_built'].format(num_flights=built), 'success')
 
+            # Phase 5: surface LH springboard dummy contention warnings.
+            from services.flight_builder import get_last_lh_flight_warnings
+            for w in get_last_lh_flight_warnings(tournament_id):
+                flash(
+                    f"LH SPRINGBOARD CONTENTION: Flight {w['flight_number']} "
+                    f"contains {w['lh_count']} left-handed cutters. "
+                    'Consider increasing flight count — LH dummy setup '
+                    'cannot be shared within one flight block.',
+                    'warning',
+                )
+
             # build_pro_flights wipes every Heat.flight_id (including college
             # spillover that was previously integrated). Chain the relay + spillover
             # so "Rebuild Flights Only" doesn't silently orphan them.

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -33,6 +33,21 @@ PLACEMENT_MODE_ROUNDROBIN = 'roundrobin'
 PLACEMENT_MODE_CLUSTER = 'cluster'
 VALID_PLACEMENT_MODES = {PLACEMENT_MODE_ROUNDROBIN, PLACEMENT_MODE_CLUSTER}
 
+# Phase 5: track LH flight-contention warnings from the most recent
+# build_pro_flights() call so the route handler can surface them to the
+# operator via flash. Keyed by tournament.id → list of warning dicts.
+_last_lh_flight_warnings: dict[int, list[dict]] = {}
+
+
+def get_last_lh_flight_warnings(tournament_id: int) -> list[dict]:
+    """Return LH-flight-contention warnings from the most recent build for
+    the given tournament (empty list when there were none).
+
+    Warning dicts contain:
+        flight_number (int), lh_count (int)
+    """
+    return list(_last_lh_flight_warnings.get(int(tournament_id), []))
+
 # How many independent greedy passes to run; best result is kept.
 N_OPTIMIZATION_PASSES = 5
 
@@ -271,8 +286,11 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None, commit: b
         flights_created += 1
 
     # Post-slice sanity check: if any flight ended up with >1 LH-containing heat,
-    # the scoring penalty was dominated by spacing constraints.  Log a warning so
-    # the admin knows the LH dummy will be over-subscribed in those flights.
+    # the scoring penalty was dominated by spacing constraints. Log a warning so
+    # the admin knows the LH dummy will be over-subscribed in those flights,
+    # AND record the warning in _last_lh_flight_warnings so the route handler
+    # can surface it to the operator via flash message (Phase 5).
+    lh_warnings_for_tournament: list[dict] = []
     for fnum, count in lh_count_per_flight.items():
         if count > 1:
             logger.warning(
@@ -281,6 +299,14 @@ def build_pro_flights(tournament: Tournament, num_flights: int = None, commit: b
                 'Manual review recommended.',
                 fnum, count,
             )
+            lh_warnings_for_tournament.append({
+                'flight_number': fnum,
+                'lh_count': count,
+            })
+    if lh_warnings_for_tournament:
+        _last_lh_flight_warnings[tournament.id] = lh_warnings_for_tournament
+    else:
+        _last_lh_flight_warnings.pop(tournament.id, None)
 
     # Insert partnered axe heats with deterministic flight placement.
     _insert_partnered_axe_heats(created_flights, partnered_axe_heats)

--- a/services/heat_generator.py
+++ b/services/heat_generator.py
@@ -200,6 +200,47 @@ def generate_event_heats(event: Event) -> int:
                 for comp in unit:
                     heat.set_stand_assignment(comp['id'], stand_num)
                 stand_idx += 1
+        elif event.stand_type == 'springboard':
+            # Phase 5 rule: Dummy 4 is the LH-configured physical dummy. If any
+            # competitor in this springboard heat is left-handed, they get
+            # stand_number=4; others fill stands 1-3 in competitor-list order.
+            # If no LH cutter is in the heat, fall through to the default
+            # per-index assignment so stand 4 still gets used.
+            lh_comp = next((c for c in heat_competitors if c.get('is_left_handed')), None)
+            if lh_comp is not None:
+                # Surface a heat-level warning if the heat has more than one LH
+                # cutter (overflow scenario) — only the first gets stand 4, the
+                # rest fall back to list-order assignment and will physically
+                # collide. This is rare but possible if LH_count > heat_count.
+                lh_comps_in_heat = [c for c in heat_competitors if c.get('is_left_handed')]
+                if len(lh_comps_in_heat) > 1 and lh_warnings is not None:
+                    lh_warnings.append({
+                        'type': 'multiple_lh_same_heat',
+                        'heat_index': heat_num - 1,
+                        'lh_count': len(lh_comps_in_heat),
+                        'lh_names': [c.get('name', '') for c in lh_comps_in_heat],
+                    })
+                # LH cutter goes on stand 4.
+                heat.set_stand_assignment(lh_comp['id'], 4)
+                # Fill stands 1, 2, 3 for the remaining cutters in order.
+                rh_stand_idx = 0
+                rh_stands = [1, 2, 3]
+                for comp in heat_competitors:
+                    if comp['id'] == lh_comp['id']:
+                        continue
+                    stand_num = (
+                        rh_stands[rh_stand_idx]
+                        if rh_stand_idx < len(rh_stands)
+                        else rh_stand_idx + 1
+                    )
+                    heat.set_stand_assignment(comp['id'], stand_num)
+                    rh_stand_idx += 1
+            else:
+                # No LH cutter — plain per-index assignment (stand 4 may still
+                # be used by whoever lands in index 3 of heat_competitors).
+                for i, comp in enumerate(heat_competitors):
+                    stand_num = stand_numbers[i] if i < len(stand_numbers) else i + 1
+                    heat.set_stand_assignment(comp['id'], stand_num)
         else:
             for i, comp in enumerate(heat_competitors):
                 stand_num = stand_numbers[i] if i < len(stand_numbers) else i + 1

--- a/tests/test_lh_springboard_stand_4.py
+++ b/tests/test_lh_springboard_stand_4.py
@@ -1,0 +1,335 @@
+"""
+Phase 5: Pro Springboard LH cutter stand-4 assignment + flight-contention
+warning surface.
+
+Locked decisions:
+- Stand 4 is the hard-coded LH dummy.
+- Max one LH cutter per flight (already enforced by existing penalty; these
+  tests guard the rule).
+- Overflow (LH_count > flight_count) allowed, surfaces warning via
+  get_last_lh_flight_warnings().
+
+Keeps and extends the existing tests/test_flight_builder_lh_constraint.py —
+those still assert the "spread across flights" property this phase keeps.
+
+Run:  pytest tests/test_lh_springboard_stand_4.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    import os
+
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+def _make_tournament(session):
+    from models import Tournament
+
+    t = Tournament(name="LH Stand 4 Test", year=2026, status="pro_active")
+    session.add(t)
+    session.flush()
+    return t
+
+
+def _make_springboard_event(session, tournament, name="Springboard"):
+    from models import Event
+
+    e = Event(
+        tournament_id=tournament.id,
+        name=name,
+        event_type="pro",
+        scoring_type="time",
+        scoring_order="lowest_wins",
+        stand_type="springboard",
+        max_stands=4,
+    )
+    session.add(e)
+    session.flush()
+    return e
+
+
+def _make_pro_competitor(session, tournament, name, is_lh=False):
+    from models.competitor import ProCompetitor
+
+    c = ProCompetitor(
+        tournament_id=tournament.id,
+        name=name,
+        gender="M",
+        status="active",
+        is_left_handed_springboard=is_lh,
+    )
+    session.add(c)
+    session.flush()
+    return c
+
+
+def _enroll(competitor, event):
+    """Register the competitor for the event (add event name to events_entered)."""
+    import json
+
+    entered = (
+        competitor.get_events_entered()
+        if hasattr(competitor, "get_events_entered")
+        else []
+    )
+    if event.name not in entered:
+        entered.append(event.name)
+        competitor.events_entered = json.dumps(entered)
+
+
+# ---------------------------------------------------------------------------
+# Stand-4 assignment rule
+# ---------------------------------------------------------------------------
+
+
+class TestLhCutterGetsStand4:
+    def test_single_lh_in_heat_gets_stand_4(self, db_session):
+        """4-cutter heat with 1 LH competitor → LH is assigned stand 4, others 1-3."""
+        from services.heat_generator import generate_event_heats
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+        rh1 = _make_pro_competitor(db_session, t, "RH One")
+        rh2 = _make_pro_competitor(db_session, t, "RH Two")
+        rh3 = _make_pro_competitor(db_session, t, "RH Three")
+        lh = _make_pro_competitor(db_session, t, "LH One", is_lh=True)
+        for comp in (rh1, rh2, rh3, lh):
+            _enroll(comp, ev)
+        db_session.flush()
+
+        generate_event_heats(ev)
+
+        from models import Heat
+
+        heats = Heat.query.filter_by(event_id=ev.id, run_number=1).all()
+        assert heats, "expected at least 1 springboard heat"
+        found_lh_stand_4 = False
+        for h in heats:
+            assignments = h.get_stand_assignments()
+            if str(lh.id) in assignments:
+                assert assignments[str(lh.id)] == 4, (
+                    f"LH cutter {lh.name} got stand {assignments[str(lh.id)]}, "
+                    "expected 4"
+                )
+                found_lh_stand_4 = True
+                # The other 3 cutters should be on stands 1-3 (in some order).
+                other_stands = sorted(
+                    v for k, v in assignments.items() if k != str(lh.id)
+                )
+                assert other_stands == [
+                    1,
+                    2,
+                    3,
+                ], f"other cutters got stands {other_stands}, expected [1, 2, 3]"
+        assert found_lh_stand_4, "LH cutter was not placed in any heat"
+
+    def test_no_lh_cutter_uses_default_assignment(self, db_session):
+        """All-RH heat: stands 1-4 filled in list order (no LH special-case)."""
+        from services.heat_generator import generate_event_heats
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+        rh_all = [_make_pro_competitor(db_session, t, f"RH {i}") for i in range(1, 5)]
+        for comp in rh_all:
+            _enroll(comp, ev)
+        db_session.flush()
+
+        generate_event_heats(ev)
+
+        from models import Heat
+
+        heats = Heat.query.filter_by(event_id=ev.id, run_number=1).all()
+        assert heats
+        for h in heats:
+            assignments = h.get_stand_assignments()
+            stands = sorted(assignments.values())
+            # Every cutter in a 4-slot heat should get stand 1, 2, 3, or 4.
+            for s in stands:
+                assert 1 <= s <= 4
+
+    def test_stand_4_used_even_without_lh(self, db_session):
+        """Stand 4 is not reserved — an RH cutter still uses it when no LH present."""
+        from services.heat_generator import generate_event_heats
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+        rh_all = [_make_pro_competitor(db_session, t, f"RH {i}") for i in range(1, 5)]
+        for comp in rh_all:
+            _enroll(comp, ev)
+        db_session.flush()
+
+        generate_event_heats(ev)
+
+        from models import Heat
+
+        heats = Heat.query.filter_by(event_id=ev.id, run_number=1).all()
+        all_stands = set()
+        for h in heats:
+            all_stands.update(h.get_stand_assignments().values())
+        assert (
+            4 in all_stands
+        ), "stand 4 must be assigned to somebody even in all-RH heats"
+
+
+# ---------------------------------------------------------------------------
+# Two-LH-in-one-heat tie-break (overflow scenario)
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleLhInSameHeat:
+    def test_two_lh_same_heat_first_gets_stand_4_and_warning_fires(self, db_session):
+        """When 2+ LH cutters land in the same heat, first gets stand 4 +
+        a 'multiple_lh_same_heat' warning is recorded."""
+        from services.heat_generator import (
+            generate_event_heats,
+            get_last_lh_overflow_warnings,
+        )
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+        # 4 LH cutters + only 1 heat capacity → forces overflow-in-same-heat.
+        # 4 competitors total so we get exactly 1 heat.
+        lh_cutters = [
+            _make_pro_competitor(db_session, t, f"LH {i}", is_lh=True)
+            for i in range(1, 5)
+        ]
+        for comp in lh_cutters:
+            _enroll(comp, ev)
+        db_session.flush()
+
+        generate_event_heats(ev)
+
+        warnings = get_last_lh_overflow_warnings(ev.id)
+        types = {w.get("type") for w in warnings}
+        assert (
+            "multiple_lh_same_heat" in types
+        ), f"expected 'multiple_lh_same_heat' warning, got types {types}"
+
+
+# ---------------------------------------------------------------------------
+# Flight-contention warning surface
+# ---------------------------------------------------------------------------
+
+
+class TestLhFlightContentionWarning:
+    def test_warning_populated_when_multiple_lh_heats_in_one_flight(self, db_session):
+        """When flight builder can't spread LH heats, get_last_lh_flight_warnings returns rows."""
+        from models import Event, Heat
+        from services.flight_builder import (
+            build_pro_flights,
+            get_last_lh_flight_warnings,
+        )
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+
+        # Seed enough LH springboard cutters so LH_count > flight_count.
+        # With num_flights=2 and 4 LH heats, at least one flight must contain >1.
+        lh_pros = [
+            _make_pro_competitor(db_session, t, f"LH {i}", is_lh=True)
+            for i in range(1, 9)
+        ]
+        for i, comp in enumerate(lh_pros):
+            _enroll(comp, ev)
+            # Place each LH cutter in its own heat so flight builder has
+            # many LH-containing heats to spread.
+            h = Heat(event_id=ev.id, heat_number=i + 1, run_number=1)
+            h.set_competitors([comp.id])
+            db_session.add(h)
+        db_session.flush()
+
+        # Build with only 2 flights — 8 LH heats / 2 flights = 4 per flight
+        # → each flight has 4 LH-containing heats → both flagged.
+        build_pro_flights(t, num_flights=2, commit=False)
+
+        warnings = get_last_lh_flight_warnings(t.id)
+        assert warnings, (
+            "expected LH flight-contention warnings when LH heat count "
+            "exceeds flight count"
+        )
+        for w in warnings:
+            assert "flight_number" in w and "lh_count" in w
+            assert w["lh_count"] > 1
+
+    def test_no_lh_cutters_means_no_warnings(self, db_session):
+        """All-RH tournament: no LH flight-contention warnings regardless of build."""
+        from models import Heat
+        from services.flight_builder import (
+            build_pro_flights,
+            get_last_lh_flight_warnings,
+        )
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+
+        for i in range(1, 9):
+            rh = _make_pro_competitor(db_session, t, f"RH {i}")
+            _enroll(rh, ev)
+            h = Heat(event_id=ev.id, heat_number=i, run_number=1)
+            h.set_competitors([rh.id])
+            db_session.add(h)
+        db_session.flush()
+
+        build_pro_flights(t, num_flights=4, commit=False)
+
+        warnings = get_last_lh_flight_warnings(t.id)
+        assert warnings == [], (
+            f'no LH cutters should produce zero warnings, got {warnings}'
+        )
+
+    def test_warnings_cleared_on_subsequent_build(self, db_session):
+        """A tournament that once had warnings should clear them on a clean rebuild."""
+        from models import Heat
+        from services.flight_builder import (
+            _last_lh_flight_warnings,
+            build_pro_flights,
+            get_last_lh_flight_warnings,
+        )
+
+        t = _make_tournament(db_session)
+        ev = _make_springboard_event(db_session, t)
+
+        # Pre-populate _last_lh_flight_warnings simulating a prior build.
+        _last_lh_flight_warnings[t.id] = [{'flight_number': 1, 'lh_count': 99}]
+        assert get_last_lh_flight_warnings(t.id)  # pre-condition
+
+        # All-RH heats → fresh build should clear the map entry.
+        for i in range(1, 9):
+            rh = _make_pro_competitor(db_session, t, f"RH {i}")
+            _enroll(rh, ev)
+            h = Heat(event_id=ev.id, heat_number=i, run_number=1)
+            h.set_competitors([rh.id])
+            db_session.add(h)
+        db_session.flush()
+
+        build_pro_flights(t, num_flights=4, commit=False)
+
+        warnings = get_last_lh_flight_warnings(t.id)
+        assert warnings == [], (
+            'build_pro_flights must clear stale LH warnings when the new '
+            'build has no contention'
+        )


### PR DESCRIPTION
## Phase 5 of 5 — flight fixes plan (see [docs/FLIGHT_FIXES_RECON.md](docs/FLIGHT_FIXES_RECON.md))

### Problem (Recon Issue 4)

Pro Springboard has 4 physical dummies; only one is set up left-handed. The heat generator already spread LH cutters one per heat (time-multiplex the LH dummy) but didn't nail them to a specific stand — they got whatever index they landed at. Operators had to remember who was LH and manually move them at show time.

### Fix

**Stand 4 is the LH dummy** (hard-coded convention — Dummy 4 in `STAND_CONFIGS.springboard.labels`).
- Inside a springboard heat: LH cutter → stand 4; others → stands 1-3 in list order.
- All-RH heats: stand 4 is still used by the list-index-3 cutter (not reserved).
- 2+ LH in same heat (overflow): first wins stand 4, others fall back to list order, `multiple_lh_same_heat` warning recorded.

**Flight-contention surface:** new module-level `_last_lh_flight_warnings` + `get_last_lh_flight_warnings(tournament_id)`. `build_pro_flights` populates + clears on every build. Route handler flashes: "LH SPRINGBOARD CONTENTION: Flight N contains M left-handed cutters. Consider increasing flight count..."

**FlightLogic.md §5.3** rewritten to document the new rule.

### Locked decision #5 honoured

`tests/test_flight_builder_lh_constraint.py` kept — still asserts "spread LH heats across flights", which Phase 5 preserves (we kept the existing penalty in `_score_ordering`).

### Test coverage (7 new)

- `TestLhCutterGetsStand4` (3): single LH → stand 4, all-RH → default, stand 4 not reserved.
- `TestMultipleLhInSameHeat` (1): overflow warning.
- `TestLhFlightContentionWarning` (3): warnings fire on contention, zero on all-RH, cleared on clean rebuild.

### Regression

- **3244 passed, 0 failed** (7 new Phase 5 + 5 legacy LH kept + all prior).
- Ruff clean.

### Test plan

- [x] Unit + integration tests green locally
- [x] Ruff clean
- [ ] CI green (triggers on push)
- [ ] Manual verify: tournament with 3 LH pros → each springboard heat containing an LH cutter shows stand 4 assignment on heat sheet; tournament with 8 LH pros across 4 flights → operator sees "LH SPRINGBOARD CONTENTION" flash after build.

## Global acceptance (all 5 phases complete)

Phases 1-5 merged on `main`:
- Phase 1 (#68): async flight build chains spillover atomically via `commit=False`.
- Phase 2 (#69): `DAY_SPLIT_EVENT_NAMES` routing + placement-mode toggle.
- Phase 3 (#70): minutes/count flight sizing modes with persistence.
- Phase 4 (#71): Pro-Am Relay in final flight + printable teams sheet.
- Phase 5 (this PR): LH cutter on Stand 4 + flight-contention flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)