### PR TITLE
docs(solutions): two test-tooling footguns from V2.14.0 ship

### DIFF
--- a/docs/solutions/test-failures/hand-written-fixture-shape-divergence-2026-04-22.md
+++ b/docs/solutions/test-failures/hand-written-fixture-shape-divergence-2026-04-22.md
@@ -1,0 +1,134 @@
+---
+module: testing
+date: 2026-04-22
+problem_type: test_failure
+component: testing_framework
+severity: high
+root_cause: fixture_shape_drift
+resolution_type: test_fix
+symptoms:
+  - "Unit tests pass. Template rendering tests pass against the fixture."
+  - "In production, the rendered output is empty / malformed because the real service emits a different JSON shape than the fixture."
+  - "Codex review spots it immediately by reading the real service class."
+tags:
+  - "pytest"
+  - "fixtures"
+  - "json-over-service"
+  - "template-rendering"
+  - "codex-review"
+  - "sibling: mock-signature-matches-buggy-call-site"
+---
+
+# Hand-written fixture shape diverges from the real service emitter
+
+## Problem
+
+In V2.14.0 Phase 4 the Pro-Am Relay pseudo-heat work added a printable teams sheet route at `/scheduling/<tid>/relay-teams-sheet`. The new template looped over each team's member list:
+
+```jinja
+{% for team in teams %}
+  {% for member in team.get('members', []) %}
+    <li>{{ member.get('name') }}</li>
+  {% endfor %}
+{% endfor %}
+```
+
+The fixture I wrote to test the route used the same key:
+
+```python
+relay_data = {
+    'status': 'drawn',
+    'teams': [
+        {'team_number': 1, 'members': [{'id': 1, 'name': 'Pro 1', 'gender': 'M', 'division': 'pro'}, ...]},
+        ...
+    ],
+}
+relay.event_state = json.dumps(relay_data)
+```
+
+**9 unit tests passed.** The route rendered 200. The teams sheet visually showed team names. Everything looked fine.
+
+But `ProAmRelay.run_lottery()` in production does NOT emit a combined `members` list. It emits two separate keys per team:
+
+```python
+# services/proam_relay.py (real shape)
+teams.append({
+    'team_number': idx + 1,
+    'pro_members': [],
+    'college_members': [],
+})
+...
+team['pro_members'].append(pro_male.pop(0))
+team['college_members'].append(college_male.pop(0))
+```
+
+So against a real drawn relay, the template's `team.get('members', [])` returned `[]` for every team. Every row on the printed sheet was empty. Ten lines of output per team stripped to a blank block.
+
+**Codex review caught it in one pass**, reading `services/proam_relay.py:185-217` against the template. The fixture had invented a key that only existed in the test. The test was self-consistent — it proved the template rendered the fixture shape, not that the template rendered production data.
+
+## Why it passed CI
+
+Tests only verify the relationship between inputs and outputs the test itself defines. If the fixture and the template agree on a made-up key, the test proves they agree — nothing more.
+
+The three layers that would have caught it:
+
+1. **Round-tripping the real emitter** — if the fixture called `ProAmRelay(tournament).run_lottery()` to generate its JSON, the template would have hit the real keys.
+2. **Content-assertion on real production state** — asserting "every member name from the drawn roster appears in the rendered HTML" rather than "the route returns 200".
+3. **Independent review reading both sides** — codex read the service class and the template and spotted the key mismatch.
+
+Only layer 3 happened, post-merge.
+
+## This is the SECOND time this pattern has bit us
+
+The sibling `mock-signature-matches-buggy-call-site-2026-04-22.md` documents the identical pattern from V2.13.0: the test mock of `background_jobs.submit` had the SAME wrong signature as the buggy production caller. Both sides agreed on the bug. Mock and caller had never touched the real function.
+
+In the V2.13.0 case, the divergence was in function signature. In V2.14.0, the divergence was in JSON shape. Both are instances of the same rule:
+
+**If the test fixture and the production caller both describe the same external contract (signature, JSON shape, protocol message), one of them must round-trip through the real thing, or the contract drifts silently.**
+
+## Resolution (V2.14.0 PR #73)
+
+1. Rewrote the fixture in `tests/test_proam_relay_placement.py::_seed_with_flights` to emit the real `pro_members` / `college_members` shape.
+2. Rewrote the template to render both lists explicitly with matching PRO/COLLEGE badges.
+3. Added content-assertion tests: `TestRelayTeamsSheetRendersRealShape::test_sheet_renders_pro_member_names` asserts every seeded pro name appears in the rendered HTML.
+4. Added status-transition tests (`TestRelayStatusTransitions`) that rebuild mid-show — codex also caught that `if status != 'drawn'` orphaned the relay once scoring started. That's a separate bug but lives in the same class of "fixture covered the happy path, production exposed a wider state machine."
+
+## Prevention — future features that synthesize JSON over an existing service
+
+When a new feature reads/writes JSON produced by an existing service (e.g. the Pro-Am Relay teams blob, Partnered Axe state, Birling bracket data):
+
+1. **Fixture derivation:** the fixture should call the real service to produce its JSON, not hand-write the blob.
+   ```python
+   # Good
+   relay = ProAmRelay(tournament)
+   relay.run_lottery(num_teams=2)
+   # Now tournament's relay_data is real — use it in the test
+
+   # Bad
+   relay.event_state = json.dumps({'status': 'drawn', 'teams': [{'members': [...]}]})
+   ```
+
+2. **Content assertions over route assertions:** `resp.status_code == 200` proves the template rendered. It does NOT prove the data was there. Assert that specific string data from the fixture appears in the rendered body.
+
+3. **Read the service's emitter when adding a new consumer:** whenever writing a template/route that reads JSON from an existing service, open the service file and read the exact shape its methods emit. `grep` for `append`, `['key']=`, or `dumps` calls that build the JSON. Copy the shape from reality, not from imagination.
+
+4. **Outside review for new consumers of existing state:** routes/templates that add new consumers of existing service state are a high-leverage codex-review target. They touch a wide data contract with minimal local code.
+
+## Pattern signature
+
+```
+Divergence type      | Caught by                | V-tag
+---------------------+--------------------------+-------
+Function signature   | codex outside review     | V2.13.0
+JSON shape           | codex outside review     | V2.14.0
+...next one?         | ?                        | ?
+```
+
+Two instances is a pattern. Add new rows here when the same thing happens again.
+
+## Related docs
+
+- [mock-signature-matches-buggy-call-site-2026-04-22.md](mock-signature-matches-buggy-call-site-2026-04-22.md) — sibling pattern on function signatures
+- [docs/FLIGHT_FIXES_RECON.md](../../FLIGHT_FIXES_RECON.md) — the recon that scoped V2.14.0 Phase 4
+- [services/proam_relay.py](../../../services/proam_relay.py) — the real emitter (run_lottery + set_teams_manually)
+- `tests/test_proam_relay_placement.py::TestRelayTeamsSheetRendersRealShape` — the content-assertion guard added after codex caught it

--- a/docs/solutions/test-failures/qa-smoke-csrf-redirect-false-positive-2026-04-22.md
+++ b/docs/solutions/test-failures/qa-smoke-csrf-redirect-false-positive-2026-04-22.md
@@ -1,0 +1,153 @@
+---
+module: testing
+date: 2026-04-22
+problem_type: test_failure
+component: qa_tooling
+severity: medium
+root_cause: ad_hoc_requests_smoke_without_csrf_or_body_assertion
+resolution_type: tooling_pattern
+symptoms:
+  - "Ad-hoc QA smoke via requests.Session() reports 200 on every auth-gated route."
+  - "Operator believes the route works. In reality every 200 is the login page rendered by the CSRFError redirect chain."
+  - "No status code or assertion catches the lie — follow_redirects=True masks the redirect through /auth/login."
+tags:
+  - "qa-tooling"
+  - "csrf"
+  - "flask-wtf"
+  - "requests-session"
+  - "app.test_client"
+  - "sibling: hand-written-fixture-shape-divergence"
+---
+
+# QA smoke returns 200 on every gated route because the requests are getting the login page
+
+## Problem (observed during V2.14.0 /ce-ship)
+
+While running Phase 3 of `/ce-ship` for the V2.14.0 release, I needed a live-server smoke confirming the 5 new flight-fixes routes served 200 against the deployed version bump. Pattern used:
+
+```python
+import requests
+s = requests.Session()
+s.post('http://127.0.0.1:5055/auth/login',
+       data={'username': 'STRATHEX', 'password': 'qa-smoke-temp'},
+       allow_redirects=True)
+for path in ('/scheduling/2/flights/build', '/scheduling/2/friday-night', ...):
+    r = s.get(f'http://127.0.0.1:5055{path}')
+    print(f'{r.status_code}  {path}')
+```
+
+All 5 routes printed **200**. I wrote in the /ce-ship report: *"all 5 flight-fixes routes serve 200 authenticated."* Shipped the release.
+
+Codex-style self-review afterward revealed the smoke was a lie. The login had failed silently with a CSRF error, the server's `@app.errorhandler(CSRFError)` handler (V2.10.1) redirected to `/auth/login`, every subsequent gated request 302'd to `/auth/login?next=...`, and `requests.Session(..., allow_redirects=True)` faithfully followed every one of those redirects — reporting 200 because the login page is 200.
+
+I had not smoked the feature routes. I had smoked the login page five times.
+
+## Root cause chain
+
+1. **Flask-WTF's `CSRFProtect`** is active on every POST form in the app. Pulled from `app.py`:
+   ```python
+   csrf = CSRFProtect()
+   ...
+   csrf.init_app(app)
+   ```
+   Without a matching token, every POST is rejected.
+
+2. **V2.10.1 added a friendly CSRFError handler** (`@app.errorhandler(CSRFError)` in `app.py`) that 302-redirects HTML requests to the referrer (or `request.path`) with a flash — so the browser user sees "Your session expired" and can retry. For a POST to `/auth/login` without a token, the referrer is empty, so `request.path` = `/auth/login` and the redirect target is itself.
+
+3. **`requests.Session()` does not automatically fetch the form** to extract `<input name="csrf_token" value="...">` before POSTing. It sends exactly the `data` dict passed in.
+
+4. **`allow_redirects=True`** (the default) follows the 302 back to `/auth/login`, which renders the form with status 200. The session has a cookie now but no authenticated user.
+
+5. **Every subsequent GET to a `MANAGEMENT_BLUEPRINTS` route** 302-redirects to `/auth/login?next=/scheduling/2/flights/build` (the Flask-Login unauthenticated guard). `allow_redirects=True` follows it. The final status is 200 — again, the login page.
+
+6. **My smoke checked `r.status_code == 200`** without looking at the response body. Every route "passed."
+
+## Verified repro
+
+```
+POST /auth/login (no csrf_token) → 302 Location: /auth/login
+GET /scheduling/2/flights/build → 302 Location: /auth/login?next=/scheduling/2/flights/build
+                                  → follows → 200 (login page)
+```
+
+With the right smoke (below):
+```
+GET /auth/login → 200, csrf_token captured
+POST /auth/login (with token) → 302 Location: /judge
+GET /scheduling/2/flights/build → 200
+  title: "Build Flights - Missoula Pro Am (flights test)"
+```
+
+## Two correct patterns
+
+### Pattern A: `app.test_client()` + direct session injection (preferred)
+
+Use the Flask test client and inject the user_id straight into the session. No HTTP, no CSRF, no real network — and it's the pattern `scripts/qa_print_hub.py` already uses:
+
+```python
+from app import create_app
+app = create_app()
+client = app.test_client()
+with client.session_transaction() as sess:
+    sess['_user_id'] = str(admin_user.id)
+# Now every client.get() is authenticated.
+resp = client.get(f'/scheduling/{tid}/flights/build')
+assert resp.status_code == 200
+assert b'Build Flights' in resp.data  # body assertion, not just status
+```
+
+Downsides: no middleware / proxy / static-file behavior — it's a WSGI-level probe, not a real HTTP roundtrip. But that's usually fine for "does the route 200 and render the expected thing."
+
+### Pattern B: live server + CSRF-aware requests session
+
+If you need a real HTTP request (e.g. to smoke a deploy URL), fetch the form first:
+
+```python
+import re, requests
+
+s = requests.Session()
+r = s.get('http://host/auth/login')
+token = re.search(r'name="csrf_token"[^>]*value="([^"]+)"', r.text).group(1)
+r = s.post('http://host/auth/login',
+           data={'username': user, 'password': pw, 'csrf_token': token},
+           allow_redirects=False)
+assert r.status_code == 302
+assert r.headers['Location'] != '/auth/login'  # would mean login failed
+# Now follow-up GETs with the session are authenticated.
+```
+
+## Always assert on the body, not just the status
+
+The core lesson: **`assert resp.status_code == 200` proves a handler returned something — not that the handler you meant to hit returned it.** Pair every route smoke with a body assertion tied to a string that only appears in the intended response:
+
+```python
+assert resp.status_code == 200
+assert b'Build Flights' in resp.data    # Phase 3 flights/build
+assert b'PRO-AM RELAY' in resp.data     # Phase 4 relay tile
+assert b'LH SPRINGBOARD' not in resp.data  # no contention warning in happy path
+```
+
+A login-page response is also 200. If the body check misses the login's `<title>Sign In</title>` it'll silently pass.
+
+## Related footgun
+
+The V2.14.0 codex P2 on [hand-written-fixture-shape-divergence-2026-04-22.md](hand-written-fixture-shape-divergence-2026-04-22.md) is the same shape of failure at a different layer:
+
+- **Fixture-shape divergence:** test input data didn't match what the real service emits → passing test against unreal data.
+- **QA smoke CSRF redirect:** test target didn't match what the real auth flow requires → passing test against the login page.
+
+Both pass. Both lie. Both get caught by independent review reading *both sides* of the contract, not just one side.
+
+## Prevention checklist for any new QA script
+
+1. **Use `app.test_client()` + `session_transaction()`** for authenticated smokes unless you specifically need to exercise the real HTTP stack.
+2. **When you do need real HTTP**, always GET the form first to extract the CSRF token before POSTing.
+3. **Always assert on body strings** unique to the intended response, not just status codes.
+4. **Run `allow_redirects=False` at least once** on the login POST. The Location header tells you exactly where the login chain ended up — if it's `/auth/login` instead of a post-login target, the smoke is compromised.
+
+## Related docs
+
+- [hand-written-fixture-shape-divergence-2026-04-22.md](hand-written-fixture-shape-divergence-2026-04-22.md) — sibling "test passed but lied" pattern at the JSON shape layer.
+- [mock-signature-matches-buggy-call-site-2026-04-22.md](mock-signature-matches-buggy-call-site-2026-04-22.md) — sibling pattern at the function signature layer.
+- `scripts/qa_print_hub.py` — reference implementation of Pattern A (test_client + session_transaction) across 36 checks.
+- `app.py::_inject_csp_nonce` / `@app.errorhandler(CSRFError)` — V2.10.1 the CSRF redirect handler that makes the failure silent.


### PR DESCRIPTION
## Two solution docs for patterns the V2.14.0 release surfaced

Both share the meta-shape: **test passed but the signal was fake.** Passing green against an unreal contract, caught only by independent review.

### 1. Hand-written fixture shape divergence

Phase 4's relay teams sheet template looped over \`team.get('members', [])\` but \`ProAmRelay.run_lottery()\` emits \`{pro_members, college_members}\` — two separate lists. The fixture used a hand-written \`'members'\` key that matched the template → 9 tests passed while production render would show empty rows. Codex caught it reading the service class against the template.

Documents: **fixture-derivation-from-real-emitter** pattern. Content-assertion over route-status-only assertion. Sibling relationship with the V2.13.0 mock-signature drift pattern.

### 2. QA smoke CSRF redirect false positive

During \`/ce-ship\` Phase 3, my ad-hoc QA smoke used \`requests.Session().post('/auth/login', ...)\` without a CSRF token. The V2.10.1 CSRFError handler redirected to \`/auth/login\`, every subsequent gated route's auth redirect landed at \`/auth/login?next=...\`, and \`allow_redirects=True\` followed them all — **reporting 200 on all 5 flight-fixes routes while actually rendering the login page.** I wrote "all routes serve 200 authenticated" in the ship report. I had smoked the login page five times.

Documents: the two correct patterns (\`app.test_client() + session_transaction\` OR CSRF-aware requests session). "Always assert on body, not just status" rule. Points at \`scripts/qa_print_hub.py\` as the existing reference implementation of Pattern A.

### Cross-linking

Both docs link each other + the V2.13.0 mock-signature-matches-buggy-call-site sibling. Together they form a three-entry pattern signature table future reviews can extend when the next instance lands.

### Release status unchanged

The V2.14.0 release itself is correct — I re-verified the flight-fixes routes with a CSRF-aware smoke during this investigation (title: "Build Flights - Missoula Pro Am (flights test)" → real page, not login). Only the original smoke tooling was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)