### PR TITLE
fix(relay): survive status transitions + render real team shape [Codex P2]

### DIFF
--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -353,7 +353,11 @@ def relay_teams_sheet(tournament_id):
     relay = ProAmRelay(tournament)
     state = relay.relay_data or {}
     teams = state.get("teams") or []
-    drawn = state.get("status") == "drawn" and bool(teams)
+    # Print-ready once the lottery has run — state machine runs
+    # not_drawn → drawn → in_progress → completed. Any post-lottery state
+    # should render the roster (crews still need to know who's on which team
+    # during scoring).
+    drawn = state.get("status") in {"drawn", "in_progress", "completed"} and bool(teams)
 
     html = render_template(
         "scheduling/relay_teams_sheet_print.html",

--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -1391,7 +1391,11 @@ def integrate_proam_relay_into_final_flight(tournament: Tournament, commit: bool
     state = relay.relay_data or {}
     teams = state.get('teams') or []
     status = state.get('status')
-    if status != 'drawn' or not teams:
+    # Post-draw states: drawn → in_progress → completed. All of these mean
+    # the lottery has been run and real teams exist — the relay still belongs
+    # in the show schedule even after results start landing. Only 'not_drawn'
+    # (or missing/empty teams) should skip placement.
+    if status not in ('drawn', 'in_progress', 'completed') or not teams:
         return {'placed': False, 'reason': 'not_drawn', 'team_count': 0}
 
     # Idempotency: wipe any existing relay Heat rows + their HeatAssignments

--- a/services/print_catalog.py
+++ b/services/print_catalog.py
@@ -229,13 +229,17 @@ def _fp_fnf(tournament, entity=None):
 
 
 def _status_relay_teams(tournament, entity=None):
-    """Status: relay is draw-complete iff ProAmRelay.relay_data shows drawn."""
+    """Status: relay is print-ready iff the lottery has been run.
+
+    Accepts any post-lottery status (drawn / in_progress / completed) — the
+    teams sheet is still relevant once scoring starts.
+    """
     from services.proam_relay import ProAmRelay
 
     relay = ProAmRelay(tournament)
     state = relay.relay_data or {}
     teams = state.get("teams") or []
-    if state.get("status") == "drawn" and teams:
+    if state.get("status") in ("drawn", "in_progress", "completed") and teams:
         return _ok()
     return _not_configured("Relay not drawn yet.")
 

--- a/templates/scheduling/relay_teams_sheet_print.html
+++ b/templates/scheduling/relay_teams_sheet_print.html
@@ -100,18 +100,30 @@
         <tbody>
             {% for team in teams %}
             <tr>
-                <td class="team-label">Team {{ loop.index }}</td>
+                <td class="team-label">Team {{ team.get('team_number', loop.index) }}</td>
                 <td class="members">
                     <ul>
-                        {% for member in team.get('members', []) %}
+                        {# ProAmRelay.run_lottery stores teams with pro_members + college_members
+                           lists, not a combined 'members' list. Render each list explicitly so
+                           PRO/COLLEGE badges match the actual division assignment. #}
+                        {% for member in team.get('pro_members', []) %}
                         <li>
                             <span class="role">
-                                {% if member.get('division') == 'pro' %}PRO{% else %}COLLEGE{% endif %}
+                                PRO
                                 {% if member.get('gender') == 'M' %}M{% elif member.get('gender') == 'F' %}F{% endif %}
                             </span>
                             {{ member.get('name', '—') }}
-                            {% if member.get('team_code') %}
-                            <small style="color:#666;">({{ member.get('team_code') }})</small>
+                        </li>
+                        {% endfor %}
+                        {% for member in team.get('college_members', []) %}
+                        <li>
+                            <span class="role">
+                                COLLEGE
+                                {% if member.get('gender') == 'M' %}M{% elif member.get('gender') == 'F' %}F{% endif %}
+                            </span>
+                            {{ member.get('name', '—') }}
+                            {% if member.get('team') and member.get('team') != 'N/A' %}
+                            <small style="color:#666;">({{ member.get('team') }})</small>
                             {% endif %}
                         </li>
                         {% endfor %}

--- a/tests/test_proam_relay_placement.py
+++ b/tests/test_proam_relay_placement.py
@@ -113,8 +113,9 @@ def _make_pro(session, tournament, name, gender="M"):
     return c
 
 
-def _seed_with_flights(session, with_relay_event=True, with_teams=False):
-    """Tournament with 2 pro flights and (optionally) a drawn Pro-Am Relay."""
+def _seed_with_flights(session, with_relay_event=True, with_teams=False, status="drawn"):
+    """Tournament with 2 pro flights and (optionally) a Pro-Am Relay in the
+    given lottery status (drawn / in_progress / completed)."""
     from models import Event
     from services.flight_builder import build_pro_flights
 
@@ -140,42 +141,27 @@ def _seed_with_flights(session, with_relay_event=True, with_teams=False):
             status="pending",
         )
         if with_teams:
+            # Mirror the real ProAmRelay.run_lottery() shape:
+            # {'pro_members': [...], 'college_members': [...]}, NOT a combined
+            # 'members' list. Codex caught this divergence post-merge.
             relay_data = {
-                "status": "drawn",
+                "status": status,
                 "teams": [
                     {
                         "team_number": 1,
-                        "members": [
-                            {
-                                "id": pros[0].id,
-                                "name": pros[0].name,
-                                "gender": "M",
-                                "division": "pro",
-                            },
-                            {
-                                "id": pros[1].id,
-                                "name": pros[1].name,
-                                "gender": "M",
-                                "division": "pro",
-                            },
+                        "pro_members": [
+                            {"id": pros[0].id, "name": pros[0].name, "gender": "M"},
+                            {"id": pros[1].id, "name": pros[1].name, "gender": "M"},
                         ],
+                        "college_members": [],
                     },
                     {
                         "team_number": 2,
-                        "members": [
-                            {
-                                "id": pros[2].id,
-                                "name": pros[2].name,
-                                "gender": "M",
-                                "division": "pro",
-                            },
-                            {
-                                "id": pros[3].id,
-                                "name": pros[3].name,
-                                "gender": "M",
-                                "division": "pro",
-                            },
+                        "pro_members": [
+                            {"id": pros[2].id, "name": pros[2].name, "gender": "M"},
+                            {"id": pros[3].id, "name": pros[3].name, "gender": "M"},
                         ],
+                        "college_members": [],
                     },
                 ],
             }
@@ -391,3 +377,123 @@ class TestRelayTeamsSheetRoute:
 
         resp = client.get(f"/scheduling/{t.id}/relay-teams-sheet")
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Codex post-merge P2: relay survives past the 'drawn' status
+# ---------------------------------------------------------------------------
+
+
+class TestRelayStatusTransitions:
+    """Locked fix for codex finding: relay pseudo-heat must be re-placeable
+    on rebuild after scoring has started. The state machine is
+    not_drawn → drawn → in_progress → completed. Only 'not_drawn' (or
+    missing/empty teams) should skip placement."""
+
+    def test_in_progress_status_still_places(self, db_session):
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(
+            db_session, with_relay_event=True, with_teams=True, status="in_progress",
+        )
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert result["placed"] is True, (
+            "Regression: an in_progress relay must not disappear from the "
+            "flight sheet when flights are rebuilt mid-show."
+        )
+
+    def test_completed_status_still_places(self, db_session):
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(
+            db_session, with_relay_event=True, with_teams=True, status="completed",
+        )
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert result["placed"] is True
+
+    def test_not_drawn_still_skips(self, db_session):
+        """Baseline guard: not_drawn still short-circuits placement."""
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(db_session, with_relay_event=True, with_teams=False)
+        result = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert result["placed"] is False
+        assert result["reason"] == "not_drawn"
+
+    def test_rebuild_mid_show_reattaches_heat(self, db_session):
+        """Simulate the exact codex scenario: run placement while 'drawn',
+        then delete the pseudo-heat (as build_pro_flights would when rebuilding),
+        bump status to 'in_progress', and re-run placement. The relay must
+        land in the final flight again."""
+        from models import Event, Heat
+        from services.flight_builder import integrate_proam_relay_into_final_flight
+
+        t, _ = _seed_with_flights(
+            db_session, with_relay_event=True, with_teams=True, status="drawn",
+        )
+        first = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert first["placed"] is True
+
+        # Mimic build_pro_flights wiping Heat.flight_id for relay heat + bump status.
+        relay_event = Event.query.filter_by(
+            tournament_id=t.id, name="Pro-Am Relay",
+        ).first()
+        Heat.query.filter_by(event_id=relay_event.id).delete(synchronize_session=False)
+        state = json.loads(relay_event.event_state or "{}")
+        state["status"] = "in_progress"
+        relay_event.event_state = json.dumps(state)
+        db_session.flush()
+
+        second = integrate_proam_relay_into_final_flight(t, commit=False)
+        assert second["placed"] is True, (
+            "Rebuild mid-show lost the relay — codex P2 regression."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Codex post-merge P2: teams sheet must render real member names
+# ---------------------------------------------------------------------------
+
+
+class TestRelayTeamsSheetRendersRealShape:
+    """ProAmRelay.run_lottery() stores team members as pro_members +
+    college_members (two separate lists). A template loop over 'members'
+    rendered empty rows against real production data — codex caught this."""
+
+    def test_sheet_renders_pro_member_names(self, db_session, client):
+        t, _pros = _seed_with_flights(
+            db_session, with_relay_event=True, with_teams=True, status="drawn",
+        )
+        _db.session.commit()
+
+        resp = client.get(f"/scheduling/{t.id}/relay-teams-sheet")
+        assert resp.status_code == 200
+        if "text/html" not in resp.content_type:
+            pytest.skip("PDF fallback — name assertion is HTML-fallback only.")
+        body = resp.data.decode("utf-8", errors="ignore")
+        # Every pro member seeded in both teams should appear by name.
+        for name in ("Pro 1", "Pro 2", "Pro 3", "Pro 4"):
+            assert name in body, (
+                f"Relay teams sheet did not render pro member {name!r}. "
+                "Codex P2 regression: template must read pro_members + "
+                "college_members, not a combined members list."
+            )
+        # Division badges match the real data shape.
+        assert "PRO" in body
+        assert "Team 1" in body
+        assert "Team 2" in body
+
+    def test_sheet_renders_when_status_is_in_progress(self, db_session, client):
+        t, _ = _seed_with_flights(
+            db_session, with_relay_event=True, with_teams=True, status="in_progress",
+        )
+        _db.session.commit()
+
+        resp = client.get(f"/scheduling/{t.id}/relay-teams-sheet")
+        assert resp.status_code == 200
+        if "text/html" not in resp.content_type:
+            pytest.skip("PDF fallback")
+        body = resp.data.decode("utf-8", errors="ignore")
+        assert "Pro 1" in body, (
+            "Teams sheet must keep rendering once scoring starts — codex P2 guard."
+        )


### PR DESCRIPTION
## Codex post-merge adversarial review of PRs #68-72 flagged two P2 bugs

Both were latent regressions hidden by a test fixture that didn't match the real \`ProAmRelay.run_lottery()\` output.

### P2-1: Relay vanishes after scoring starts

**Problem:** \`integrate_proam_relay_into_final_flight\` checked \`if status != 'drawn'\` and returned \`placed=False\`. The actual state machine is \`not_drawn → drawn → in_progress → completed\` ([services/proam_relay.py:55,261,266,297,306](services/proam_relay.py)). Any flight rebuild after the first relay event was scored orphaned the relay pseudo-heat — it disappeared from the flight sheet mid-show.

**Fix:** accept \`drawn\`, \`in_progress\`, \`completed\`. Propagated to:
- [services/flight_builder.py](services/flight_builder.py) — placement gate
- [services/print_catalog.py::_status_relay_teams](services/print_catalog.py) — Print Hub status
- [routes/scheduling/heat_sheets.py::relay_teams_sheet](routes/scheduling/heat_sheets.py) — template \`drawn\` flag

### P2-2: Teams sheet rendered empty rows against real data

**Problem:** \`ProAmRelay.run_lottery()\` stores each team as \`{team_number, pro_members, college_members}\` (two separate lists). The Phase 4 template looped over \`team.get('members', [])\` — a key that doesn't exist in production. **Every team row printed with zero members.** Only the made-up fixture \`'members'\` key made the template appear to work.

**Fix:** [templates/scheduling/relay_teams_sheet_print.html](templates/scheduling/relay_teams_sheet_print.html) now renders \`pro_members\` and \`college_members\` as two explicit blocks with matching PRO/COLLEGE badges. Test fixture rebuilt to use the real production shape.

### Tests (6 new, 15 total in file)

- \`TestRelayStatusTransitions\` (4): in_progress + completed placement, not_drawn baseline, rebuild-mid-show scenario.
- \`TestRelayTeamsSheetRendersRealShape\` (2): sheet contains every member name; sheet keeps rendering through in_progress.

### Regression

**3250 passed, 0 failed** (6 new codex-P2 guards + all Phase 1-5 work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)