### PR TITLE
feat(relay): redraw accepts operator-chosen num_teams (V2.14.3)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,20 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-23 (V2.14.3)
+
+**What changed for you.** Judges running the Pro-Am Relay can now pick the number of teams when they Redraw, instead of being locked to whatever count was drawn first. On the Relay dashboard, the Redraw Lottery form now exposes the same **Number of Teams** dropdown as the initial Draw form, defaulting to the currently-drawn count but letting you pick anything up to `capacity.max_teams`. So: judge drew 2 teams, later realizes the opt-in pool supports 3, clicks Redraw, picks 3, done. No more manual state reset, no more judges stuck at 2 teams because the bottleneck pool shifted overnight.
+
+**Patch — Relay redraw accepts operator-chosen num_teams.** Race-weekend operator reported the `/tournament/<tid>/proam-relay/` page showed "Max Possible Teams: 3" alongside "Teams Formed: 2" with no visible way to expand. `POST /proam-relay/redraw` was hard-coded to `num_teams=existing_team_count or 2`, so clicking Redraw just re-rolled the same 2-team split. The initial Draw form at `status=not_drawn` already had a team-count dropdown; the Redraw form at `status=drawn` did not.
+
+- `routes/proam_relay.py::redraw_lottery` now reads `num_teams` from POST, falls back to the existing team count when the field is absent (legacy form submissions still work), rejects non-int / zero / negative input with a flash + redirect (no 500), and echoes the chosen count in the success flash so operators see confirmation of what was drawn.
+- `templates/proam_relay/dashboard.html` adds a `<select name="num_teams">` inside the Redraw form capped at `capacity.max_teams`. Default clamped to `min(teams|length, capacity.max_teams)` so a shrunken pool (competitors scratched between draw and redraw) never leaves zero options selected and defaults to a valid choice.
+- 8 new regression tests in `tests/test_proam_relay_redraw_route.py`: 2→3 team escalation via POST, legacy empty-form fallback, parametrized invalid-input matrix (five, 0, -1, 3.5, empty) each preserving state, and HTML assertion that the selector + capacity note render on the drawn-state dashboard. Uses a dedicated module-scoped app fixture + login-based `auth_client` so committing routes (`run_lottery`, `redraw_lottery`) do not collide with the shared conftest `admin_user` fixture.
+
+**Also shipped — operations documentation.** `docs/solutions/best-practices/railway-ssh-base64-python-pattern-2026-04-22.md` captures the base64-encoded-Python-through-remote-pipeline pattern used during the 2026-04-22 production admin password reset. The three independent obstacles solved: (1) internal-only `DATABASE_URL` hostnames that only resolve inside the Railway container network, (2) PowerShell → Railway CLI → remote `sh` quoting chain corruption that mangles `python -c "..."`, (3) Railway's TTY allocation on `railway ssh` that makes `@'...'@ | python` drop into the interactive REPL instead of reading stdin. Base64 alphabet has zero shell metacharacters and the `echo ... | base64 -d | python` pipeline gives Python a non-TTY stdin. All credentials are placeholder strings, no real secrets embedded.
+
+---
+
 ### 2026-04-22 (V2.14.2)
 
 **What changed for you.** The Run Show page (`/scheduling/<tid>/events`) no longer flashes "X events have no heats yet" warnings for events that intentionally never produce heats — Axe Throw, Caber Toss, Peavey Log Roll, and Pulp Toss (college come-and-go signup format) plus Partnered Axe Throw and Pro-Am Relay (state-machine events that store progression in `Event.payouts` JSON). The Current Schedule status panel now reflects actual schedule readiness instead of crying wolf on every page load. Same release also surfaces the flight sizing controls (mode toggle, num_flights, target minutes per flight, minutes per heat) directly on the Run Show page above the Generate buttons — no more bouncing to `/flights/build` to retune flight count between Generate clicks. Both pages share the same persisted `schedule_config`, so changing flight count in either place updates the other.

--- a/docs/solutions/best-practices/railway-ssh-base64-python-pattern-2026-04-22.md
+++ b/docs/solutions/best-practices/railway-ssh-base64-python-pattern-2026-04-22.md
@@ -1,0 +1,172 @@
+---
+title: "Railway SSH base64-pipe-to-Python pattern for remote prod ops"
+date: 2026-04-22
+category: best-practices
+module: operations
+problem_type: best_practice
+component: tooling
+severity: medium
+applies_when:
+  - "Need to execute arbitrary Python against a Railway-hosted container from a developer laptop"
+  - "DATABASE_URL uses a *.railway.internal private host unreachable from outside the Railway network"
+  - "Invoking the command from PowerShell (or any shell that mangles nested quotes across CLI -> remote sh)"
+  - "Running a multi-line Python payload through `railway ssh` where TTY allocation breaks stdin piping"
+tags:
+  - railway
+  - ssh
+  - base64
+  - remote-shell
+  - quoting
+  - powershell
+  - credential-reset
+---
+
+# Railway SSH base64-pipe-to-Python pattern for remote prod ops
+
+## Context
+
+You need to run a one-shot admin script against a Railway-hosted Flask + Postgres production app. Three independent obstacles block the obvious paths:
+
+1. **You cannot reach the Postgres instance from your laptop.** Railway's `DATABASE_URL` points at an internal hostname (e.g. `postgres-hb8.railway.internal`) that only resolves inside the Railway container network. `railway run python script.py` injects the env var locally but the hostname fails to resolve (`psycopg2.OperationalError: could not translate host name`). `DATABASE_PUBLIC_URL` isn't always set on the app service, and pulling the Postgres proxy URL via `railway variables --service Postgres` dumps credentials into your terminal transcript.
+
+2. **Quoting hell blocks `python -c`.** On Windows PowerShell, passing a multi-statement Python source string through `railway ssh python -c "..."` gets mangled. PowerShell strips outer double quotes when forwarding to native executables; the remote `sh -c` then sees unquoted parens and errors with `sh: 1: Syntax error: word unexpected (expecting ")")`. Escaping variants (outer single quotes + backslash-escaped inner doubles, here-strings, etc.) all fail somewhere in the PS → Railway CLI → remote `sh` chain.
+
+3. **TTY allocation blocks stdin piping.** `@'...'@ | railway ssh python` looks correct but `railway ssh` allocates a TTY on the remote. Python sees stdin as a TTY, opens the interactive `>>>` prompt, and ignores the piped source.
+
+Deploying the script as a committed Flask CLI command works but takes 3–8 minutes per iteration; the Railway dashboard web shell is manual and not paste-friendly.
+
+## Guidance
+
+Use a base64-encoded payload decoded inside a remote pipeline:
+
+```powershell
+cd "c:\path\to\repo"; railway ssh 'echo <BASE64> | base64 -d | python'
+```
+
+The base64 alphabet (`[A-Za-z0-9+/=]`) contains zero shell metacharacters, so nothing in the payload can be reinterpreted by PowerShell, the Railway CLI, or the remote `sh`. The pipeline `echo ... | base64 -d | python` gives python a non-TTY stdin (the upstream pipe), so even inside Railway's allocated TTY session python reads source from fd 0 instead of going interactive.
+
+**Generator helper** (run locally, paste the output into the one-liner):
+
+```powershell
+python -c "import base64, pathlib; print(base64.b64encode(pathlib.Path('script.py').read_bytes()).decode())"
+```
+
+Bash equivalent:
+
+```bash
+base64 -w0 script.py
+```
+
+Workflow: write `script.py` locally, encode it, paste the base64 blob into the PowerShell template, run once, delete the local file.
+
+## Why This Works
+
+The pattern resolves three unrelated issues in one line:
+
+- **DNS** — executing inside the container means `postgres-hb8.railway.internal` resolves normally.
+- **Quoting** — base64 strips every character PowerShell, the Railway CLI, or the remote `sh` might reinterpret.
+- **TTY** — python's stdin inside a pipeline is the pipe, never the allocated TTY.
+
+**Alternative paths and when each one fits better** (session history):
+
+- **Public Postgres proxy + local `psql` / `pg_dump` / `flask db upgrade`** — use when the operation is raw SQL or schema-level. Railway's Postgres service exposes `DATABASE_PUBLIC_URL` (format `postgresql://postgres:<pass>@turntable.proxy.rlwy.net:<port>/railway`) via `railway variables --service Postgres`. This is the path used during the 2026-04-08 Postgres recovery incident. See the complementary playbook linked in **Related**. Downside: credentials end up in local terminal scrollback.
+- **Committed Flask CLI command + `railway run flask <cmd>`** — safest for recurring operations, but the full deploy cycle (lint, CI, Railway build) is 3–8 minutes per iteration. Unacceptable for race-week firefighting.
+- **Railway web dashboard shell** — works, but breaks copy-paste of multi-line scripts and leaves no local audit trail.
+
+Prefer the base64-ssh pattern when you need Flask app context (ORM models, app factories, service methods) rather than raw SQL, and when iteration speed matters more than permanence.
+
+## When to Apply
+
+Use this pattern for **one-shot operations that do not involve schema changes**:
+
+- Credential resets (the original use case)
+- Invalidating stale sessions or tokens
+- Patching a bad row that slipped past validation
+- Seeding a missing config row
+- Ad-hoc debugging queries against production
+
+**Do not** use it for schema migrations — those go through Flask-Migrate (`flask db upgrade`) via Railway's `preDeployCommand` in `railway.toml`. Do not use it for recurring operations — promote those to a real Flask CLI command under `flask <name>` in `app.py`.
+
+## Examples
+
+### Worked example: reset an admin password on production
+
+Local `_reset_admin.py` — replace the two `<placeholder>` values before encoding:
+
+```python
+from sqlalchemy import select
+from app import create_app
+from database import db
+from models import User
+
+app = create_app()
+with app.app_context():
+    u = db.session.execute(
+        select(User).filter_by(username="<admin-username>")
+    ).scalar_one_or_none()
+    if u is None:
+        u = User(username="<admin-username>", role="admin")
+        db.session.add(u)
+        print("creating")
+    else:
+        print(f"before: id={u.id} role={u.role} active={u.is_active_user}")
+    u.set_password("<new-password>")
+    db.session.commit()
+    print("done")
+```
+
+Encode and run:
+
+```powershell
+$b64 = python -c "import base64, pathlib; print(base64.b64encode(pathlib.Path('_reset_admin.py').read_bytes()).decode())"
+railway ssh "echo $b64 | base64 -d | python"
+```
+
+Expected output:
+
+```
+before: id=1 role=admin active=True
+done
+```
+
+The actual credentials belong in auto memory (`memory/project_prod_admin_credential.md`), not in this repo doc.
+
+### Hypothetical example: invalidate all judge sessions after a suspected leak
+
+```python
+from sqlalchemy import select
+from app import create_app
+from database import db
+from models import User
+
+app = create_app()
+with app.app_context():
+    judges = db.session.execute(
+        select(User).filter(User.role.in_(["admin", "judge"]))
+    ).scalars().all()
+    for u in judges:
+        u.session_token = None
+        u.session_expires_at = None
+    db.session.commit()
+    print(f"invalidated {len(judges)} judge sessions")
+```
+
+Same encode-and-run pipeline. Judges are forced to log in again on their next request; no deploy required, no schema change, no credential exposure in local shell history.
+
+## Prevention / Operational Notes
+
+- **Idempotence.** Payload scripts should converge on retry, not duplicate rows. Use `filter_by(...).first()` + if/else rather than unconditional `add()`.
+- **Capture before mutating.** Print the before-state, mutate, print the after-state. The terminal scrollback becomes your audit trail.
+- **Delete the local `script.py` after the run.** The base64 blob in shell history is the only artifact you want sticking around, and it's opaque enough to be safe in scrollback.
+- **Never embed real credentials or tokens in the Python source.** Pull them from `os.environ` on the remote if you need them.
+- **Revoke project tokens used during emergencies.** The 2026-04-08 incident flagged a Railway project token that should have been revoked after race weekend (session history). If one is still active, audit before any future show weekend.
+- **Sanity-check the target.** Before running against production, confirm `railway status` shows the expected project + environment + service. `railway ssh` to the wrong environment is the fastest way to mutate the wrong database.
+- **Terminal-supervised only.** These snippets intentionally omit `try/except` around `db.session.commit()` — a raw `IntegrityError` traceback is acceptable signal when a human is watching the scrollback. Before promoting any of this shape into a committed Flask CLI command or service method, wrap `commit()` in `try/except IntegrityError: db.session.rollback()` and log the failure with context. The one-shot pattern is a diagnostic, not a template for production code.
+- **Use SQLAlchemy 2.x idioms.** The examples use `db.session.execute(select(User)...)` rather than the legacy `User.query.filter_by(...)` Query API. Copy-paste shapes into real modules and you propagate whichever ORM style you model here, so the snippets deliberately teach the 2.x path the codebase should be on.
+
+## Related
+
+- [`railway-postgres-operational-playbook-2026-04-21.md`](railway-postgres-operational-playbook-2026-04-21.md) — canonical playbook for Railway Postgres ops using `DATABASE_PUBLIC_URL` + local Python/`psql`. Covers the complementary **local → public proxy** path; this doc covers the **local → internal-only via ssh** path. Both patterns live in the same toolkit — pick by whether you need app context (ssh+base64) or raw SQL + schema ops (public proxy).
+- `memory/project_prod_admin_credential.md` (auto memory [claude]) — the current production admin credential; rotate after show weekend.
+- `memory/incident_2026-04-08_postgres_recovery.md` (auto memory [claude]) — historical precedent for Railway prod DB access; established the public-proxy path as a peer technique (session history).
+- `memory/feedback_one_block_commands.md` (auto memory [claude]) — user preference for ONE paste-ready block per operational command; this pattern was selected in part because it fits that constraint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.14.2"
+version = "2.14.3"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.14.2',
+        'version': '2.14.3',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.14.2',
+        'version': '2.14.3',
     })
 
 

--- a/routes/proam_relay.py
+++ b/routes/proam_relay.py
@@ -65,11 +65,23 @@ def redraw_lottery(tournament_id):
     tournament = Tournament.query.get_or_404(tournament_id)
     relay = get_proam_relay(tournament)
 
+    existing_team_count = len(relay.get_teams()) or 2
+    raw = request.form.get('num_teams')
+    if raw is None or raw == '':
+        num_teams = existing_team_count
+    else:
+        try:
+            num_teams = int(raw)
+            if num_teams < 1:
+                raise ValueError('num_teams must be at least 1')
+        except (TypeError, ValueError):
+            flash('Invalid number of teams.', 'error')
+            return redirect(url_for('proam_relay.relay_dashboard', tournament_id=tournament_id))
+
     try:
-        existing_team_count = len(relay.get_teams()) or 2
-        result = relay.redraw_lottery(num_teams=existing_team_count)
+        result = relay.redraw_lottery(num_teams=num_teams)
         invalidate_tournament_caches(tournament_id)
-        flash('Lottery has been redrawn!', 'success')
+        flash(f"Lottery has been redrawn with {num_teams} team(s).", 'success')
     except ValueError as e:
         flash(str(e), 'danger')
 

--- a/templates/proam_relay/dashboard.html
+++ b/templates/proam_relay/dashboard.html
@@ -171,6 +171,20 @@
                         <form action="{{ url_for('proam_relay.redraw_lottery', tournament_id=tournament.id) }}" method="POST"
                               data-confirm="This will clear all teams and results. Are you sure?">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            {% if capacity.max_teams > 0 %}
+                            {% set default_redraw_n = [teams|length, capacity.max_teams]|min %}
+                            <div class="mb-2">
+                                <label class="form-label small text-muted mb-1">Number of Teams</label>
+                                <select name="num_teams" class="form-select form-select-sm">
+                                    {% for n in range(1, capacity.max_teams + 1) %}
+                                    <option value="{{ n }}" {% if n == default_redraw_n %}selected{% endif %}>{{ n }} Team{% if n != 1 %}s{% endif %}</option>
+                                    {% endfor %}
+                                </select>
+                                <div class="form-text small">
+                                    Max {{ capacity.max_teams }} based on current opt-ins.
+                                </div>
+                            </div>
+                            {% endif %}
                             <button type="submit" class="btn btn-outline-danger w-100">
                                 <i class="bi bi-arrow-repeat"></i> Redraw Lottery
                             </button>

--- a/tests/test_proam_relay_redraw_route.py
+++ b/tests/test_proam_relay_redraw_route.py
@@ -1,0 +1,193 @@
+"""
+Route-level tests for the Pro-Am Relay redraw endpoint.
+
+Covers the num_teams form field added so judges can switch from an initial
+2-team draw to 3 teams (or back) without manually clearing state. Uses a
+local module-scoped app + login-based auth_client so committing routes
+(run_lottery, redraw_lottery) do not collide with the shared admin_user
+fixture in conftest.
+"""
+
+import os
+
+import pytest
+
+from database import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    from tests.db_test_utils import create_test_app
+
+    _app, db_path = create_test_app()
+    with _app.app_context():
+        _seed_admin()
+        yield _app
+        _db.session.remove()
+    try:
+        os.unlink(db_path)
+    except OSError:
+        pass
+
+
+def _seed_admin():
+    from models.user import User
+
+    if not User.query.filter_by(username="relay_admin").first():
+        u = User(username="relay_admin", role="admin")
+        u.set_password("relay_pass")
+        _db.session.add(u)
+        _db.session.commit()
+
+
+@pytest.fixture(autouse=True)
+def db_session(app):
+    with app.app_context():
+        _db.session.begin_nested()
+        yield _db.session
+        _db.session.rollback()
+
+
+@pytest.fixture()
+def auth_client(app):
+    c = app.test_client()
+    c.post(
+        "/auth/login",
+        data={"username": "relay_admin", "password": "relay_pass"},
+        follow_redirects=True,
+    )
+    return c
+
+
+def _seed_relay_tournament(session, pros_per_gender=6, cols_per_gender=6):
+    """Seed a tournament with enough opted-in competitors for ``min`` teams.
+
+    With 6M/6F pro + 6M/6F college the lottery capacity is 3. Callers can
+    then run_lottery at 1/2/3 teams and exercise the redraw path.
+    """
+    from models import Tournament
+    from models.competitor import CollegeCompetitor, ProCompetitor
+    from models.team import Team
+
+    t = Tournament(name="Relay Redraw Test", year=2026, status="pro_active")
+    session.add(t)
+    session.flush()
+
+    team = Team(
+        tournament_id=t.id, team_code="U-A", school_name="U", school_abbreviation="U"
+    )
+    session.add(team)
+    session.flush()
+
+    for i in range(pros_per_gender):
+        session.add(
+            ProCompetitor(
+                tournament_id=t.id,
+                name=f"PM{i}",
+                gender="M",
+                pro_am_lottery_opt_in=True,
+                status="active",
+            )
+        )
+        session.add(
+            ProCompetitor(
+                tournament_id=t.id,
+                name=f"PF{i}",
+                gender="F",
+                pro_am_lottery_opt_in=True,
+                status="active",
+            )
+        )
+
+    for i in range(cols_per_gender):
+        for g in ("M", "F"):
+            c = CollegeCompetitor(
+                tournament_id=t.id,
+                team_id=team.id,
+                name=f"C{g}{i}",
+                gender=g,
+                status="active",
+            )
+            c.pro_am_lottery_opt_in = True
+            session.add(c)
+
+    session.flush()
+    return t
+
+
+class TestRedrawNumTeams:
+    """Redraw route must honor a judge-chosen num_teams, not the existing count."""
+
+    def test_redraw_escalates_team_count(self, app, auth_client, db_session):
+        """After a 2-team draw, POST num_teams=3 should redraw at 3."""
+        from services.proam_relay import ProAmRelay
+
+        t = _seed_relay_tournament(db_session)
+        relay = ProAmRelay(t)
+        relay.run_lottery(num_teams=2)
+        assert len(relay.get_teams()) == 2
+
+        r = auth_client.post(
+            f"/tournament/{t.id}/proam-relay/redraw",
+            data={"num_teams": "3"},
+        )
+        assert r.status_code == 302
+
+        assert len(ProAmRelay(t).get_teams()) == 3
+
+    def test_redraw_without_num_teams_falls_back_to_existing(
+        self, app, auth_client, db_session
+    ):
+        """Legacy form submission without num_teams must still work."""
+        from services.proam_relay import ProAmRelay
+
+        t = _seed_relay_tournament(db_session)
+        relay = ProAmRelay(t)
+        relay.run_lottery(num_teams=2)
+
+        r = auth_client.post(
+            f"/tournament/{t.id}/proam-relay/redraw",
+            data={},
+        )
+        assert r.status_code == 302
+
+        assert len(ProAmRelay(t).get_teams()) == 2
+
+    @pytest.mark.parametrize("bad", ["five", "0", "-1", "3.5", ""])
+    def test_redraw_rejects_invalid_num_teams_without_crash(
+        self, app, auth_client, db_session, bad
+    ):
+        """Non-integer, zero, or negative input flashes error and preserves state.
+
+        Empty string ("") is treated as missing and falls back to existing count
+        (same as the no-num_teams case) — the assertion below covers both shapes.
+        """
+        from services.proam_relay import ProAmRelay
+
+        t = _seed_relay_tournament(db_session)
+        relay = ProAmRelay(t)
+        relay.run_lottery(num_teams=2)
+
+        r = auth_client.post(
+            f"/tournament/{t.id}/proam-relay/redraw",
+            data={"num_teams": bad},
+        )
+        assert r.status_code == 302, f"bad input {bad!r} did not redirect"
+        assert (
+            len(ProAmRelay(t).get_teams()) == 2
+        ), f"bad input {bad!r} should not alter team count"
+
+    def test_dashboard_surfaces_num_teams_selector_when_drawn(
+        self, app, auth_client, db_session
+    ):
+        """Dashboard in drawn state must render the num_teams selector inside the redraw form."""
+        from services.proam_relay import ProAmRelay
+
+        t = _seed_relay_tournament(db_session)
+        ProAmRelay(t).run_lottery(num_teams=2)
+
+        r = auth_client.get(f"/tournament/{t.id}/proam-relay/")
+        assert r.status_code == 200
+        html = r.get_data(as_text=True)
+        assert 'name="num_teams"' in html, "num_teams select missing from dashboard"
+        assert "Max 3 based on current opt-ins" in html, "capacity note missing"

--- a/tests/test_relay_lottery_realistic.py
+++ b/tests/test_relay_lottery_realistic.py
@@ -363,3 +363,5 @@ class TestRelayResultRecording:
         assert len(results) == 2
         assert results[0]['team_number'] == 2, "Team with lower total time should be first"
         assert results[1]['team_number'] == 1
+
+


### PR DESCRIPTION
## Summary

**Relay redraw team-count fix.** Judges running the Pro-Am Relay can now pick the number of teams when they Redraw, instead of being locked to whatever count was drawn first. Race-weekend trigger: operator saw "Max Possible Teams: 3" next to "Teams Formed: 2" on `/tournament/<tid>/proam-relay/` and had no visible path to expand — Redraw was hard-coded to re-use the existing count.

- `routes/proam_relay.py::redraw_lottery` — reads `num_teams` from POST, falls back to existing count (legacy-form compatible), rejects non-int/zero/negative with a flash + redirect (no 500), echoes chosen count in the success flash
- `templates/proam_relay/dashboard.html` — `<select name="num_teams">` added inside Redraw form, capped at `capacity.max_teams`, default clamped to `min(teams|length, capacity.max_teams)` so post-scratch pool shrinkage never leaves zero options selected

**Railway SSH operations docs.** New `docs/solutions/best-practices/railway-ssh-base64-python-pattern-2026-04-22.md` captures the base64-pipe-to-Python pattern used during the 2026-04-22 production admin credential reset. Three independent obstacles solved: internal-only `DATABASE_URL` hostnames, PowerShell → Railway CLI → remote `sh` quoting chain corruption, and TTY allocation breaking stdin piping. Placeholders only, no credentials embedded.

## Commits

- `feat(relay): redraw accepts operator-chosen num_teams` — route + template changes + 8 new regression tests
- `docs(solutions): Railway SSH base64-pipe-to-Python pattern for remote prod ops` — 172-line ops pattern doc
- `chore(V2.14.3): release — relay redraw team-count + Railway SSH docs` — VERSION bump + CHANGELOG

## Test Coverage

New file `tests/test_proam_relay_redraw_route.py` — dedicated module-scoped app + login-based `auth_client` to sidestep committing-route collisions with the shared conftest `admin_user` fixture:

- `test_redraw_escalates_team_count` — 2→3 teams via POST `num_teams=3`
- `test_redraw_without_num_teams_falls_back_to_existing` — legacy form submissions still work
- `test_redraw_rejects_invalid_num_teams_without_crash` — parametrized over `five`, `0`, `-1`, `3.5`, empty — all 302 redirect, state preserved (5 cases)
- `test_dashboard_surfaces_num_teams_selector_when_drawn` — HTML assertion for `name="num_teams"` + capacity note

Full suite green: 193 passed across relay (29) + redraw route (8) + placement (9) + route smoke (139) + schedule_status guards (8).

## Pre-Landing Review

Self-reviewed. One edge case caught mid-session: if competitors are scratched after the initial draw such that `teams|length > capacity.max_teams`, the original `{% if n == teams|length %}selected{% endif %}` would leave no option selected and the browser would default to "1 Team" silently. Fixed by clamping default to `min(teams|length, capacity.max_teams)`.

No security/auth/data-integrity surface touched — the route is already gated by `require_judge_for_management_routes` via `MANAGEMENT_BLUEPRINTS`, CSRF token preserved, `run_lottery`/`redraw_lottery` service already validates pool sizes and raises `ValueError` (caught and flashed).

## Deploy

- Railway auto-deploys from main on merge
- Post-merge verification: `curl https://missoula-pro-am-manager-production.up.railway.app/health` should return `"version": "2.14.3"`
- No migration, no model columns, no schema changes

## Scope note

This PR is stacked behind #81 (V2.14.2 scheduling scope fix) which landed as `68e78ca` on main immediately before this branch was rebased. Version collision was resolved sequentially: V2.14.2 for scheduling, V2.14.3 for relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)