### PR TITLE
fix(run-show): warning panel CTAs actually generate (V2.14.6)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -592,6 +592,28 @@ STAND_CONFIGS = {
 
 ## Changelog
 
+### 2026-04-23 (V2.14.6)
+
+**What changed for you.** The "Generate pro heats" button in the Schedule Status warning panel on Run Show > Build Schedule now actually generates heats when you click it. Same for the matching college, "rebuild flights", and Cookie/Standing conflict warnings — one click on the warning button runs the operation it advertises. When events get skipped because no competitors entered them, the post-redirect flash names the skipped events explicitly and links straight to the right registration page so you can fix it without hunting.
+
+**Root cause.** `services/schedule_status.py` rendered every actionable warning's call-to-action as `<a href="{{ url_for('scheduling.event_list', tournament_id=tid) }}">`. But `scheduling.event_list` IS the Run Show page itself — clicking the warning button reloaded the same page with no generation triggered. Operators (correctly) read this as a broken button. Compounding the confusion: when the actual `Generate All Heats + Build Flights` form button on the same page DID run, the wrapper `_generate_all_heats` lumped every "no competitors entered" event into one silent `Skipped N without entrants` flash with no event names and no link to fix anything. So skipped events stayed invisible on the next page render and the warning kept shouting "13 pro events have no heats" with no actionable path forward.
+
+**Fix.** Two-part:
+
+1. `services/schedule_status.py` adds a `submit_action` field to the `Warning_` TypedDict. Four warnings now carry an action: `college_missing` (`generate_all`), `pro_missing` (`generate_all`), `pro_heats_without_flights` (`rebuild_flights`), and `cookie_block_simultaneous` (`rebuild_flights`). `templates/scheduling/events.html` renders these as POST `<form>` buttons that submit to `scheduling.event_list` with the named action. Non-actionable warnings keep the `<a href>` fallback. One click = one generation run.
+
+2. `routes/scheduling/__init__.py` `_generate_all_heats` now collects skipped events by name into `skipped_events: list[tuple[Event, str]]`, splits them by `event_type`, and emits two distinct `Markup`-flashed warnings (one for college, one for pro) that name every skipped event and link to the matching registration page (`registration.pro_registration` / `registration.college_registration`). Operators land directly on the page where they can add the missing entries, then click Generate again.
+
+**Tests.** New `TestWarningsCarrySubmitAction` class in `tests/test_schedule_status.py` (4 tests): asserts the three actionable warnings carry the correct `submit_action` value, plus a route-level test that `GET /scheduling/<tid>/events` actually renders `name="action" value="generate_all"` in the warning panel HTML (guards against a regression where the template loses the form-button branch). End-to-end Flask test client verification confirms the POST round-trips through the handler (302 redirect) and the follow-up GET surfaces a flash containing both the skipped event name and the pro registration link.
+
+**Meta-lesson.** When a warning panel CTA links to the same page the user is on, the click is silently a no-op. Either the warning needs an actionable `submit_action` so one click runs the operation, or the warning needs a different target (an anchor jump, a sibling page) so the click visibly does something. Static `url_for(...)` warning links with no awareness of the rendering page are the failure mode here.
+
+**Full suite.** 37 passed across `tests/test_schedule_status.py`, `tests/test_one_click_and_fnf.py`, `tests/test_flight_builder_async_spillover.py` (the relevant intersection). Zero regressions.
+
+**Files touched.** `services/schedule_status.py` (+10/-0), `templates/scheduling/events.html` (+15/-2), `routes/scheduling/__init__.py` (+57/-9), `tests/test_schedule_status.py` (+127 — `TestWarningsCarrySubmitAction`), `pyproject.toml` (2.14.5 → 2.14.6), `routes/main.py` (two `/health` + `/health/diag` literals bumped per PREPARE FOR COMMIT step 5). No migration. No payout-related files touched (parallel session V2.14.5 owned that area).
+
+---
+
 ### 2026-04-23 (V2.14.5)
 
 **What changed for you.** The Payout Manager page (sidebar → Scoring → Configure Payouts) no longer 500s when any saved payout template exists. Same fix covers the per-event payouts page and the Tournament Setup payouts tab.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "missoula-pro-am-manager"
-version = "2.14.5"
+version = "2.14.6"
 description = "Tournament management system for the Missoula Pro-Am timbersports competition"
 requires-python = ">=3.10"
 license = { text = "Proprietary" }

--- a/routes/main.py
+++ b/routes/main.py
@@ -76,7 +76,7 @@ def health():
         'migration_current': migration_current,
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
-        'version': '2.14.5',
+        'version': '2.14.6',
     })
 
 
@@ -160,7 +160,7 @@ def health_diag():
             'hsts_will_be_set': cfg.get('ENV_NAME') == 'production',
             'csp_will_be_set': True,
         },
-        'version': '2.14.5',
+        'version': '2.14.6',
     })
 
 

--- a/routes/scheduling/__init__.py
+++ b/routes/scheduling/__init__.py
@@ -218,12 +218,22 @@ def _generate_all_heats(tournament: Tournament, generate_event_heats_fn):
     Each event is wrapped in its own savepoint (begin_nested) so that a failure
     in one event is rolled back in isolation without corrupting the session state
     for subsequent events or for the flight-building step that follows.
+
+    Per-event outcomes are surfaced to the operator via flash:
+      - generated: count + nothing more (success, common case)
+      - skipped (no entrants): each event named individually so the operator can
+        click straight through to registration and add the missing competitors,
+        rather than seeing a single "Skipped 13 without entrants" line that
+        gives no path to resolution.
+      - errors (anything else): each event named with the underlying error,
+        plus a per-event ``error`` flash so they cannot be missed.
     """
     from flask import flash
+    from markupsafe import Markup, escape
     events = tournament.events.order_by(Event.event_type, Event.name, Event.gender).all()
     generated = 0
-    skipped = 0
-    errors = 0
+    skipped_events: list[tuple[Event, str]] = []
+    failed_events: list[tuple[Event, str]] = []
 
     for event in events:
         try:
@@ -232,15 +242,64 @@ def _generate_all_heats(tournament: Tournament, generate_event_heats_fn):
             generated += 1
         except Exception as exc:
             # begin_nested().__exit__ rolls back to the savepoint on exception.
-            if 'No competitors entered' in str(exc):
-                skipped += 1
+            msg = str(exc)
+            if 'No competitors entered' in msg:
+                skipped_events.append((event, msg))
             else:
-                errors += 1
-                flash(f'Heat generation error for {event.display_name}: {exc}', 'error')
+                failed_events.append((event, msg))
+                flash(
+                    f'Heat generation error for {event.display_name}: {msg}',
+                    'error',
+                )
 
-    flash(f'Heats generated for {generated} event(s). Skipped {skipped} without entrants.', 'success')
-    if errors:
-        flash(f'Failed to generate heats for {errors} event(s).', 'error')
+    flash(f'Heats generated for {generated} event(s).', 'success')
+
+    if skipped_events:
+        # Build clickable per-division summary so operators can jump straight
+        # to the right registration page and fix the missing entries.
+        from flask import url_for
+        college_skipped = [e for e, _ in skipped_events if e.event_type == 'college']
+        pro_skipped = [e for e, _ in skipped_events if e.event_type == 'pro']
+
+        if pro_skipped:
+            names = ', '.join(_event_label(e) for e in pro_skipped)
+            link = url_for('registration.pro_registration', tournament_id=tournament.id)
+            flash(
+                Markup(
+                    f'{len(pro_skipped)} pro event(s) skipped — no competitors entered: '
+                    f'<strong>{escape(names)}</strong>. '
+                    f'<a href="{escape(link)}" class="alert-link">Open pro registration</a> '
+                    f'to add entries, then click Generate again.'
+                ),
+                'warning',
+            )
+        if college_skipped:
+            names = ', '.join(_event_label(e) for e in college_skipped)
+            link = url_for('registration.college_registration', tournament_id=tournament.id)
+            flash(
+                Markup(
+                    f'{len(college_skipped)} college event(s) skipped — no competitors entered: '
+                    f'<strong>{escape(names)}</strong>. '
+                    f'<a href="{escape(link)}" class="alert-link">Open college registration</a> '
+                    f'to add entries, then click Generate again.'
+                ),
+                'warning',
+            )
+
+    if failed_events:
+        flash(
+            f'Failed to generate heats for {len(failed_events)} event(s) — see errors above.',
+            'error',
+        )
+
+
+def _event_label(event: Event) -> str:
+    """Compact label for flash messages: ``"Underhand (M)"``."""
+    base = event.display_name if hasattr(event, 'display_name') else event.name
+    gender = (getattr(event, 'gender', None) or '').strip()
+    if gender and f'({gender})' not in base:
+        return f'{base} ({gender})'
+    return base
 
 
 def _build_pro_flights_if_possible(tournament: Tournament, build_pro_flights_fn, num_flights=None):

--- a/services/schedule_status.py
+++ b/services/schedule_status.py
@@ -40,6 +40,13 @@ class Warning_(TypedDict, total=False):
     detail: str
     link: str | None
     link_label: str | None
+    # When set, the events.html warning panel renders the call-to-action
+    # as a POST <form> submitting this value as the ``action`` field to
+    # ``scheduling.event_list`` instead of a hyperlink. Lets a single
+    # click on the warning actually run the operation it advertises
+    # (e.g. "Generate pro heats" actually generates), instead of bouncing
+    # the user back to the page they are already on.
+    submit_action: str | None
 
 
 class DayStatus(TypedDict):
@@ -213,6 +220,7 @@ def _build_warnings(
                 + ("…" if len(college_missing) > 5 else ""),
                 "link": url_for("scheduling.event_list", tournament_id=tid),
                 "link_label": "Generate college heats",
+                "submit_action": "generate_all",
             }
         )
 
@@ -230,6 +238,7 @@ def _build_warnings(
                 + ("…" if len(pro_missing) > 5 else ""),
                 "link": url_for("scheduling.event_list", tournament_id=tid),
                 "link_label": "Generate pro heats",
+                "submit_action": "generate_all",
             }
         )
 
@@ -243,6 +252,7 @@ def _build_warnings(
                 "detail": 'Click "Build Flights" or "One-click Saturday Show Build" to group heats into flights.',
                 "link": url_for("scheduling.event_list", tournament_id=tid),
                 "link_label": "Build flights",
+                "submit_action": "rebuild_flights",
             }
         )
 
@@ -280,6 +290,7 @@ def _build_warnings(
                 "detail": "These events share physical stands and must not run at the same time. Rebuild flights to resolve.",
                 "link": url_for("scheduling.event_list", tournament_id=tid),
                 "link_label": "Rebuild flights",
+                "submit_action": "rebuild_flights",
             }
         )
 

--- a/templates/scheduling/events.html
+++ b/templates/scheduling/events.html
@@ -282,7 +282,21 @@
                                 <div class="fw-semibold">{{ w.title }}</div>
                                 {% if w.detail %}<div class="small text-muted">{{ w.detail }}</div>{% endif %}
                             </div>
-                            {% if w.link %}
+                            {% if w.submit_action %}
+                            {# Actionable warning: render as POST form so a single click on
+                               the warning runs the operation it advertises. The previous
+                               <a href="event_list"> bounced the user back to the page they
+                               were already on with no generation triggered. #}
+                            <form method="POST" action="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}"
+                                  class="flex-shrink-0 m-0" data-loading>
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" name="action" value="{{ w.submit_action }}"
+                                        class="btn btn-sm btn-{{ w.severity }}"
+                                        data-confirm="{{ w.link_label or 'Run this action?' }} — proceed?">
+                                    <i class="bi bi-lightning-charge me-1"></i>{{ w.link_label or 'Run' }}
+                                </button>
+                            </form>
+                            {% elif w.link %}
                             <a href="{{ w.link }}" class="btn btn-sm btn-outline-{{ w.severity }} flex-shrink-0">
                                 {{ w.link_label or 'Open' }}
                             </a>

--- a/tests/test_schedule_status.py
+++ b/tests/test_schedule_status.py
@@ -243,3 +243,127 @@ class TestEventListRouteRendersPanel:
         html = r.get_data(as_text=True)
         assert "Current Schedule" in html, "status panel missing from events.html"
         assert "No events configured yet" in html
+
+
+class TestWarningsCarrySubmitAction:
+    """Regression tests for the V2.14.x bug where the 'Generate pro heats'
+    button in the schedule status panel was a hyperlink to scheduling.event_list
+    — i.e. the page the operator was already on. Clicking it just reloaded
+    the page with no generation triggered, which the operator (correctly)
+    perceived as a broken button.
+
+    The fix: actionable warnings now carry a ``submit_action`` field that the
+    template uses to render a POST <form> button submitting that action to
+    scheduling.event_list. One click runs the operation it advertises.
+    """
+
+    def test_pro_missing_heats_carries_submit_action(self, app, tournament):
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Springboard",
+                event_type="pro",
+                gender="M",
+                scoring_type="time",
+                stand_type="springboard",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.commit()
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        pro_warning = next(
+            (w for w in s["warnings"] if "pro event" in w["title"]), None
+        )
+        assert pro_warning is not None
+        assert pro_warning.get("submit_action") == "generate_all", (
+            "pro_missing warning must carry submit_action='generate_all' so the "
+            "warning button actually generates instead of reloading the page"
+        )
+
+    def test_college_missing_heats_carries_submit_action(self, app, tournament):
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Underhand",
+                event_type="college",
+                gender="M",
+                scoring_type="time",
+                stand_type="underhand",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.commit()
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        college_warning = next(
+            (w for w in s["warnings"] if "college event" in w["title"]), None
+        )
+        assert college_warning is not None
+        assert college_warning.get("submit_action") == "generate_all"
+
+    def test_pro_heats_without_flights_carries_rebuild_action(self, app, tournament):
+        with app.app_context():
+            ev = Event(
+                tournament_id=tournament.id,
+                name="Springboard",
+                event_type="pro",
+                gender="M",
+                scoring_type="time",
+                stand_type="springboard",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.flush()
+            h = Heat(event_id=ev.id, heat_number=1, run_number=1, competitors="[]")
+            db.session.add(h)
+            db.session.commit()
+        with app.test_request_context("/"):
+            s = build_schedule_status(tournament)
+        flights_warning = next(
+            (w for w in s["warnings"] if "flights are not built" in w["title"]), None
+        )
+        assert flights_warning is not None
+        assert flights_warning.get("submit_action") == "rebuild_flights"
+
+    def test_template_renders_form_button_when_submit_action_set(self, app, client):
+        """The events.html template must render an actionable warning as a POST
+        form button (not a hyperlink) so clicking it triggers generation.
+        """
+        with app.app_context():
+            t = Tournament(name="Submit Action Render Test", year=2026, status="setup")
+            db.session.add(t)
+            db.session.flush()
+            ev = Event(
+                tournament_id=t.id,
+                name="Springboard",
+                event_type="pro",
+                gender="M",
+                scoring_type="time",
+                stand_type="springboard",
+                is_open=False,
+            )
+            db.session.add(ev)
+            db.session.commit()
+            tid = t.id
+
+            from models.user import User
+            u = User(username="submit_action_admin", role="admin")
+            u.set_password("testpass123")
+            db.session.add(u)
+            db.session.commit()
+            uid = u.id
+
+        with client.session_transaction() as sess:
+            sess["_user_id"] = str(uid)
+            sess["_fresh"] = True
+
+        r = client.get(f"/scheduling/{tid}/events")
+        assert r.status_code == 200
+        html = r.get_data(as_text=True)
+        # The warning must render as a POST form with the action field set.
+        # A bare <a href> would mean the click bug is back.
+        assert 'name="action" value="generate_all"' in html, (
+            "actionable warning must render as a POST submit button so a single "
+            "click triggers generation"
+        )


### PR DESCRIPTION
## Summary

- The "Generate pro heats" / "Generate college heats" / "Build flights" / "Rebuild flights" buttons in the Schedule Status warning panel on Run Show > Build Schedule now **actually run** the operation when clicked, instead of bouncing the operator back to the page they were already on.
- When `_generate_all_heats` skips events because no competitors entered them, the post-redirect flash now **names the skipped events** and **links straight to the right registration page** so the operator can fix the gap without hunting.

## Why this matters

Race-week operator was on Run Show > Build Schedule with the warning "13 pro event(s) have no heats yet" and a "Generate pro heats" button. Clicking the button reloaded the same page with no generation triggered. The button label was a lie — it was rendered as `<a href="scheduling.event_list">` and `scheduling.event_list` IS the Run Show page itself. Operators correctly read this as a broken button.

Compounding: when the actual orange "Generate All Heats + Build Flights" form button on the same page DID run, the wrapper `_generate_all_heats` lumped every "no competitors entered" event into a single "Skipped N without entrants" flash with no event names and no path to fix anything. So the warning kept shouting "13 pro events have no heats" with no actionable resolution.

## What changed

**Three production files + one test file:**

1. `services/schedule_status.py` — Added `submit_action` field to the `Warning_` TypedDict. Four warnings now carry an action: `college_missing` and `pro_missing` (`generate_all`), `pro_heats_without_flights` and `cookie_block_simultaneous` (`rebuild_flights`).

2. `templates/scheduling/events.html` — Warning panel renders the CTA as a POST `<form>` button submitting to `scheduling.event_list` with the named action when `submit_action` is set. Non-actionable warnings keep the `<a href>` fallback.

3. `routes/scheduling/__init__.py` — `_generate_all_heats` now collects skipped events by name, splits by `event_type`, and emits two distinct `Markup`-flashed warnings (college vs pro) that name every skipped event and link to the matching registration page.

4. `tests/test_schedule_status.py` — New `TestWarningsCarrySubmitAction` class (4 tests) including a route-level test that asserts the rendered HTML contains `name="action" value="generate_all"` (guards against template regression that drops the form-button branch).

## Coordination with parallel session V2.14.5

Zero file overlap with PR #85 (payout templates). Bumped 2.14.5 → 2.14.6 across `pyproject.toml` + both `routes/main.py` `/health` + `/health/diag` literals per PREPARE FOR COMMIT step 5. Suite includes both V2.14.5 payout-template-render tests and the new V2.14.6 warning tests — all 41 pass together.

## Test plan

- [x] `pytest tests/test_schedule_status.py` — 12/12 pass (8 existing + 4 new regression)
- [x] `pytest tests/test_one_click_and_fnf.py tests/test_flight_builder_async_spillover.py tests/test_payout_template_render.py` — 29/29 pass (no regressions in adjacent areas, V2.14.5 payout tests still green)
- [x] End-to-end Flask test client: GET renders POST form, POST `action=generate_all` returns 302, follow-up GET surfaces flash with skipped event name + registration link
- [ ] Post-deploy: `curl https://missoula-pro-am-manager-production.up.railway.app/health` returns `"version":"2.14.6"`
- [ ] Post-deploy: race-week operator clicks "Generate pro heats" warning button on Run Show — confirms generation actually runs

## Meta-lesson captured

When a warning panel CTA links to the same page the user is on, the click is silently a no-op. Either the warning needs an actionable `submit_action` so one click runs the operation, or the warning needs a different target (anchor jump, sibling page) so the click visibly does something. Static `url_for(...)` warning links with no awareness of the rendering page are the failure mode here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)