### PR TITLE
hotfix: pre-PEP-701 f-string compat for unpaired flash

### DIFF
--- a/routes/scheduling/__init__.py
+++ b/routes/scheduling/__init__.py
@@ -269,10 +269,14 @@ def _generate_all_heats(tournament: Tournament, generate_event_heats_fn):
         total = sum(len(rows) for _, rows in unpaired_by_event)
         per_event_blurbs = []
         for ev, rows in unpaired_by_event:
-            names = ', '.join(
-                f"{r['comp_name']}{(' → \"' + r['partner_name'] + '\"') if r['partner_name'] else ''}"
-                for r in rows[:3]
-            )
+            # Build each name blurb without backslashes inside the f-string
+            # expression (Python 3.10 / pre-PEP-701 constraint). Prod runs 3.10.
+            def _blurb(row: dict) -> str:
+                partner = row.get('partner_name') or ''
+                if partner:
+                    return '{} → "{}"'.format(row.get('comp_name', ''), partner)
+                return row.get('comp_name', '')
+            names = ', '.join(_blurb(r) for r in rows[:3])
             extra = f' (+{len(rows) - 3} more)' if len(rows) > 3 else ''
             per_event_blurbs.append(
                 f'<strong>{escape(_event_label(ev))}</strong>: {escape(names)}{extra}'


### PR DESCRIPTION
## Summary

Hotfix for V2.14.10 deploy failure on Railway. Production runs Python 3.10; my unpaired-partner flash code at \`routes/scheduling/__init__.py:273\` had a backslash inside an f-string expression part, which PEP 701 (3.12+) only just allowed. Pre-3.12 raises:

\`\`\`
SyntaxError: f-string expression part cannot include a backslash
\`\`\`

App couldn't import → \`flask db upgrade\` (Railway pre-deploy command) failed → V2.14.10 stayed un-shipped. Prod still on V2.14.9 (no downtime).

## Fix

Extract a local \`_blurb()\` helper so the conditional + string concatenation lives outside the f-string. Backslashes in the LITERAL portions of f-strings are fine on 3.10; only the EXPRESSION portion between \`{}\` is restricted.

## Verified

\`\`\`
for f in <every-file-touched-in-V2.14.10>; do
  python -c "import ast; ast.parse(open('$f').read(), feature_version=(3,10))"
done
\`\`\`

All clean. Only the \`__init__.py\` line had the violation.

## Test plan

- [x] AST parse with \`feature_version=(3,10)\` on all V2.14.10 files
- [x] Existing test suite green (252/252)
- [ ] Railway deploy succeeds
- [ ] \`/health\` reports \`2.14.10\`

## Why no version bump

V2.14.10 attempt 1 failed before serving any traffic. Attempt 2 ships the same content with the syntax fix. Bumping to .11 would imply meaningful behaviour change vs the V2.14.10 changelog — there is none.

## Note for future

This is the same foot-gun MEMORY.md flagged in V2.6.x: nested-f-string Python 3.12+ syntax that crashes on 3.10. Adding a CI lint pass that runs \`ast.parse(..., feature_version=(3,10))\` on every \`.py\` file would catch this class before it reaches Railway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)