### PR TITLE
Harden race-day reliability and compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,7 @@ jobs:
           PROAM_ROUTE_SMOKE_SOURCE_DB: instance/ci_route_smoke.db
         run: |
           pytest -x -q --tb=short \
-            --ignore=tests/test_migration_integrity.py \
-            --ignore=tests/test_db_constraints.py \
-            --ignore=tests/test_model_json_safety.py \
-            --ignore=tests/test_postgres_compat.py
+            --ignore=tests/test_migration_integrity.py
 
   postgres-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,7 @@ jobs:
             --ignore=tests/test_migration_integrity.py \
             --ignore=tests/test_db_constraints.py \
             --ignore=tests/test_model_json_safety.py \
-            --ignore=tests/test_postgres_compat.py \
-            --ignore=tests/test_edge_cases.py \
-            --ignore=tests/test_integration_qa.py
+            --ignore=tests/test_postgres_compat.py
 
   postgres-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       # AttributeError on first_tournament.id for all 245 tests. Sets its own
       # DATABASE_URL/SECRET_KEY, so it needs no env block here.
       - name: Build seeded route-smoke database
+        env:
+          PROAM_ALLOW_CI_SMOKE_DB_BUILD: "1"
         run: python scripts/ci_build_smoke_db.py
 
       - name: Run tests
@@ -47,6 +49,7 @@ jobs:
           SECRET_KEY: ci-test-secret-key
           DATABASE_URL: sqlite:///test.db
           TEST_USE_CREATE_ALL: "1"
+          PROAM_ROUTE_SMOKE_SOURCE_DB: instance/ci_route_smoke.db
         run: |
           pytest -x -q --tb=short \
             --ignore=tests/test_migration_integrity.py \
@@ -152,6 +155,8 @@ jobs:
       # test_route_smoke.py replays the alembic chain once per parametrized
       # route and peaks near 5 GB.
       - name: Build seeded route-smoke database
+        env:
+          PROAM_ALLOW_CI_SMOKE_DB_BUILD: "1"
         run: python scripts/ci_build_smoke_db.py
 
       - name: Run the unit suite on PostgreSQL
@@ -162,6 +167,7 @@ jobs:
           PROAM_UNIT_PG_HOST: localhost
           PROAM_UNIT_PG_USER: postgres
           PROAM_UNIT_PG_PASSWORD: postgres
+          PROAM_ROUTE_SMOKE_SOURCE_DB: instance/ci_route_smoke.db
         run: pytest tests -q --tb=short -p no:randomly
 
   lint:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -65,12 +65,7 @@ logger = logging.getLogger('alembic.env')
 
 
 def get_engine():
-    try:
-        # this works with Flask-SQLAlchemy<3 and Alchemical
-        return current_app.extensions['migrate'].db.get_engine()
-    except (TypeError, AttributeError):
-        # this works with Flask-SQLAlchemy>=3
-        return current_app.extensions['migrate'].db.engine
+    return current_app.extensions['migrate'].db.engine
 
 
 def get_engine_url():

--- a/migrations/versions/u0c4d5e6f7a8_birling_bracket_tables.py
+++ b/migrations/versions/u0c4d5e6f7a8_birling_bracket_tables.py
@@ -119,6 +119,12 @@ BIG_ID = sa.BigInteger().with_variant(sa.Integer(), "sqlite")
 
 _POOL_TABLE = {"college": "college_competitors", "pro": "pro_competitors"}
 
+_FALL_INSERT = sa.text(
+    "INSERT INTO birling_falls "
+    "(match_row_id, fall_number, winner_uid, recorded_at) "
+    "VALUES (:m, :n, :w, :t)"
+).bindparams(sa.bindparam("t", type_=sa.DateTime()))
+
 
 def _parse(raw):
     """Parse a ``payouts`` value into a dict, forgiving what it must.
@@ -450,9 +456,7 @@ def _write(connection, plan):
 
         for fall in match["falls"]:
             connection.execute(
-                sa.text("INSERT INTO birling_falls "
-                        "(match_row_id, fall_number, winner_uid, recorded_at) "
-                        "VALUES (:m, :n, :w, :t)"),
+                _FALL_INSERT,
                 {"m": row_id, "n": fall["fall_number"], "w": fall["winner_uid"],
                  "t": fall["recorded_at"]})
 

--- a/models/audit_log.py
+++ b/models/audit_log.py
@@ -1,7 +1,6 @@
 """Audit log model for critical state changes."""
-from datetime import datetime
-
 from database import db
+from services.time_utils import utc_now_naive
 
 
 class AuditLog(db.Model):
@@ -22,5 +21,5 @@ class AuditLog(db.Model):
     ip_address = db.Column(db.String(64), nullable=True)
     user_agent = db.Column(db.String(255), nullable=True)
     details_json = db.Column(db.Text, nullable=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
 

--- a/models/competitor_identity.py
+++ b/models/competitor_identity.py
@@ -45,11 +45,11 @@ registration path somebody writes.  ``attach_identity_allocator`` therefore
 creates the identity object at construction time, so there is always something
 for the proxy to write through.
 """
-from datetime import datetime
 
 import sqlalchemy as sa
 
 from database import db
+from services.time_utils import utc_now_naive
 
 from ._types import BIG_ID
 
@@ -77,7 +77,7 @@ class Competitor(db.Model):
         nullable=False,
     )
 
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
 
     # Contact.  Moved off pro_competitors / college_competitors by q6e7f8a0b2c3.
     #
@@ -129,7 +129,7 @@ def allocate_uid(connection, tournament_id, kind):
         table.insert().values(
             kind=kind,
             tournament_id=tournament_id,
-            created_at=datetime.utcnow(),
+            created_at=utc_now_naive(),
         )
     )
     return result.inserted_primary_key[0]

--- a/models/print_email_log.py
+++ b/models/print_email_log.py
@@ -4,9 +4,9 @@ One row per send attempt. Populated by services/email_delivery.py.
 """
 
 import json
-from datetime import datetime
 
 from database import db
+from services.time_utils import utc_now_naive
 
 EMAIL_LOG_STATUSES = ("queued", "sent", "failed")
 
@@ -31,7 +31,7 @@ class PrintEmailLog(db.Model):
     )
     subject = db.Column(db.String(300), nullable=False)
 
-    sent_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    sent_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
     sent_by_user_id = db.Column(
         db.Integer,
         db.ForeignKey("users.id", ondelete="SET NULL"),

--- a/models/print_tracker.py
+++ b/models/print_tracker.py
@@ -9,9 +9,8 @@ data underlying the print; if the fingerprint changes between the last print
 and the next Hub page load, the row is flagged STALE.
 """
 
-from datetime import datetime
-
 from database import db
+from services.time_utils import utc_now_naive
 
 
 class PrintTracker(db.Model):
@@ -34,7 +33,7 @@ class PrintTracker(db.Model):
     # ids that exist; orphans are acceptable historical bookkeeping.
     entity_id = db.Column(db.Integer, nullable=True)
 
-    last_printed_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    last_printed_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
     last_printed_fingerprint = db.Column(db.String(64), nullable=False)
     last_printed_by_user_id = db.Column(
         db.Integer,

--- a/models/tournament.py
+++ b/models/tournament.py
@@ -1,12 +1,11 @@
 """
 Tournament model for managing overall tournament state.
 """
-from datetime import datetime
-
 import sqlalchemy as sa
 
 from config import TournamentStatus  # noqa: F401 — re-exported for convenience
 from database import db
+from services.time_utils import utc_now_naive
 
 
 class Tournament(db.Model):
@@ -35,8 +34,10 @@ class Tournament(db.Model):
     schedule_config = db.Column(db.Text, nullable=True)
 
     # Timestamps
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
+    updated_at = db.Column(
+        db.DateTime, nullable=False, default=utc_now_naive, onupdate=utc_now_naive
+    )
 
     # Relationships
     # O3: every dynamic relationship carries a deterministic default order.

--- a/models/tournament_event.py
+++ b/models/tournament_event.py
@@ -30,11 +30,10 @@ This model is inert.  The migration creates the table; nothing writes to it and
 nothing reads from it.  It exists so the reducer, projector, and dispatcher in
 later phases have a substrate already in production and already migrated.
 """
-from datetime import datetime
-
 import sqlalchemy as sa
 
 from database import db
+from services.time_utils import utc_now_naive
 
 from ._types import BIG_ID, JSON_PAYLOAD
 
@@ -71,7 +70,7 @@ class TournamentEvent(db.Model):
     )
 
     # Injected at the edge. NEVER read inside the reducer.
-    occurred_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    occurred_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
 
     # Fully self-describing intent. Must carry everything the reducer needs;
     # the reducer is not allowed to query other tables to interpret it.

--- a/models/user.py
+++ b/models/user.py
@@ -1,8 +1,6 @@
 """
 User model for role-based authentication.
 """
-from datetime import datetime
-
 import sqlalchemy as sa
 
 try:
@@ -22,6 +20,7 @@ except ModuleNotFoundError:
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from database import db
+from services.time_utils import utc_now_naive
 
 
 class User(UserMixin, db.Model):
@@ -51,8 +50,8 @@ class User(UserMixin, db.Model):
         db.Boolean, nullable=False, default=True, server_default=sa.true()
     )
 
-    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    created_at = db.Column(db.DateTime, default=utc_now_naive, nullable=False)
+    updated_at = db.Column(db.DateTime, default=utc_now_naive, onupdate=utc_now_naive, nullable=False)
 
     def __repr__(self):
         return f'<User {self.username} ({self.role})>'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+xfail_strict = true
+filterwarnings = ["error::DeprecationWarning"]
 
 [tool.coverage.run]
 source = ["routes", "services", "models"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,9 +12,8 @@ markers =
 
 # Default: show short summary, 1-line per failure, warnings
 addopts = --tb=short -q
+xfail_strict = true
 
-# Ignore deprecation warnings from dependencies we don't control
+# Keep removed APIs from returning unnoticed as dependencies evolve.
 filterwarnings =
-    ignore::DeprecationWarning:sqlalchemy
-    ignore::DeprecationWarning:supabase
-    ignore::DeprecationWarning:flask_sqlalchemy
+    error::DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ psycopg2-binary==2.9.10
 
 # Excel Processing
 pandas==2.1.3
-openpyxl==3.1.2
+openpyxl==3.1.5
 
 # Utilities
 # CSO PR #10: bumped Werkzeug 3.0.6 → 3.1.6 to fix CVE-2025-66221,

--- a/routes/api.py
+++ b/routes/api.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 
 from flask import Blueprint, Response, current_app, jsonify, stream_with_context
 
+from database import db
 from services.time_utils import utc_now_naive
 
 
@@ -117,7 +118,7 @@ except ImportError:
 @api_bp.route('/public/tournaments/<int:tournament_id>/standings')
 @_limit('120 per minute')
 def public_standings(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pro_earnings_rows = (
         ProCompetitor.query
         .filter_by(tournament_id=tournament.id, status='active')
@@ -142,7 +143,7 @@ def public_standings(tournament_id):
 
 @api_bp.route('/public/tournaments/<int:tournament_id>/schedule')
 def public_schedule(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = tournament.events.order_by(Event.event_type, Event.name, Event.gender).all()
     event_ids = [e.id for e in events]
 
@@ -182,7 +183,7 @@ def public_schedule(tournament_id):
 
 @api_bp.route('/public/tournaments/<int:tournament_id>/results')
 def public_results(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     completed_events = tournament.events.filter_by(status='completed').order_by(Event.event_type, Event.name, Event.gender).all()
     event_ids = [e.id for e in completed_events]
 
@@ -231,7 +232,7 @@ def public_results(tournament_id):
 @_limit('120 per minute')
 def standings_poll(tournament_id):
     """Lightweight polling endpoint for live leaderboard auto-refresh."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     cache_key = f'api:standings-poll:{tournament_id}'
     ttl_seconds = max(1, int(current_app.config.get('PUBLIC_CACHE_TTL_SECONDS', 5)))
     cached = cache_get(cache_key)
@@ -370,7 +371,7 @@ def handicap_input(tournament_id):
     Public payload intended for handicap portal integrations.
     Includes chopping-only historical rows for model ingestion.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     return jsonify({
         'tournament': {
             'id': tournament.id,

--- a/routes/api.py
+++ b/routes/api.py
@@ -8,6 +8,8 @@ from decimal import Decimal
 
 from flask import Blueprint, Response, current_app, jsonify, stream_with_context
 
+from services.time_utils import utc_now_naive
+
 
 def _json_default(obj):
     """JSON encoder fallback for types the stdlib encoder doesn't handle.
@@ -278,7 +280,7 @@ def standings_poll(tournament_id):
 
     payload = {
         'tournament_id': tournament_id,
-        'last_updated': datetime.utcnow().isoformat() + 'Z',
+        'last_updated': utc_now_naive().isoformat() + 'Z',
         'college_teams': teams,
         'bull': bull,
         'belle': belle,

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -252,7 +252,7 @@ def toggle_user_active(user_id):
     if denied:
         return denied
 
-    user = User.query.get_or_404(user_id)
+    user = db.get_or_404(User, user_id)
     if user.id == current_user.id:
         log_action('user_toggle_active_denied', 'user', user.id, {
             'reason': 'self_disable_attempt',

--- a/routes/import_routes.py
+++ b/routes/import_routes.py
@@ -27,6 +27,7 @@ from database import db
 from models import Event, EventResult, ProCompetitor, Tournament
 from services.audit import log_action
 from services.gear_sharing import build_name_index, parse_gear_sharing_details, resolve_partner_name
+from services.time_utils import utc_now_naive
 from services.upload_security import malware_scan, save_upload, validate_excel_upload
 
 import_pro_bp = Blueprint('import_pro', __name__)
@@ -258,7 +259,7 @@ def confirm_pro_entries(tournament_id):
     # Competitors whose gear_sharing was just written and need to be mirrored
     # to their partners after the main commit (gear audit fix G5 — 2026-04-07).
     gear_synced_competitors: list = []
-    now      = datetime.utcnow()
+    now      = utc_now_naive()
 
     roster = ProCompetitor.query.filter_by(tournament_id=tournament_id).all()
     existing_names = [c.name for c in roster]

--- a/routes/import_routes.py
+++ b/routes/import_routes.py
@@ -88,7 +88,7 @@ def _temp_path(filename: str) -> str:
 # ---------------------------------------------------------------------------
 @import_pro_bp.route('/<int:tournament_id>/pro-entries', methods=['GET', 'POST'])
 def upload_pro_entries(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if request.method == 'GET':
         return render_template('pro/import_upload.html', tournament=tournament)
@@ -183,7 +183,7 @@ def upload_pro_entries(tournament_id):
 # ---------------------------------------------------------------------------
 @import_pro_bp.route('/<int:tournament_id>/pro-entries/review')
 def review_pro_entries(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     temp_name = session.get(_session_key(tournament_id))
     if not temp_name:
@@ -227,7 +227,7 @@ def review_pro_entries(tournament_id):
 # ---------------------------------------------------------------------------
 @import_pro_bp.route('/<int:tournament_id>/pro-entries/confirm', methods=['POST'])
 def confirm_pro_entries(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     temp_name = session.get(_session_key(tournament_id))
     if not temp_name:

--- a/routes/main.py
+++ b/routes/main.py
@@ -291,7 +291,7 @@ def new_tournament():
 @main_bp.route('/tournament/<int:tournament_id>')
 def tournament_detail(tournament_id):
     """Tournament detail and management page."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     from models.wood_config import WoodConfig
     # Get summary statistics
@@ -315,7 +315,7 @@ def tournament_detail(tournament_id):
 @main_bp.route('/tournament/<int:tournament_id>/setup', methods=['GET'])
 def tournament_setup(tournament_id):
     """Consolidated setup page: events, wood specs, and tournament dates."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     active_tab = request.args.get('tab', 'payouts')
 
     # Events tab data — helpers live in scheduling.py
@@ -395,7 +395,7 @@ def tournament_setup(tournament_id):
 def save_tournament_settings(tournament_id):
     """Save tournament name, year, and dates."""
     from datetime import date as date_type
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     name = request.form.get('name', '').strip()
     if name:
@@ -443,7 +443,7 @@ def save_tournament_settings(tournament_id):
 @main_bp.route('/tournament/<int:tournament_id>/activate/<competition_type>', methods=['POST'])
 def activate_competition(tournament_id, competition_type):
     """Activate college or pro competition for a tournament."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if competition_type == 'college':
         tournament.status = TournamentStatus.COLLEGE_ACTIVE
@@ -476,7 +476,7 @@ def activate_competition(tournament_id, competition_type):
 @main_bp.route('/tournament/<int:tournament_id>/delete', methods=['POST'])
 def delete_tournament(tournament_id):
     """Delete a tournament from the dashboard list."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     tournament_name = f'{tournament.name} {tournament.year}'
     confirmation = request.form.get('confirm_delete', '').strip()
 
@@ -530,7 +530,7 @@ def delete_tournament(tournament_id):
 @main_bp.route('/tournament/<int:tournament_id>/college')
 def college_dashboard(tournament_id):
     """College competition dashboard."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     teams = tournament.teams.all()
     events = tournament.events.filter_by(event_type='college').all()
@@ -565,7 +565,7 @@ def college_dashboard(tournament_id):
 @main_bp.route('/tournament/<int:tournament_id>/pro')
 def pro_dashboard(tournament_id):
     """Professional competition dashboard."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     competitors = tournament.pro_competitors.all()
     events = tournament.events.filter_by(event_type='pro').all()
@@ -615,7 +615,7 @@ def pro_dashboard(tournament_id):
 @main_bp.route('/tournament/<int:tournament_id>/clone', methods=['POST'])
 def clone_tournament(tournament_id):
     """Clone a tournament: copy events (no heats/results) and all competitor/team records."""
-    source = Tournament.query.get_or_404(tournament_id)
+    source = db.get_or_404(Tournament, tournament_id)
 
     # Create new tournament
     new_tournament = Tournament(
@@ -819,7 +819,7 @@ def ops_dashboard(tid):
     Read-only.  Requires judge role (main is in MANAGEMENT_BLUEPRINTS).
     Auto-refreshes every 30 seconds via JS.
     """
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
 
     from models.audit_log import AuditLog
     from models.event import EventResult
@@ -1026,7 +1026,7 @@ def export_tournament_config(tournament_id):
     and schedule config. Seeds the modular platform — extract REAL config from a
     WORKING tournament instead of building abstract config from scratch.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = Event.query.filter_by(tournament_id=tournament_id).order_by(Event.name).all()
 
     event_configs = []

--- a/routes/main.py
+++ b/routes/main.py
@@ -933,6 +933,21 @@ def ops_dashboard(tid):
     # ------------------------------------------------------------------
     # Section 4: Payout status — pro events only
     # ------------------------------------------------------------------
+    # Keep the operator's go/no-go signal on the race-day dashboard. The full
+    # report remains the source for details and any authorized autofix action.
+    try:
+        from services.preflight import build_preflight_report
+
+        preflight_report = build_preflight_report(tournament)
+        preflight_summary = {
+            'available': True,
+            'issue_count': preflight_report['issue_count'],
+            'has_blockers': preflight_report['has_blockers'],
+        }
+    except Exception:
+        logger.warning('ops_dashboard: scheduling preflight failed', exc_info=True)
+        preflight_summary = {'available': False, 'issue_count': 0, 'has_blockers': False}
+
     pro_event_ids = [ev.id for ev in all_events if ev.event_type == 'pro']
     total_purse = 0.0
     total_settled = 0.0
@@ -995,6 +1010,7 @@ def ops_dashboard(tid):
         team_health=team_health,
         relay_event=relay_event,
         integrity_warnings=integrity_warnings,
+        preflight_summary=preflight_summary,
         payout_summary=payout_summary,
         events=events,
         recent_jobs=recent_jobs,

--- a/routes/partnered_axe.py
+++ b/routes/partnered_axe.py
@@ -63,7 +63,7 @@ def dashboard(tournament_id):
     an Event row (GET-with-side-effect is the same class of bug as the
     Woodboss ghost rows — one of the reasons this branch exists).
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = find_partnered_axe_throw(tournament_id)
 
     if pat is None:
@@ -90,7 +90,7 @@ def dashboard(tournament_id):
 @bp.route('/enable', methods=['POST'])
 def enable(tournament_id):
     """Explicit POST to create the Partnered Axe Throw event row."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     get_or_create_partnered_axe_throw(tournament_id)
     invalidate_tournament_caches(tournament_id)
     flash('Partnered Axe Throw enabled for this tournament.', 'success')
@@ -100,7 +100,7 @@ def enable(tournament_id):
 @bp.route('/register-pair', methods=['POST'])
 def register_pair(tournament_id):
     """Register a new pair."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = get_or_create_partnered_axe_throw(tournament_id)
 
     try:
@@ -130,7 +130,7 @@ def register_pair(tournament_id):
 @bp.route('/prelims')
 def prelims(tournament_id):
     """Prelims scoring page."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = find_partnered_axe_throw(tournament_id)
     if pat is None:
         flash('Partnered Axe Throw is not enabled for this tournament.', 'warning')
@@ -148,7 +148,7 @@ def prelims(tournament_id):
 @bp.route('/prelims/record', methods=['POST'])
 def record_prelim(tournament_id):
     """Record a prelim result."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = get_or_create_partnered_axe_throw(tournament_id)
 
     try:
@@ -185,7 +185,7 @@ def record_prelim(tournament_id):
 @bp.route('/advance-to-finals', methods=['POST'])
 def advance_to_finals(tournament_id):
     """Advance top 4 to finals."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = get_or_create_partnered_axe_throw(tournament_id)
 
     try:
@@ -204,7 +204,7 @@ def advance_to_finals(tournament_id):
 @bp.route('/finals')
 def finals(tournament_id):
     """Finals scoring page."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = find_partnered_axe_throw(tournament_id)
     if pat is None:
         flash('Partnered Axe Throw is not enabled for this tournament.', 'warning')
@@ -221,7 +221,7 @@ def finals(tournament_id):
 @bp.route('/finals/record', methods=['POST'])
 def record_final(tournament_id):
     """Record a final result."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = get_or_create_partnered_axe_throw(tournament_id)
 
     try:
@@ -257,7 +257,7 @@ def record_final(tournament_id):
 @bp.route('/results')
 def results(tournament_id):
     """Final results page."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = find_partnered_axe_throw(tournament_id)
     if pat is None:
         flash('Partnered Axe Throw is not enabled for this tournament.', 'warning')
@@ -274,7 +274,7 @@ def results(tournament_id):
 @bp.route('/reset', methods=['POST'])
 def reset(tournament_id):
     """Reset the event."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = find_partnered_axe_throw(tournament_id)
     if pat is None:
         flash('Partnered Axe Throw is not enabled for this tournament.', 'warning')
@@ -291,7 +291,7 @@ def reset(tournament_id):
 @bp.route('/api/status')
 def api_status(tournament_id):
     """Get event status as JSON."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     pat = find_partnered_axe_throw(tournament_id)
     if pat is None:
         return jsonify({

--- a/routes/portal.py
+++ b/routes/portal.py
@@ -16,6 +16,7 @@ from flask_login import current_user, login_required
 from sqlalchemy import func
 
 from config import TournamentStatus
+from database import db
 from models import Event, EventResult, Heat, Team, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 from models.school_captain import SchoolCaptain
@@ -65,7 +66,7 @@ def competitor_access():
             flash('Please enter the competitor full name.', 'error')
             return redirect(url_for('portal.competitor_access', view=view_mode))
 
-        tournament = Tournament.query.get_or_404(tournament_id)
+        tournament = db.get_or_404(Tournament, tournament_id)
         matches = _find_competitor_matches(tournament, full_name)
         if not matches:
             flash('No competitor found with that name in this tournament.', 'error')
@@ -105,7 +106,7 @@ def competitor_access():
 def spectator_dashboard(tournament_id):
     """Public spectator landing page with College vs Pro choice."""
     view_mode = _resolve_view_mode(prefer_mobile=True)
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     return render_template(
         'portal/spectator_dashboard.html',
         tournament=tournament,
@@ -118,7 +119,7 @@ def spectator_dashboard(tournament_id):
 def spectator_college_standings(tournament_id):
     """College-focused spectator page."""
     view_mode = _resolve_view_mode(prefer_mobile=True)
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     payload = _cached_public_payload(
         f'portal:college:{tournament_id}',
         lambda: _build_college_spectator_payload(tournament),
@@ -140,7 +141,7 @@ def spectator_college_standings(tournament_id):
 def spectator_pro_standings(tournament_id):
     """Pro-focused spectator page."""
     view_mode = _resolve_view_mode(prefer_mobile=True)
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     payload = _cached_public_payload(
         f'portal:pro:{tournament_id}',
@@ -160,7 +161,7 @@ def spectator_pro_standings(tournament_id):
 def spectator_relay_results(tournament_id):
     """Public Pro-Am Relay results page."""
     view_mode = _resolve_view_mode(prefer_mobile=True)
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.proam_relay import get_proam_relay
 
     relay = get_proam_relay(tournament)
@@ -179,8 +180,8 @@ def spectator_relay_results(tournament_id):
 def spectator_event_results(tournament_id, event_id):
     """Public event results page with heat/ranking sorting options."""
     view_mode = _resolve_view_mode(prefer_mobile=True)
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
     if event.status != 'completed':
@@ -223,7 +224,7 @@ def competitor_public():
         flash('Invalid competitor portal link.', 'error')
         return redirect(url_for('portal.competitor_access', view=view_mode))
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     competitor = _load_competitor(tournament_id, competitor_type, competitor_id)
     if not competitor:
         flash('Competitor not found for this tournament.', 'error')
@@ -267,7 +268,7 @@ def competitor_claim():
         flash('Invalid competitor verification request.', 'error')
         return redirect(url_for('portal.competitor_access', view=view_mode))
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     competitor = _load_competitor(tournament_id, competitor_type, competitor_id)
     if not competitor:
         flash('Competitor not found for this tournament.', 'error')
@@ -335,7 +336,6 @@ def competitor_claim():
             ))
         competitor.set_portal_pin(pin)
         _mark_competitor_session_authorized(tournament_id, competitor_type, competitor_id)
-        from database import db
         db.session.commit()
         flash('PIN set. Your competitor portal is now protected.', 'success')
         return redirect(url_for(
@@ -380,7 +380,7 @@ def competitor_dashboard():
         flash('Competitor account is missing tournament/competitor link data.', 'error')
         return redirect(url_for('main.index'))
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     competitor = _load_competitor(tournament_id, competitor_type, competitor_id)
     if not competitor:
         flash('Linked competitor record was not found.', 'error')
@@ -696,7 +696,7 @@ def _build_pro_spectator_payload(tournament: Tournament) -> dict:
 @portal_bp.route('/kiosk/<int:tournament_id>')
 def kiosk(tournament_id):
     """Auto-rotating fullscreen kiosk display for TV/projector."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     # College team standings
     from models import Team
@@ -778,7 +778,6 @@ def sms_opt_in_toggle():
     new_state = not bool(competitor.phone_opted_in)
     competitor.phone_opted_in = new_state
 
-    from database import db
     from services.audit import log_action
     log_action('sms_opt_in_changed', 'competitor', competitor_id, {
         'competitor_type': competitor_type,
@@ -823,7 +822,7 @@ def school_access():
             flash('Please enter your school name.', 'error')
             return redirect(url_for('portal.school_access', view=view_mode))
 
-        tournament = Tournament.query.get_or_404(tournament_id)
+        tournament = db.get_or_404(Tournament, tournament_id)
         matched_schools = _find_schools(tournament, school_query)
 
         if not matched_schools:
@@ -872,7 +871,7 @@ def school_claim():
         flash('Invalid school portal link.', 'error')
         return redirect(url_for('portal.school_access', view=view_mode))
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if not tournament.teams.filter_by(school_name=school_name, status='active').first():
         flash('School not found in this tournament.', 'error')
@@ -893,8 +892,6 @@ def school_claim():
     requires_pin = captain is not None and captain.has_pin
 
     if request.method == 'POST':
-        from database import db
-
         if requires_pin:
             pin = (request.form.get('pin') or '').strip()
             if not _is_valid_pin(pin):
@@ -975,7 +972,7 @@ def school_dashboard():
         flash('Invalid school portal link.', 'error')
         return redirect(url_for('portal.school_access', view=view_mode))
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if not _can_access_school_page(tournament_id, school_name):
         return redirect(url_for(
@@ -1155,14 +1152,14 @@ def competitor_my_results(tournament_id, competitor_type, competitor_id):
     holds an authenticated claim for this competitor, PIN is not re-prompted.
     """
     view_mode = _resolve_view_mode(prefer_mobile=True)
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if competitor_type == 'college':
-        competitor = CollegeCompetitor.query.get_or_404(competitor_id)
+        competitor = db.get_or_404(CollegeCompetitor, competitor_id)
         if competitor.tournament_id != tournament_id:
             abort(404)
     elif competitor_type == 'pro':
-        competitor = ProCompetitor.query.get_or_404(competitor_id)
+        competitor = db.get_or_404(ProCompetitor, competitor_id)
         if competitor.tournament_id != tournament_id:
             abort(404)
     else:

--- a/routes/proam_relay.py
+++ b/routes/proam_relay.py
@@ -24,7 +24,7 @@ bp = Blueprint('proam_relay', __name__, url_prefix='/tournament/<int:tournament_
 @bp.route('/')
 def relay_dashboard(tournament_id):
     """Pro-Am Relay dashboard."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     teams = relay.get_teams()
@@ -47,7 +47,7 @@ def relay_dashboard(tournament_id):
 @bp.route('/draw', methods=['POST'])
 def draw_lottery(tournament_id):
     """Run the Pro-Am Relay lottery."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     try:
@@ -74,7 +74,7 @@ def draw_lottery(tournament_id):
 @bp.route('/redraw', methods=['POST'])
 def redraw_lottery(tournament_id):
     """Clear and redraw the lottery."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     existing_team_count = len(relay.get_teams()) or 2
@@ -106,7 +106,7 @@ def redraw_lottery(tournament_id):
 @bp.route('/teams')
 def view_teams(tournament_id):
     """View the relay teams."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
     teams = relay.get_teams()
     team_health = {t['team_number']: compute_team_health(t, tournament) for t in teams}
@@ -122,7 +122,7 @@ def view_teams(tournament_id):
 @bp.route('/results', methods=['GET', 'POST'])
 def enter_results(tournament_id):
     """Enter relay total times per team."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     if request.method == 'POST':
@@ -165,7 +165,7 @@ def enter_results(tournament_id):
 @bp.route('/standings')
 def standings(tournament_id):
     """View relay standings/results."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     return render_template('proam_relay/standings.html',
@@ -179,7 +179,7 @@ def standings(tournament_id):
 @bp.route('/manual-teams', methods=['GET'])
 def manual_teams(tournament_id):
     """Manual team builder with drag-and-drop."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     return render_template('proam_relay/manual_teams.html',
@@ -194,7 +194,7 @@ def manual_teams(tournament_id):
 @bp.route('/manual-teams/save', methods=['POST'])
 def save_manual_teams(tournament_id):
     """Save manually assigned teams."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     try:
@@ -221,7 +221,7 @@ def save_manual_teams(tournament_id):
 @bp.route('/replace-competitor', methods=['POST'])
 def replace_competitor(tournament_id):
     """Replace a competitor on a team (e.g., due to injury)."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     try:
@@ -255,7 +255,7 @@ def replace_competitor(tournament_id):
 @bp.route('/payouts', methods=['GET'])
 def relay_payouts(tournament_id):
     """Show relay payout configuration form."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay_event = Event.query.filter_by(
         tournament_id=tournament_id, name='Pro-Am Relay'
     ).first()
@@ -274,7 +274,7 @@ def relay_payouts(tournament_id):
 @bp.route('/payouts', methods=['POST'])
 def save_relay_payouts(tournament_id):
     """Save per-team lump sum payout amounts."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     relay_event = Event.query.filter_by(
         tournament_id=tournament_id, name='Pro-Am Relay'
     ).first()
@@ -304,7 +304,7 @@ def save_relay_payouts(tournament_id):
 @bp.route('/api/status')
 def api_status(tournament_id):
     """Get relay status as JSON."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = get_proam_relay(tournament)
 
     return jsonify({

--- a/routes/registration.py
+++ b/routes/registration.py
@@ -451,7 +451,7 @@ def remove_competitor_event(tournament_id, competitor_id):
 
     # Re-validate team
     errors_by_team = _validate_college_entry_constraints({competitor.team_id})
-    team = Team.query.get(competitor.team_id)
+    team = db.session.get(Team, competitor.team_id)
     if team:
         team_errors = errors_by_team.get(competitor.team_id, [])
         team.set_validation_errors(team_errors)
@@ -490,7 +490,7 @@ def add_competitor_event(tournament_id, competitor_id):
 
     # Re-validate team
     errors_by_team = _validate_college_entry_constraints({competitor.team_id})
-    team = Team.query.get(competitor.team_id)
+    team = db.session.get(Team, competitor.team_id)
     if team:
         team_errors = errors_by_team.get(competitor.team_id, [])
         team.set_validation_errors(team_errors)
@@ -522,7 +522,7 @@ def set_competitor_partner(tournament_id, competitor_id):
 
     # Re-validate team
     errors_by_team = _validate_college_entry_constraints({competitor.team_id})
-    team = Team.query.get(competitor.team_id)
+    team = db.session.get(Team, competitor.team_id)
     if team:
         team_errors = errors_by_team.get(competitor.team_id, [])
         team.set_validation_errors(team_errors)
@@ -1296,7 +1296,7 @@ def pro_gear_group_remove(tournament_id):
                 comp.gear_sharing = json.dumps(gear)
                 removed += 1
     elif competitor_id:
-        comp = ProCompetitor.query.get(competitor_id)
+        comp = db.session.get(ProCompetitor, competitor_id)
         if comp and comp.tournament_id == tournament_id:
             gear = comp.get_gear_sharing()
             if gear.get(event_key) == group_value:
@@ -1370,7 +1370,7 @@ def college_gear_update_ajax(tournament_id):
     except (TypeError, ValueError):
         return jsonify({'ok': False, 'error': 'Invalid competitor ID.'})
 
-    comp = CollegeCompetitor.query.get(competitor_id)
+    comp = db.session.get(CollegeCompetitor, competitor_id)
     if not comp or comp.tournament_id != tournament_id:
         return jsonify({'ok': False, 'error': 'Competitor not found.'})
 

--- a/routes/registration.py
+++ b/routes/registration.py
@@ -89,7 +89,7 @@ def allowed_file(filename):
 @registration_bp.route('/<int:tournament_id>/college')
 def college_registration(tournament_id):
     """College team registration page."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     all_teams = tournament.teams.all()
     valid_teams = [t for t in all_teams if t.status != 'invalid']
     invalid_teams = [t for t in all_teams if t.status == 'invalid']
@@ -105,7 +105,7 @@ def college_registration(tournament_id):
 @write_limit('10 per minute')  # Excel parsing is expensive; prevents accidental or malicious flood.
 def upload_college_entry(tournament_id):
     """Upload and process a college entry form Excel file."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if 'file' not in request.files:
         flash(text.FLASH['no_file'], 'error')
@@ -171,8 +171,8 @@ def upload_college_entry(tournament_id):
 @registration_bp.route('/<int:tournament_id>/college/team/<int:team_id>')
 def team_detail(tournament_id, team_id):
     """View and edit team details."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    team = Team.query.get_or_404(team_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    team = db.get_or_404(Team, team_id)
     if team.tournament_id != tournament.id:
         flash('Team not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -239,7 +239,7 @@ def team_detail(tournament_id, team_id):
 @registration_bp.route('/<int:tournament_id>/college/competitor/<int:competitor_id>/scratch', methods=['POST'])
 def scratch_college_competitor(tournament_id, competitor_id):
     """Scratch a college competitor via the cascade preview flow."""
-    competitor = CollegeCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(CollegeCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -259,7 +259,7 @@ def scratch_college_competitor(tournament_id, competitor_id):
 @registration_bp.route('/<int:tournament_id>/college/competitor/<int:competitor_id>/delete', methods=['POST'])
 def delete_college_competitor(tournament_id, competitor_id):
     """Delete a college competitor from registration and schedule."""
-    competitor = CollegeCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(CollegeCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -287,7 +287,7 @@ def delete_college_competitor(tournament_id, competitor_id):
 @registration_bp.route('/<int:tournament_id>/college/team/<int:team_id>/delete', methods=['POST'])
 def delete_college_team(tournament_id, team_id):
     """Delete a college team and all its competitors."""
-    team = Team.query.get_or_404(team_id)
+    team = db.get_or_404(Team, team_id)
     if team.tournament_id != tournament_id:
         flash('Team not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -322,7 +322,7 @@ def delete_college_team(tournament_id, team_id):
 def revalidate_team(tournament_id, team_id):
     """Re-run constraint validation for a team and promote to active if clean."""
     from services.excel_io import _validate_college_entry_constraints
-    team = Team.query.get_or_404(team_id)
+    team = db.get_or_404(Team, team_id)
     if team.tournament_id != tournament_id:
         flash('Team not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -353,7 +353,7 @@ def revalidate_team(tournament_id, team_id):
 @registration_bp.route('/<int:tournament_id>/college/team/<int:team_id>/override-validation', methods=['POST'])
 def override_team_validation(tournament_id, team_id):
     """Admin override: force a team to valid status despite validation errors."""
-    team = Team.query.get_or_404(team_id)
+    team = db.get_or_404(Team, team_id)
     if team.tournament_id != tournament_id:
         flash('Team not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -395,7 +395,7 @@ def remove_team_override(tournament_id, team_id):
     re-apply the override.
     """
     from services.excel_io import _validate_college_entry_constraints
-    team = Team.query.get_or_404(team_id)
+    team = db.get_or_404(Team, team_id)
     if team.tournament_id != tournament_id:
         flash('Team not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -427,7 +427,7 @@ def remove_team_override(tournament_id, team_id):
 def remove_competitor_event(tournament_id, competitor_id):
     """Remove a single event from a competitor's entry and re-validate the team."""
     from services.excel_io import _validate_college_entry_constraints
-    competitor = CollegeCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(CollegeCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -466,7 +466,7 @@ def remove_competitor_event(tournament_id, competitor_id):
 def add_competitor_event(tournament_id, competitor_id):
     """Add a single event to a competitor's entry and re-validate the team."""
     from services.excel_io import _validate_college_entry_constraints
-    competitor = CollegeCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(CollegeCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -505,7 +505,7 @@ def add_competitor_event(tournament_id, competitor_id):
 def set_competitor_partner(tournament_id, competitor_id):
     """Set or clear a competitor's partner for a specific event, then re-validate the team."""
     from services.excel_io import _validate_college_entry_constraints
-    competitor = CollegeCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(CollegeCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.college_registration', tournament_id=tournament_id))
@@ -539,7 +539,7 @@ def set_competitor_partner(tournament_id, competitor_id):
 @registration_bp.route('/<int:tournament_id>/pro')
 def pro_registration(tournament_id):
     """Legacy pro registration route now merged into the Pro dashboard."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     return redirect(url_for('main.pro_dashboard', tournament_id=tournament_id))
 
 
@@ -547,7 +547,7 @@ def pro_registration(tournament_id):
 @write_limit('30 per minute')  # Rate-limit competitor creation to prevent runaway imports.
 def new_pro_competitor(tournament_id):
     """Add a new professional competitor."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if request.method == 'POST':
         competitor = ProCompetitor(
@@ -619,8 +619,8 @@ def new_pro_competitor(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/<int:competitor_id>')
 def pro_competitor_detail(tournament_id, competitor_id):
     """View and edit professional competitor details."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament.id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.pro_registration', tournament_id=tournament_id))
@@ -685,8 +685,8 @@ def pro_competitor_detail(tournament_id, competitor_id):
 @registration_bp.route('/<int:tournament_id>/pro/<int:competitor_id>/update-events', methods=['POST'])
 def update_pro_events(tournament_id, competitor_id):
     """Update pro competitor event enrollment, fees, and gear sharing."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament.id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.pro_registration', tournament_id=tournament_id))
@@ -785,7 +785,7 @@ def update_pro_events(tournament_id, competitor_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing')
 def pro_gear_manager(tournament_id):
     """Gear-sharing audit and management dashboard for pro competitors."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import build_gear_report, get_gear_groups
     report = build_gear_report(tournament)
     gear_groups = get_gear_groups(tournament)
@@ -817,7 +817,7 @@ def pro_gear_manager(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/parse', methods=['POST'])
 def pro_gear_parse(tournament_id):
     """Parse free-text gear_sharing_details fields into structured gear_sharing maps."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import parse_all_gear_details
     try:
         result = parse_all_gear_details(tournament)
@@ -839,7 +839,7 @@ def pro_gear_parse(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/sync-heats', methods=['POST'])
 def pro_gear_sync_heats(tournament_id):
     """Detect and auto-fix gear-sharing conflicts in existing pro heats."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import fix_heat_gear_conflicts
     try:
         result = fix_heat_gear_conflicts(tournament)
@@ -875,14 +875,14 @@ def pro_gear_sync_heats(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/update', methods=['POST'])
 def pro_gear_update(tournament_id):
     """Set or clear a single gear-sharing entry for a pro competitor."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     try:
         competitor_id = int(request.form.get('competitor_id', ''))
     except (TypeError, ValueError):
         flash('Invalid competitor ID.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
 
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
@@ -952,13 +952,13 @@ def pro_gear_update(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/update-ajax', methods=['POST'])
 def pro_gear_update_ajax(tournament_id):
     """AJAX JSON endpoint for inline gear-sharing edits in the dashboard unresolved table."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     try:
         competitor_id = int(request.form.get('competitor_id', ''))
     except (TypeError, ValueError):
         return jsonify({'ok': False, 'error': 'Invalid competitor ID'}), 400
 
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         return jsonify({'ok': False, 'error': 'Competitor not found in this tournament'}), 403
 
@@ -1010,14 +1010,14 @@ def pro_gear_update_ajax(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/remove', methods=['POST'])
 def pro_gear_remove(tournament_id):
     """Remove a gear-sharing entry from a pro competitor."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     try:
         competitor_id = int(request.form.get('competitor_id', ''))
     except (TypeError, ValueError):
         flash('Invalid competitor ID.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
 
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
@@ -1039,7 +1039,7 @@ def pro_gear_remove(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/auto-assign-partners', methods=['POST'])
 def auto_assign_pro_partners_route(tournament_id):
     """Auto assign partners for pro partnered events."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.partner_matching import auto_assign_pro_partners
 
     summary = auto_assign_pro_partners(tournament)
@@ -1074,7 +1074,7 @@ def auto_assign_pro_partners_route(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/complete-pairs', methods=['POST'])
 def pro_gear_complete_pairs(tournament_id):
     """Write reciprocal gear-sharing entries for all one-sided pairs."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import complete_one_sided_pairs
     try:
         result = complete_one_sided_pairs(tournament)
@@ -1091,7 +1091,7 @@ def pro_gear_complete_pairs(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/cleanup-scratched', methods=['POST'])
 def pro_gear_cleanup_scratched(tournament_id):
     """Remove gear-sharing entries referencing scratched competitors."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import cleanup_scratched_gear_entries
     try:
         result = cleanup_scratched_gear_entries(tournament)
@@ -1118,7 +1118,7 @@ def pro_gear_cleanup_scratched(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/cleanup-non-enrolled', methods=['POST'])
 def pro_gear_cleanup_non_enrolled(tournament_id):
     """Remove gear-sharing entries pointing at events the competitor is not enrolled in."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import cleanup_non_enrolled_gear_entries
     try:
         result = cleanup_non_enrolled_gear_entries(tournament)
@@ -1147,7 +1147,7 @@ def pro_gear_cleanup_non_enrolled(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/auto-partners', methods=['POST'])
 def pro_gear_auto_partners(tournament_id):
     """Copy gear_sharing entries into partners for partnered events."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import auto_populate_partners_from_gear
     try:
         result = auto_populate_partners_from_gear(tournament)
@@ -1167,7 +1167,7 @@ def pro_gear_auto_partners(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/parse-review')
 def pro_gear_parse_review(tournament_id):
     """Show proposed gear-sharing parse results for review before committing."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import build_parse_review
     rows = build_parse_review(tournament)
     return render_template(
@@ -1180,7 +1180,7 @@ def pro_gear_parse_review(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/parse-confirm', methods=['POST'])
 def pro_gear_parse_confirm(tournament_id):
     """Commit approved parse rows from the parse-review page."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import (
         build_parse_review,
         normalize_person_name,
@@ -1222,7 +1222,7 @@ def pro_gear_parse_confirm(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/group-create', methods=['POST'])
 def pro_gear_group_create(tournament_id):
     """Create or update a gear-sharing group (multiple pairs sharing one piece of equipment)."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     group_name = (request.form.get('group_name') or '').strip()
     event_key = (request.form.get('event_key') or '').strip()
     competitor_ids_raw = request.form.getlist('competitor_ids')
@@ -1273,7 +1273,7 @@ def pro_gear_group_create(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/gear-sharing/group-remove', methods=['POST'])
 def pro_gear_group_remove(tournament_id):
     """Remove a gear-sharing group entry from one or all members."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     group_name = (request.form.get('group_name') or '').strip()
     event_key = (request.form.get('event_key') or '').strip()
     remove_all = request.form.get('remove_all') == 'on'
@@ -1322,7 +1322,7 @@ def pro_gear_group_remove(tournament_id):
 @registration_bp.route('/<int:tournament_id>/college/gear-sharing/update', methods=['POST'])
 def college_gear_update(tournament_id):
     """Set a gear-sharing entry for a college competitor."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     from models.competitor import CollegeCompetitor
     try:
         competitor_id = int(request.form.get('competitor_id', ''))
@@ -1330,7 +1330,7 @@ def college_gear_update(tournament_id):
         flash('Invalid competitor ID.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
 
-    comp = CollegeCompetitor.query.get_or_404(competitor_id)
+    comp = db.get_or_404(CollegeCompetitor, competitor_id)
     if comp.tournament_id != tournament_id:
         flash('Competitor not found.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
@@ -1363,7 +1363,7 @@ def college_gear_update(tournament_id):
 @registration_bp.route('/<int:tournament_id>/college/gear-sharing/update-ajax', methods=['POST'])
 def college_gear_update_ajax(tournament_id):
     """AJAX: Set a gear-sharing entry for a college competitor and return JSON."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     from models.competitor import CollegeCompetitor
     try:
         competitor_id = int(request.form.get('competitor_id', ''))
@@ -1399,7 +1399,7 @@ def college_gear_update_ajax(tournament_id):
 @registration_bp.route('/<int:tournament_id>/college/gear-sharing/remove', methods=['POST'])
 def college_gear_remove(tournament_id):
     """Remove a gear-sharing entry from a college competitor."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     from models.competitor import CollegeCompetitor
     try:
         competitor_id = int(request.form.get('competitor_id', ''))
@@ -1407,7 +1407,7 @@ def college_gear_remove(tournament_id):
         flash('Invalid competitor ID.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
 
-    comp = CollegeCompetitor.query.get_or_404(competitor_id)
+    comp = db.get_or_404(CollegeCompetitor, competitor_id)
     if comp.tournament_id != tournament_id:
         flash('Competitor not found.', 'error')
         return redirect(url_for('registration.pro_gear_manager', tournament_id=tournament_id))
@@ -1435,7 +1435,7 @@ def college_gear_remove(tournament_id):
 @record_print('gear_sharing_print')
 def pro_gear_print(tournament_id):
     """Printable gear-sharing report grouped by equipment category."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.gear_sharing import build_gear_report, get_gear_groups
     report = build_gear_report(tournament)
     gear_groups = get_gear_groups(tournament)
@@ -1454,7 +1454,7 @@ def pro_gear_print(tournament_id):
 @registration_bp.route('/<int:tournament_id>/pro/<int:competitor_id>/scratch', methods=['POST'])
 def scratch_pro_competitor(tournament_id, competitor_id):
     """Scratch a professional competitor via the cascade preview flow."""
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.pro_registration', tournament_id=tournament_id))
@@ -1550,7 +1550,7 @@ def _validate_image(file_storage) -> bool:
 @registration_bp.route('/<int:tournament_id>/pro/<int:competitor_id>/upload-headshot', methods=['POST'])
 def upload_pro_headshot(tournament_id, competitor_id):
     """Upload a headshot image for a pro competitor."""
-    competitor = ProCompetitor.query.get_or_404(competitor_id)
+    competitor = db.get_or_404(ProCompetitor, competitor_id)
     if competitor.tournament_id != tournament_id:
         flash('Competitor not found in this tournament.', 'error')
         return redirect(url_for('registration.pro_registration', tournament_id=tournament_id))

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -146,7 +146,7 @@ def college_standings(tournament_id):
     fails to break the tie.  The plain ``bull`` / ``belle`` lists stay in
     the payload for backwards compat with any caller that expects them.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     payload = _cached_payload(
         f'reports:{tournament_id}:college_standings',
@@ -196,7 +196,7 @@ def college_standings(tournament_id):
 @record_print('college_standings')
 def college_standings_print(tournament_id):
     """Printable version of college standings."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     bull = tournament.get_bull_of_woods(5)
     belle = tournament.get_belle_of_woods(5)
@@ -212,8 +212,8 @@ def college_standings_print(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/event/<int:event_id>/results')
 def event_results_report(tournament_id, event_id):
     """View detailed event results."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament.id:
         abort(404)
 
@@ -229,8 +229,8 @@ def event_results_report(tournament_id, event_id):
 @record_print('event_results', entity_id_kwarg='event_id')
 def event_results_print(tournament_id, event_id):
     """Printable version of event results."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament.id:
         abort(404)
 
@@ -245,7 +245,7 @@ def event_results_print(tournament_id, event_id):
 @reporting_bp.route('/<int:tournament_id>/pro/payouts', methods=['GET', 'POST'])
 def pro_payout_summary(tournament_id):
     """View pro competitor payout summary with settlement tracking."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from models.competitor import ProCompetitor
 
     if request.method == 'POST':
@@ -313,7 +313,7 @@ def pro_payout_summary(tournament_id):
 @record_print('pro_payouts')
 def pro_payout_summary_print(tournament_id):
     """Printable version of payout summary."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     competitors = tournament.pro_competitors.filter_by(status='active').all()
     competitors = sorted(competitors, key=lambda c: c.total_earnings, reverse=True)
@@ -329,7 +329,7 @@ def pro_payout_summary_print(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/all-results')
 def all_results(tournament_id):
     """View all event results for the tournament."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     college_events = tournament.events.filter_by(event_type='college', status='completed').all()
     pro_events = tournament.events.filter_by(event_type='pro', status='completed').all()
@@ -344,7 +344,7 @@ def all_results(tournament_id):
 @record_print('all_results')
 def all_results_print(tournament_id):
     """Printable version of all results."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     college_events = tournament.events.filter_by(event_type='college', status='completed').all()
     pro_events = tournament.events.filter_by(event_type='pro', status='completed').all()
@@ -358,7 +358,7 @@ def all_results_print(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/export-results')
 def export_results(tournament_id):
     """Export standings and event results to Excel."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     export = build_results_export(tournament)
     log_action('report_export_downloaded', 'tournament', tournament.id, {
         'tournament_id': tournament.id,
@@ -381,7 +381,7 @@ def export_results(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/export-chopping')
 def export_chopping_results(tournament_id):
     """Export only chopping event scores/results for external handicap tools."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     fmt = (request.args.get('format') or 'xlsx').strip().lower()
 
     if fmt == 'json':
@@ -416,7 +416,7 @@ def export_chopping_results(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/export-results/async', methods=['POST'])
 def export_results_async(tournament_id):
     """Start export generation as a background job for larger tournaments."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     job_id = submit_results_export_job(tournament_id)
     log_action('report_export_job_started', 'tournament', tournament.id, {'job_id': job_id})
     db.session.commit()
@@ -425,7 +425,7 @@ def export_results_async(tournament_id):
 
 @reporting_bp.route('/<int:tournament_id>/jobs/<job_id>')
 def export_results_job_status(tournament_id, job_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     job = resolve_completed_export_path(tournament_id, job_id, get_job)
     if not job:
         abort(404)
@@ -522,7 +522,7 @@ def export_video_judge_workbook(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/export-video-judge/async', methods=['POST'])
 def export_video_judge_workbook_async(tournament_id):
     """Start Video Judge workbook generation as a background job."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     job_id = submit_video_judge_export_job(tournament_id)
     log_action('report_export_job_started', 'tournament', tournament.id, {
         'job_id': job_id,
@@ -536,7 +536,7 @@ def export_video_judge_workbook_async(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/backup')
 def backup_database(tournament_id):
     """Download a raw sqlite backup file for disaster recovery."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
 
@@ -556,7 +556,7 @@ def backup_database(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/restore', methods=['POST'])
 def restore_database(tournament_id):
     """Restore SQLite database from an uploaded backup file."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
 
@@ -634,7 +634,7 @@ def payout_settlement(tournament_id):
 @reporting_bp.route('/<int:tournament_id>/pro/fee-tracker', methods=['GET', 'POST'])
 def fee_tracker(tournament_id):
     """Consolidated view for tracking entry fee collection from pro competitors."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from models.competitor import ProCompetitor
 
     if request.method == 'POST':
@@ -716,7 +716,7 @@ def pro_event_fees(tournament_id):
       fee_<event_id>   — fee amount for that event (float, blank to skip)
       overwrite        — if present, overwrite existing non-zero fees too
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from models.competitor import ProCompetitor
 
     pro_events = Event.query.filter_by(
@@ -805,7 +805,7 @@ def pro_event_fees(tournament_id):
 def cloud_backup(tournament_id):
     """Trigger an S3 cloud backup (or local fallback) and return JSON status."""
     from flask import jsonify
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
 
@@ -834,7 +834,7 @@ def ala_membership_report(tournament_id):
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.ala_report import build_ala_report
 
     report = build_ala_report(tournament)
@@ -856,7 +856,7 @@ def ala_membership_report_pdf(tournament_id):
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.ala_report import build_ala_report, generate_ala_pdf
 
     report = build_ala_report(tournament)
@@ -899,7 +899,7 @@ def ala_email_report(tournament_id):
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.ala_report import build_ala_report, generate_ala_pdf
 
     report = build_ala_report(tournament)

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -494,7 +494,7 @@ def export_video_judge_workbook(tournament_id):
     tournaments use the /async variant to offload via background_jobs.
     """
     from services.video_judge_export import VideoJudgeWorkbookError
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     try:
         export = build_video_judge_export(tournament)
     except VideoJudgeWorkbookError as exc:

--- a/routes/scheduling/ability_rankings.py
+++ b/routes/scheduling/ability_rankings.py
@@ -30,7 +30,7 @@ def ability_rankings(tournament_id):
         ProEventRank,
     )
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if request.method == 'POST':
         # Parse order_{category}_{gender} fields — each is a comma-separated list

--- a/routes/scheduling/assign_marks.py
+++ b/routes/scheduling/assign_marks.py
@@ -320,7 +320,7 @@ def assign_marks(tournament_id: int, event_id: int):
       manual_save   — write per-row mark inputs from the table
       csv_import    — parse pasted "name,mark" CSV/TSV block
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     event = Event.query.filter_by(id=event_id, tournament_id=tournament_id).first_or_404()
 
     eligible = is_mark_assignment_eligible(event)

--- a/routes/scheduling/birling.py
+++ b/routes/scheduling/birling.py
@@ -67,8 +67,8 @@ def _flash_projection_refusal(bb):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling', methods=['GET'])
 def birling_manage(tournament_id, event_id):
     """Birling bracket management page — seeding, generation, and match recording."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -154,8 +154,8 @@ def birling_manage(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/generate', methods=['POST'])
 def birling_generate(tournament_id, event_id):
     """Generate a new birling bracket using seeded order from form."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -238,8 +238,8 @@ def birling_generate(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/record', methods=['POST'])
 def birling_record_match(tournament_id, event_id):
     """Record the result of a birling match."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -293,8 +293,8 @@ def birling_record_match(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/fall', methods=['POST'])
 def birling_record_fall(tournament_id, event_id):
     """Record a single fall in a best-of-3 birling match."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -370,8 +370,8 @@ def _fall_loser_count(result):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/undo', methods=['POST'])
 def birling_undo_match(tournament_id, event_id):
     """Undo a birling match result — return both competitors to the match."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -421,8 +421,8 @@ def birling_undo_match(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/reset', methods=['POST'])
 def birling_reset(tournament_id, event_id):
     """Reset the birling bracket (clear all data)."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -446,8 +446,8 @@ def birling_reset(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/birling/finalize', methods=['POST'])
 def birling_finalize(tournament_id, event_id):
     """Finalize birling bracket — write placements to EventResult records."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -492,7 +492,7 @@ def birling_finalize(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/birling', methods=['GET'])
 def birling_index(tournament_id):
     """Landing page listing every college birling event in the tournament."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = (
         Event.query
         .filter_by(tournament_id=tournament_id)
@@ -567,8 +567,8 @@ def birling_print_blank(tournament_id, event_id):
     matches play out.  If the bracket has not been generated yet, flash
     a redirect back to the seeding page.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id or event.scoring_type != 'bracket':
         abort(404)
 
@@ -601,7 +601,7 @@ def birling_print_all(tournament_id):
     the ``judge_sheets_all`` idiom: one click, one document, show-prep
     ready.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = (
         Event.query
         .filter_by(tournament_id=tournament_id)

--- a/routes/scheduling/events.py
+++ b/routes/scheduling/events.py
@@ -210,7 +210,7 @@ def event_list(tournament_id):
     from services.flight_builder import build_pro_flights, integrate_college_spillover_into_flights
     from services.heat_generator import generate_event_heats
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     session_key = f'schedule_options_{tournament_id}'
 
     all_pro = tournament.events.filter_by(event_type='pro').order_by(Event.name, Event.gender).all()
@@ -302,7 +302,7 @@ def event_list(tournament_id):
 @scheduling_bp.route('/<int:tournament_id>/events/setup', methods=['GET', 'POST'])
 def setup_events(tournament_id):
     """Configure events for the tournament."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     college_open_events = [_with_field_key(e) for e in config.COLLEGE_OPEN_EVENTS]
     college_closed_events = [_with_field_key(e) for e in config.COLLEGE_CLOSED_EVENTS]
     pro_events = [_with_field_key(e) for e in config.PRO_EVENTS]
@@ -609,7 +609,7 @@ def day_schedule(tournament_id):
 def reorder_friday_events(tournament_id):
     """Save custom Friday event display order. Expects JSON {event_ids: [int, ...]}."""
     from flask import jsonify
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     try:
         data = request.get_json(force=True)
         event_ids = [int(eid) for eid in data.get('event_ids', [])]
@@ -633,7 +633,7 @@ def reorder_friday_events(tournament_id):
 def reorder_saturday_events(tournament_id):
     """Save custom Saturday event display order (fallback mode). Expects JSON {event_ids: [int, ...]}."""
     from flask import jsonify
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     try:
         data = request.get_json(force=True)
         event_ids = [int(eid) for eid in data.get('event_ids', [])]
@@ -657,7 +657,7 @@ def reset_event_order(tournament_id):
     Without the day key, resets both.
     """
     from flask import jsonify
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     cfg = tournament.get_schedule_config()
     try:
         data = request.get_json(force=True) or {}
@@ -688,7 +688,7 @@ def _day_schedule_legacy(tournament_id):
     from services.heat_generator import generate_event_heats
     from services.schedule_builder import COLLEGE_SATURDAY_PRIORITY, build_day_schedule
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     friday_feature_names = set(config.FRIDAY_NIGHT_EVENTS)
     pro_events = [
         event for event in tournament.events.filter_by(event_type='pro').order_by(Event.name, Event.gender).all()
@@ -815,7 +815,7 @@ def _build_event_progress(event: Event, entrant_count: int) -> dict:
 def apply_saturday_priority(tournament_id):
     """Re-number college event heats so COLLEGE_SATURDAY_PRIORITY_DEFAULT events run first."""
     import json as _json
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     # Load override file if present, else use default
     order_path = _os.path.join('instance', f'saturday_priority_{tournament_id}.json')

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -36,7 +36,7 @@ def one_click_generate(tournament_id):
     from services.heat_generator import generate_event_heats
     from services.saw_block_assignment import trigger_saw_block_recompute
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     db_config = tournament.get_schedule_config() or {}
     saturday_college_event_ids = [int(i) for i in db_config.get('saturday_college_event_ids', [])]
@@ -83,7 +83,7 @@ def one_click_generate(tournament_id):
 @scheduling_bp.route('/<int:tournament_id>/flights')
 def flight_list(tournament_id):
     """View and manage flights for pro competition."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     flights = Flight.query.filter_by(tournament_id=tournament_id).order_by(Flight.flight_number).all()
 
     # Pre-fetch competitor names + stand assignments for display.
@@ -255,7 +255,7 @@ def _resolve_num_flights_from_persisted_config(tournament) -> int | None:
 @scheduling_bp.route('/<int:tournament_id>/flights/build', methods=['GET', 'POST'])
 def build_flights(tournament_id):
     """Build flights for pro competition."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if request.method == 'POST':
         from services.flight_builder import build_pro_flights
@@ -536,7 +536,7 @@ def build_flights(tournament_id):
 @scheduling_bp.route('/<int:tournament_id>/flights/<int:flight_id>/reorder', methods=['POST'])
 def reorder_flight_heats(tournament_id, flight_id):
     """Reorder heats within a flight. Expects JSON {heat_ids: [int, ...]}."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     flight = Flight.query.filter_by(id=flight_id, tournament_id=tournament_id).first_or_404()
     try:
         data = request.get_json(force=True)
@@ -569,7 +569,7 @@ def bulk_reorder_flights(tournament_id):
     currently assigned to any of those flights — otherwise refuse to prevent
     an incomplete drag from wiping state.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     try:
         data = request.get_json(force=True)
@@ -642,7 +642,7 @@ def drag_move_competitor(tournament_id, source_heat_id):
 
     Returns: {ok: bool, error?: str, source?: {...}, target?: {...}}
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     source = Heat.query.filter_by(id=source_heat_id).first_or_404()
 
     try:
@@ -772,7 +772,7 @@ def drag_move_competitor(tournament_id, source_heat_id):
 @scheduling_bp.route('/<int:tournament_id>/flights/<int:flight_id>/start', methods=['POST'])
 def start_flight(tournament_id, flight_id):
     """Mark a flight as in_progress and send SMS to competitors in upcoming flights."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     flight = Flight.query.filter_by(id=flight_id, tournament_id=tournament_id).first_or_404()
 
     if flight.status == 'in_progress':

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -92,7 +92,7 @@ def flight_list(tournament_id):
     for flight in flights:
         heat_rows = []
         for heat in flight.get_heats_ordered():
-            event = Event.query.get(heat.event_id)
+            event = db.session.get(Event, heat.event_id)
             if not event:
                 continue
             comp_ids = heat.get_competitors()
@@ -388,7 +388,7 @@ def build_flights(tournament_id):
                     integrate_college_spillover_into_flights,
                     integrate_proam_relay_into_final_flight,
                 )
-                target = Tournament.query.get(target_tournament_id)
+                target = db.session.get(Tournament, target_tournament_id)
                 if not target:
                     raise RuntimeError(f'Tournament {target_tournament_id} not found.')
                 try:
@@ -824,7 +824,7 @@ def _send_upcoming_heat_sms(tournament_id: int, current_flight_number: int) -> N
         return
 
     # Batch-load all events referenced by this flight's heats so the SMS
-    # notify path doesn't issue one Event.query.get() per heat. Was N+1.
+    # notify path doesn't issue one db.session.get(Event, ) per heat. Was N+1.
     heats = list(target_flight.heats.all())
     event_ids = {h.event_id for h in heats}
     events_by_id = {

--- a/routes/scheduling/friday_feature.py
+++ b/routes/scheduling/friday_feature.py
@@ -244,13 +244,13 @@ def friday_feature_print(tournament_id):
     fnf_config = _load_fnf_config(tournament)
     fnf_schedule = _build_fnf_schedule(tournament, eligible_events, fnf_config)
 
-    from datetime import datetime
+    from services.time_utils import utc_now_naive
     return render_template(
         'scheduling/friday_feature_print.html',
         tournament=tournament,
         fnf_schedule=fnf_schedule,
         notes=fnf_config.get('notes', ''),
-        now=datetime.utcnow(),
+        now=utc_now_naive(),
     )
 
 
@@ -263,9 +263,8 @@ def friday_feature_pdf(tournament_id):
     On Railway the fallback serves HTML with Content-Type text/html so the user
     can still print via Ctrl-P without the deploy needing cairo/pango.
     """
-    from datetime import datetime
-
     from services.print_response import weasyprint_or_html
+    from services.time_utils import utc_now_naive
 
     tournament = Tournament.query.get_or_404(tournament_id)
     eligible_names = set(config.FRIDAY_NIGHT_EVENTS)
@@ -280,7 +279,7 @@ def friday_feature_pdf(tournament_id):
         tournament=tournament,
         fnf_schedule=fnf_schedule,
         notes=fnf_config.get('notes', ''),
-        now=datetime.utcnow(),
+        now=utc_now_naive(),
     )
     safe_name = f"{tournament.name}_{tournament.year}_friday_night_feature".replace(' ', '_').replace('/', '-')
     return weasyprint_or_html(html, safe_name)

--- a/routes/scheduling/friday_feature.py
+++ b/routes/scheduling/friday_feature.py
@@ -82,7 +82,7 @@ def friday_feature(tournament_id):
     """Configure Friday Night Feature events and Saturday college spillover."""
     from services.schedule_builder import COLLEGE_SATURDAY_PRIORITY
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     # FNF: pro events eligible for Friday Night
     eligible_names = set(config.FRIDAY_NIGHT_EVENTS)
@@ -236,7 +236,7 @@ def friday_feature(tournament_id):
 @record_print('fnf_print')
 def friday_feature_print(tournament_id):
     """Printable Friday Night Feature schedule — heat-by-heat order per event."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     eligible_names = set(config.FRIDAY_NIGHT_EVENTS)
     pro_events = tournament.events.filter_by(event_type='pro').order_by(Event.name, Event.gender).all()
     eligible_events = [e for e in pro_events if e.name in eligible_names]
@@ -266,7 +266,7 @@ def friday_feature_pdf(tournament_id):
     from services.print_response import weasyprint_or_html
     from services.time_utils import utc_now_naive
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     eligible_names = set(config.FRIDAY_NIGHT_EVENTS)
     pro_events = tournament.events.filter_by(event_type='pro').order_by(Event.name, Event.gender).all()
     eligible_events = [e for e in pro_events if e.name in eligible_names]

--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -50,7 +50,7 @@ def _hydrate_schedule_entries(
 ) -> list:
     hydrated = []
     for item in entries:
-        event = Event.query.get(item.get("event_id")) if item.get("event_id") else None
+        event = db.session.get(Event, item.get("event_id")) if item.get("event_id") else None
         detail_heats = []
         is_bracket = False
         is_partnered = False
@@ -63,7 +63,7 @@ def _hydrate_schedule_entries(
             if is_bracket:
                 bracket_competitors = _get_bracket_competitors(event)
             elif item.get("heat_id"):
-                heat = Heat.query.get(item["heat_id"])
+                heat = db.session.get(Heat, item["heat_id"])
                 if heat:
                     detail_heats = [_serialize_heat_detail(tournament, event, heat)]
             else:
@@ -187,7 +187,7 @@ def heat_sheets(tournament_id):
         for heat in heats_in_flight:
             comp_ids = heat.get_competitors()
             assignments = heat.get_stand_assignments()
-            event = Event.query.get(heat.event_id)
+            event = db.session.get(Event, heat.event_id)
             if not event:
                 continue
             if event.event_type == "college":

--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -160,9 +160,8 @@ def _serialize_heat_detail(tournament: Tournament, event: Event, heat: Heat) -> 
 @record_print("heat_sheets")
 def heat_sheets(tournament_id):
     """Print-ready heat sheets for all flights and events."""
-    from datetime import datetime
-
     from services.flight_builder import _STAND_CONFLICT_GAP
+    from services.time_utils import utc_now_naive
 
     tournament = Tournament.query.get_or_404(tournament_id)
 
@@ -343,7 +342,7 @@ def heat_sheets(tournament_id):
         flight_data=flight_data,
         no_flight_heats=no_flight_heats,
         birling_brackets=birling_brackets,
-        now=datetime.utcnow(),
+        now=utc_now_naive(),
         stand_conflict_gap=_STAND_CONFLICT_GAP,
     )
 
@@ -363,10 +362,9 @@ def relay_teams_sheet(tournament_id):
     cairo/pango fall back to HTML (Content-Type: text/html) while still showing
     a PDF filename hint.
     """
-    from datetime import datetime
-
     from services.print_response import weasyprint_or_html
     from services.proam_relay import ProAmRelay
+    from services.time_utils import utc_now_naive
 
     tournament = Tournament.query.get_or_404(tournament_id)
     relay = ProAmRelay(tournament)
@@ -383,7 +381,7 @@ def relay_teams_sheet(tournament_id):
         tournament=tournament,
         teams=teams,
         drawn=drawn,
-        now=datetime.utcnow(),
+        now=utc_now_naive(),
     )
     safe_name = (
         f"{tournament.name}_{tournament.year}_relay_teams"

--- a/routes/scheduling/heat_sheets.py
+++ b/routes/scheduling/heat_sheets.py
@@ -163,7 +163,7 @@ def heat_sheets(tournament_id):
     from services.flight_builder import _STAND_CONFLICT_GAP
     from services.time_utils import utc_now_naive
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     # Build {(event_id, competitor_id): status} for SCR/DNF indicators on heat sheets
     result_status = {
@@ -366,7 +366,7 @@ def relay_teams_sheet(tournament_id):
     from services.proam_relay import ProAmRelay
     from services.time_utils import utc_now_naive
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     relay = ProAmRelay(tournament)
     state = relay.relay_data or {}
     teams = state.get("teams") or []
@@ -396,7 +396,7 @@ def day_schedule_print(tournament_id):
     """Printable day schedule with heat/stand assignments."""
     from services.schedule_builder import build_day_schedule
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     session_key = f"schedule_options_{tournament_id}"
     # DB-first read: Friday Showcase page + Run Show page both persist these
     # keys to schedule_config. Reading session-only meant a printout from a

--- a/routes/scheduling/heats.py
+++ b/routes/scheduling/heats.py
@@ -28,8 +28,8 @@ from . import (
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/heats')
 def event_heats(tournament_id, event_id):
     """View and manage heats for an event."""
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament.id:
         abort(404)
 
@@ -109,7 +109,7 @@ def event_heats(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/generate-heats', methods=['POST'])
 def generate_heats(tournament_id, event_id):
     """Generate heats for an event using snake draft distribution."""
-    event = Event.query.get_or_404(event_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
 
@@ -250,7 +250,7 @@ def generate_college_heats(tournament_id):
     """Bulk-generate heats for all closed college events in one click."""
     from services.heat_generator import generate_event_heats
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = tournament.events.filter_by(event_type='college').order_by(Event.name, Event.gender).all()
 
     generated = 0
@@ -307,7 +307,7 @@ def generate_college_heats(tournament_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/move-competitor', methods=['POST'])
 def move_competitor_between_heats(tournament_id, event_id):
     """Move a competitor between heats (and mirrored dual run heat, if needed)."""
-    event = Event.query.get_or_404(event_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
 
@@ -319,8 +319,8 @@ def move_competitor_between_heats(tournament_id, event_id):
         flash('Invalid move request.', 'error')
         return redirect(url_for('scheduling.event_heats', tournament_id=tournament_id, event_id=event_id))
 
-    from_heat = Heat.query.get_or_404(from_heat_id)
-    to_heat = Heat.query.get_or_404(to_heat_id)
+    from_heat = db.get_or_404(Heat, from_heat_id)
+    to_heat = db.get_or_404(Heat, to_heat_id)
     if from_heat.event_id != event.id or to_heat.event_id != event.id:
         abort(404)
     if from_heat.id == to_heat.id:
@@ -468,7 +468,7 @@ def scratch_competitor(tournament_id, event_id):
     references, and recalculates positions if the event has scored results.
     For dual-run events, mirrors the scratch across both run heats.
     """
-    event = Event.query.get_or_404(event_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
 
@@ -479,7 +479,7 @@ def scratch_competitor(tournament_id, event_id):
         flash('Invalid scratch request.', 'error')
         return redirect(url_for('scheduling.event_heats', tournament_id=tournament_id, event_id=event_id))
 
-    heat = Heat.query.get_or_404(heat_id)
+    heat = db.get_or_404(Heat, heat_id)
     if heat.event_id != event.id:
         abort(404)
 
@@ -603,8 +603,8 @@ def add_to_heat(tournament_id, event_id):
     Validates capacity, creates EventResult if missing, and mirrors
     dual-run events. Blocked once the show is active for that division.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
-    event = Event.query.get_or_404(event_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
 
@@ -615,7 +615,7 @@ def add_to_heat(tournament_id, event_id):
         flash('Invalid add request.', 'error')
         return redirect(url_for('scheduling.event_heats', tournament_id=tournament_id, event_id=event_id))
 
-    heat = Heat.query.get_or_404(heat_id)
+    heat = db.get_or_404(Heat, heat_id)
     if heat.event_id != event.id:
         abort(404)
 
@@ -792,11 +792,11 @@ def add_to_heat(tournament_id, event_id):
 @scheduling_bp.route('/<int:tournament_id>/event/<int:event_id>/delete-heat/<int:heat_id>', methods=['POST'])
 def delete_heat(tournament_id, event_id, heat_id):
     """Delete an empty heat and renumber remaining heats."""
-    event = Event.query.get_or_404(event_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
 
-    heat = Heat.query.get_or_404(heat_id)
+    heat = db.get_or_404(Heat, heat_id)
     if heat.event_id != event.id:
         abort(404)
 
@@ -887,7 +887,7 @@ def recompute_saw_blocks(tournament_id):
     """Manually recompute hand-saw stand block assignments for the tournament."""
     from services.saw_block_assignment import assign_saw_blocks
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     try:
         summary = assign_saw_blocks(tournament)
         flash(
@@ -914,7 +914,7 @@ def saw_blocks_status(tournament_id):
         get_saturday_ordered_heats,
     )
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     def _rows(ordered_heats):
         rows = []

--- a/routes/scheduling/heats.py
+++ b/routes/scheduling/heats.py
@@ -204,7 +204,7 @@ def generate_heats(tournament_id, event_id):
                 'warning'
             )
         # Recompute hand-saw stand block alternation after heat gen commits.
-        tournament = Tournament.query.get(tournament_id)
+        tournament = db.session.get(Tournament, tournament_id)
         if tournament is not None:
             trigger_saw_block_recompute(tournament)
     except Exception as e:
@@ -395,7 +395,7 @@ def move_competitor_between_heats(tournament_id, event_id):
         try:
             from models import Event as EventModel
             from services.gear_sharing import competitors_share_gear_for_event
-            mover = ProCompetitor.query.get(competitor_id)
+            mover = db.session.get(ProCompetitor, competitor_id)
             if mover:
                 mover_gear = mover.get_gear_sharing()
                 all_events = EventModel.query.filter_by(tournament_id=event.tournament_id).all()
@@ -495,9 +495,9 @@ def scratch_competitor(tournament_id, event_id):
 
     # Look up competitor name for flash message
     if event.event_type == 'college':
-        comp = CollegeCompetitor.query.get(competitor_id)
+        comp = db.session.get(CollegeCompetitor, competitor_id)
     else:
-        comp = ProCompetitor.query.get(competitor_id)
+        comp = db.session.get(ProCompetitor, competitor_id)
     comp_name = comp.display_name if comp else f'Competitor #{competitor_id}'
 
     try:
@@ -538,7 +538,7 @@ def scratch_competitor(tournament_id, event_id):
         if comp:
             try:
                 from services.gear_sharing import cleanup_scratched_gear_entries
-                tournament = Tournament.query.get(tournament_id)
+                tournament = db.session.get(Tournament, tournament_id)
                 cleanup_scratched_gear_entries(tournament, scratched_competitor=comp)
             except Exception:
                 pass  # Gear cleanup failure should not block the scratch

--- a/routes/scheduling/partners.py
+++ b/routes/scheduling/partners.py
@@ -162,7 +162,7 @@ def set_partner_bidirectional(orphan, new_partner, event):
 @scheduling_bp.route("/<int:tid>/events/<int:eid>/partner-queue")
 def partner_queue(tid, eid):
     """GET: Show orphaned partners needing reassignment."""
-    event = Event.query.get_or_404(eid)
+    event = db.get_or_404(Event, eid)
     if event.tournament_id != tid:
         abort(404)
     if not getattr(event, "is_partnered", False):
@@ -206,7 +206,7 @@ def partner_queue(tid, eid):
 @scheduling_bp.route("/<int:tid>/events/<int:eid>/reassign-partner", methods=["POST"])
 def reassign_partner(tid, eid):
     """POST: Assign a new partner to an orphaned competitor."""
-    event = Event.query.get_or_404(eid)
+    event = db.get_or_404(Event, eid)
     if event.tournament_id != tid:
         abort(404)
 

--- a/routes/scheduling/partners.py
+++ b/routes/scheduling/partners.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def _load_competitor(comp_id, comp_type):
     """Load a competitor by ID and type string ('pro' or 'college')."""
     Model = ProCompetitor if comp_type == "pro" else CollegeCompetitor
-    return Model.query.get(comp_id)
+    return db.session.get(Model, comp_id)
 
 
 def get_orphaned_competitors(event):

--- a/routes/scheduling/preflight.py
+++ b/routes/scheduling/preflight.py
@@ -21,7 +21,7 @@ from . import scheduling_bp
 @scheduling_bp.route('/<int:tournament_id>/preflight', methods=['GET', 'POST'])
 def preflight_check(tournament_id):
     """Run preflight checks and offer one-click auto-fix actions."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     from services.flight_builder import integrate_college_spillover_into_flights
     from services.partner_matching import auto_assign_pro_partners
     from services.preflight import build_preflight_report
@@ -81,7 +81,7 @@ def preflight_check(tournament_id):
 def preflight_json(tournament_id):
     """JSON endpoint: inline preflight status for the events page."""
     from services.preflight import BLOCKING_CODES, build_preflight_report
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     session_key = f'schedule_options_{tournament_id}'
     saved = tournament.get_schedule_config() or session.get(session_key, {})
     saturday_ids = [int(eid) for eid in saved.get('saturday_college_event_ids', [])]
@@ -108,7 +108,7 @@ def preflight_json(tournament_id):
 @scheduling_bp.route('/<int:tournament_id>/events/generate-async', methods=['POST'])
 def generate_async(tournament_id):
     """Submit heat + flight generation as a background job and return a job_id."""
-    Tournament.query.get_or_404(tournament_id)
+    db.get_or_404(Tournament, tournament_id)
 
     job_id = submit_job(
         f'generate_all:{tournament_id}',

--- a/routes/scheduling/print_hub.py
+++ b/routes/scheduling/print_hub.py
@@ -375,9 +375,9 @@ def _render_document_html(tournament, doc, entity_obj):
     Flask view function directly — view functions may set response headers
     we don't want in an email context.
     """
-    from datetime import datetime
-
     from flask import render_template
+
+    from services.time_utils import utc_now_naive
 
     filename_base = f"{tournament.name}_{tournament.year}_{doc.key}".replace(" ", "_")
 
@@ -389,7 +389,7 @@ def _render_document_html(tournament, doc, entity_obj):
             "scheduling/pro_checkout_roster_print.html",
             tournament=tournament,
             rows=rows,
-            now=datetime.utcnow(),
+            now=utc_now_naive(),
         )
         return html, filename_base
 
@@ -424,7 +424,7 @@ def _render_document_html(tournament, doc, entity_obj):
             tournament=tournament,
             fnf_schedule=fnf_schedule,
             notes=fnf_config.get("notes", ""),
-            now=datetime.utcnow(),
+            now=utc_now_naive(),
         )
         return html, filename_base
 
@@ -646,6 +646,6 @@ def _compose_body(tournament, doc_label: str, extra_note: Optional[str]) -> str:
 
 
 def _utcnow_iso() -> str:
-    from datetime import datetime
+    from services.time_utils import utc_now_naive
 
-    return datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    return utc_now_naive().strftime("%Y-%m-%d %H:%M UTC")

--- a/routes/scheduling/print_hub.py
+++ b/routes/scheduling/print_hub.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 @scheduling_bp.route("/<int:tournament_id>/print-hub")
 def print_hub(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     rows = print_catalog.build_hub_rows(tournament)
 
     # Precompute the Print button URL for each row. Dynamic docs require
@@ -113,7 +113,7 @@ def _users_with_email() -> list:
 @scheduling_bp.route("/<int:tournament_id>/print-hub/email", methods=["POST"])
 @write_limit("20 per minute")
 def print_hub_email(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     if not email_delivery.is_configured():
         flash(

--- a/routes/scheduling/pro_checkout_roster.py
+++ b/routes/scheduling/pro_checkout_roster.py
@@ -8,13 +8,12 @@ installed, HTML fallback otherwise).
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from flask import render_template
 
 from models import Event, Tournament
 from services.print_catalog import record_print
 from services.print_response import weasyprint_or_html
+from services.time_utils import utc_now_naive
 
 from . import scheduling_bp
 
@@ -75,7 +74,7 @@ def pro_checkout_roster_print(tournament_id):
         "scheduling/pro_checkout_roster_print.html",
         tournament=tournament,
         rows=rows,
-        now=datetime.utcnow(),
+        now=utc_now_naive(),
     )
 
 
@@ -89,7 +88,7 @@ def pro_checkout_roster_pdf(tournament_id):
         "scheduling/pro_checkout_roster_print.html",
         tournament=tournament,
         rows=rows,
-        now=datetime.utcnow(),
+        now=utc_now_naive(),
     )
     filename = f"{tournament.name}_{tournament.year}_pro_checkout_roster".replace(
         " ", "_"

--- a/routes/scheduling/pro_checkout_roster.py
+++ b/routes/scheduling/pro_checkout_roster.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from flask import render_template
 
+from database import db
 from models import Event, Tournament
 from services.print_catalog import record_print
 from services.print_response import weasyprint_or_html
@@ -68,7 +69,7 @@ def _build_checkout_rows(tournament: Tournament) -> list[dict]:
 @record_print("pro_checkout")
 def pro_checkout_roster_print(tournament_id):
     """HTML print view — judge loads in browser and Ctrl-P."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     rows = _build_checkout_rows(tournament)
     return render_template(
         "scheduling/pro_checkout_roster_print.html",
@@ -82,7 +83,7 @@ def pro_checkout_roster_print(tournament_id):
 @record_print("pro_checkout")
 def pro_checkout_roster_pdf(tournament_id):
     """PDF download (WeasyPrint if installed, HTML fallback on Railway)."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     rows = _build_checkout_rows(tournament)
     html = render_template(
         "scheduling/pro_checkout_roster_print.html",

--- a/routes/scheduling/show_day.py
+++ b/routes/scheduling/show_day.py
@@ -3,6 +3,7 @@ Show Day live operations dashboard route.
 """
 from flask import render_template
 
+from database import db
 from models import Event, Flight, Heat, Tournament
 
 from . import scheduling_bp
@@ -28,12 +29,12 @@ def show_day(tournament_id):
         if current_heat is None:
             current_heat = next((h for h in heats_ordered if h.status not in ('completed',)), None)
 
-        current_event = Event.query.get(current_heat.event_id) if current_heat else None
+        current_event = db.session.get(Event, current_heat.event_id) if current_heat else None
 
         upcoming_pairs = []
         for h in heats_ordered:
             if h.status != 'completed' and h is not current_heat:
-                ev = Event.query.get(h.event_id)
+                ev = db.session.get(Event, h.event_id)
                 if ev:
                     upcoming_pairs.append((h, ev))
                 if len(upcoming_pairs) >= 2:

--- a/routes/scheduling/show_day.py
+++ b/routes/scheduling/show_day.py
@@ -15,7 +15,7 @@ from . import scheduling_bp
 @scheduling_bp.route('/<int:tournament_id>/show-day')
 def show_day(tournament_id):
     """Live operations dashboard for show day."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     flights = Flight.query.filter_by(tournament_id=tournament_id).order_by(Flight.flight_number).all()
 
     flight_data = []

--- a/routes/scoring.py
+++ b/routes/scoring.py
@@ -95,7 +95,7 @@ def _push_strathmark_results(event: Event, tournament_id: int) -> None:
     """
     try:
         from services import strathmark_sync
-        tournament = Tournament.query.get(tournament_id)
+        tournament = db.session.get(Tournament, tournament_id)
         year = tournament.year if tournament else 0
 
         if event.event_type == 'pro' and event.stand_type in ('standing_block', 'underhand'):
@@ -698,7 +698,7 @@ def enter_heat_results(tournament_id, heat_id):
         user_id = _current_user_id()
         if heat.is_locked() and heat.locked_by_user_id != (user_id or -1):
             from models.user import User
-            locker = User.query.get(heat.locked_by_user_id)
+            locker = db.session.get(User, heat.locked_by_user_id)
             owner = locker.username if locker else f'User #{heat.locked_by_user_id}'
             msg = f'Heat is currently being edited by {owner}. Your submission was not saved.'
             if _is_async():
@@ -727,7 +727,7 @@ def enter_heat_results(tournament_id, heat_id):
         if heat.is_locked() and heat.locked_by_user_id != user_id:
             lock_blocked = True
             from models.user import User
-            locker = User.query.get(heat.locked_by_user_id)
+            locker = db.session.get(User, heat.locked_by_user_id)
             lock_owner = locker.username if locker else f'User #{heat.locked_by_user_id}'
         else:
             heat.acquire_lock(user_id)
@@ -886,7 +886,7 @@ def undo_heat_save(tournament_id, heat_id):
                 )
                 touched_team_ids = {c.team_id for c in touched_comps if c.team_id}
                 for team_id in touched_team_ids:
-                    team = Team.query.get(team_id)
+                    team = db.session.get(Team, team_id)
                     if team:
                         team.recalculate_points()
 
@@ -1027,14 +1027,14 @@ def _load_competitor_for_tournament(tournament_id: int, competitor_id: int):
 
     comp_type = (request.values.get('competitor_type') or '').strip().lower()
     if comp_type == 'college':
-        comp = CollegeCompetitor.query.get(competitor_id)
+        comp = db.session.get(CollegeCompetitor, competitor_id)
     elif comp_type == 'pro':
-        comp = ProCompetitor.query.get(competitor_id)
+        comp = db.session.get(ProCompetitor, competitor_id)
     elif comp_type:
         abort(400, description='Invalid competitor_type.')
     else:
-        pro = ProCompetitor.query.get(competitor_id)
-        college = CollegeCompetitor.query.get(competitor_id)
+        pro = db.session.get(ProCompetitor, competitor_id)
+        college = db.session.get(CollegeCompetitor, competitor_id)
         in_tournament = [
             c for c in (pro, college)
             if c is not None and c.tournament_id == tournament_id
@@ -1412,7 +1412,7 @@ def tournament_payout_manager(tournament_id):
             if not event_ids:
                 flash('Select at least one event.', 'error')
                 return _payout_redirect()
-            template = PayoutTemplate.query.get(tpl_id)
+            template = db.session.get(PayoutTemplate, tpl_id)
             if not template:
                 flash('Template not found.', 'error')
                 return _payout_redirect()
@@ -1834,11 +1834,11 @@ def replay_offline_score():
     if not tournament_id or not heat_id:
         return jsonify({'ok': False, 'message': 'Missing tournament or heat ID.'}), 400
 
-    tournament = Tournament.query.get(tournament_id)
+    tournament = db.session.get(Tournament, tournament_id)
     if not tournament:
         return jsonify({'ok': False, 'message': 'Tournament not found.'}), 404
 
-    heat = Heat.query.get(heat_id)
+    heat = db.session.get(Heat, heat_id)
     if not heat or not heat.event or heat.event.tournament_id != tournament_id:
         return jsonify({'ok': False, 'message': 'Heat not found.'}), 404
 

--- a/routes/scoring.py
+++ b/routes/scoring.py
@@ -51,14 +51,14 @@ scoring_bp = Blueprint('scoring', __name__)
 # ---------------------------------------------------------------------------
 
 def _event_for_tournament_or_404(tournament_id: int, event_id: int) -> Event:
-    event = Event.query.get_or_404(event_id)
+    event = db.get_or_404(Event, event_id)
     if event.tournament_id != tournament_id:
         abort(404)
     return event
 
 
 def _heat_for_tournament_or_404(tournament_id: int, heat_id: int) -> Heat:
-    heat = Heat.query.get_or_404(heat_id)
+    heat = db.get_or_404(Heat, heat_id)
     if not heat.event or heat.event.tournament_id != tournament_id:
         abort(404)
     return heat
@@ -531,7 +531,7 @@ def next_unscored_heat(tournament_id, event_id):
 @scoring_bp.route('/<int:tournament_id>/next-incomplete-event')
 def next_incomplete_event(tournament_id):
     """Jump to the first event with pending heats in this tournament."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     # Find events that have at least one pending heat
     incomplete = (Event.query
                   .join(Heat, Heat.event_id == Event.id)
@@ -552,7 +552,7 @@ def next_incomplete_event(tournament_id):
 
 @scoring_bp.route('/<int:tournament_id>/event/<int:event_id>/results')
 def event_results(tournament_id, event_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     event = _event_for_tournament_or_404(tournament_id, event_id)
     heats = event.heats.order_by(Heat.heat_number, Heat.run_number).all()
     results = event.get_results_sorted()
@@ -687,7 +687,7 @@ def finalize_event(tournament_id, event_id):
 @login_required
 @write_limit('60 per minute')
 def enter_heat_results(tournament_id, heat_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     heat = _heat_for_tournament_or_404(tournament_id, heat_id)
     event = heat.event
 
@@ -967,7 +967,7 @@ def record_throwoff(tournament_id, event_id):
 
 @scoring_bp.route('/<int:tournament_id>/event/<int:event_id>/import-results', methods=['GET', 'POST'])
 def import_results(tournament_id, event_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     event = _event_for_tournament_or_404(tournament_id, event_id)
 
     if request.method == 'POST':
@@ -1023,7 +1023,7 @@ def _load_competitor_for_tournament(tournament_id: int, competitor_id: int):
     that path is only reachable from a hand-typed URL.
     Aborts 404 if not found, 403 if tournament mismatch (IDOR guard R6).
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     comp_type = (request.values.get('competitor_type') or '').strip().lower()
     if comp_type == 'college':
@@ -1271,7 +1271,7 @@ def scratch_undo(tournament_id, competitor_id):
 
 @scoring_bp.route('/<int:tournament_id>/offline-ops')
 def offline_ops(tournament_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = tournament.events.order_by(Event.name).all()
     event_directory = {e.id: {'name': e.display_name, 'type': e.event_type} for e in events}
     return render_template('scoring/offline_ops.html',
@@ -1284,7 +1284,7 @@ def offline_ops(tournament_id):
 
 @scoring_bp.route('/<int:tournament_id>/event/<int:event_id>/payouts', methods=['GET', 'POST'])
 def configure_payouts(tournament_id, event_id):
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     event = _event_for_tournament_or_404(tournament_id, event_id)
 
     if event.event_type != 'pro':
@@ -1388,7 +1388,7 @@ def _parse_payout_form() -> dict | None:
 @scoring_bp.route('/<int:tournament_id>/pro/payout-manager', methods=['GET', 'POST'])
 def tournament_payout_manager(tournament_id):
     """Tournament-level payout configuration dashboard for all pro events."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     def _payout_redirect():
         """Return redirect to payout manager or setup page depending on return_to."""
@@ -1590,9 +1590,9 @@ def toggle_settlement(tid, rid):
     AJAX callers (X-Requested-With: XMLHttpRequest) receive JSON
     ``{"ok": true, "settled": <bool>}``.  Plain-form callers are redirected.
     """
-    result = EventResult.query.get_or_404(rid)
+    result = db.get_or_404(EventResult, rid)
     # Ownership check — result must belong to an event in this tournament.
-    event = Event.query.get_or_404(result.event_id)
+    event = db.get_or_404(Event, result.event_id)
     if event.tournament_id != tid:
         abort(404)
 
@@ -1627,7 +1627,7 @@ def heat_sheet_pdf(tournament_id, heat_id):
     Attempts to render a PDF via WeasyPrint if installed; falls back to a
     print-optimised HTML page that the browser can save as PDF.
     """
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     heat = _heat_for_tournament_or_404(tournament_id, heat_id)
     event = heat.event
 
@@ -1715,7 +1715,7 @@ def judge_sheet_for_event(tournament_id: int, event_id: int):
     """Blank judge sheet PDF (or HTML fallback) for a single event."""
     from services.judge_sheet import get_event_heats_for_judging
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     event = _event_for_tournament_or_404(tournament_id, event_id)
     sheet = get_event_heats_for_judging(event.id)
     if sheet is None:
@@ -1735,7 +1735,7 @@ def judge_sheets_all(tournament_id: int):
     """
     from services.judge_sheet import get_event_heats_for_judging
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     events = (
         Event.query
         .filter_by(tournament_id=tournament.id)
@@ -1875,7 +1875,7 @@ def repair_points(tournament_id):
             and getattr(current_user, 'role', None) == 'admin'):
         return jsonify({'ok': False, 'message': 'Admin role required.'}), 403
 
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     from models.competitor import CollegeCompetitor
     from models.team import Team

--- a/routes/validation.py
+++ b/routes/validation.py
@@ -3,6 +3,7 @@ Routes for validation and data integrity checks.
 """
 from flask import Blueprint, jsonify, render_template, request
 
+from database import db
 from models import Tournament
 from services.validation import (
     CollegeCompetitorValidator,
@@ -18,7 +19,7 @@ bp = Blueprint('validation', __name__, url_prefix='/tournament/<int:tournament_i
 @bp.route('/')
 def validation_dashboard(tournament_id):
     """Validation dashboard showing all checks."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
 
     # Run all validations
     results = TournamentValidator.validate_full(tournament_id)
@@ -32,7 +33,7 @@ def validation_dashboard(tournament_id):
 @bp.route('/college')
 def college_validation(tournament_id):
     """Detailed college validation results."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     result = TournamentValidator.validate_college(tournament_id)
 
     return render_template('validation/college.html',
@@ -43,7 +44,7 @@ def college_validation(tournament_id):
 @bp.route('/pro')
 def pro_validation(tournament_id):
     """Detailed pro validation results."""
-    tournament = Tournament.query.get_or_404(tournament_id)
+    tournament = db.get_or_404(Tournament, tournament_id)
     result = TournamentValidator.validate_pro(tournament_id)
 
     return render_template('validation/pro.html',

--- a/routes/woodboss.py
+++ b/routes/woodboss.py
@@ -28,7 +28,7 @@ woodboss_public_bp = Blueprint('woodboss_public', __name__)
 
 @woodboss_bp.route('/<int:tid>')
 def dashboard(tid):
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     report = woodboss_svc.get_wood_report(tid)
     share_token = woodboss_svc.generate_share_token(
         tid, current_app.config.get('SECRET_KEY', '')
@@ -47,7 +47,7 @@ def dashboard(tid):
 
 @woodboss_bp.route('/<int:tid>/config', methods=['GET'])
 def config_form(tid):
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     configs = woodboss_svc._get_configs(tid)
     block_rows = woodboss_svc.calculate_blocks(tid, configs=configs)
     general_cfg = configs.get(woodboss_svc.LOG_GENERAL_KEY)
@@ -89,7 +89,7 @@ def config_form(tid):
 
 @woodboss_bp.route('/<int:tid>/config', methods=['POST'])
 def save_config(tid):
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
 
     # Gather all unique config_keys from the form
     all_keys = set()
@@ -205,7 +205,7 @@ def save_config(tid):
 @woodboss_bp.route('/<int:tid>/config/copy-from', methods=['POST'])
 def copy_from(tid):
     """Copy wood specs from another tournament into this one."""
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     try:
         source_tid = int(request.form.get('source_tid', 0))
     except (ValueError, TypeError):
@@ -273,7 +273,7 @@ def copy_from(tid):
 @woodboss_bp.route('/<int:tid>/config/apply-preset', methods=['POST'])
 def apply_preset(tid):
     """Apply a named wood preset to this tournament's config."""
-    Tournament.query.get_or_404(tid)
+    db.get_or_404(Tournament, tid)
     preset_name = request.form.get('preset_name', '').strip()
     if not preset_name:
         flash('No preset selected.', 'warning')
@@ -297,7 +297,7 @@ def apply_preset(tid):
 @woodboss_bp.route('/<int:tid>/config/save-preset', methods=['POST'])
 def save_preset(tid):
     """Save current tournament config as a named preset."""
-    Tournament.query.get_or_404(tid)
+    db.get_or_404(Tournament, tid)
     preset_name = request.form.get('preset_name', '').strip()
     if not preset_name:
         flash('Preset name is required.', 'warning')
@@ -328,7 +328,7 @@ def save_preset(tid):
 @woodboss_bp.route('/<int:tid>/config/delete-preset', methods=['POST'])
 def delete_preset(tid):
     """Delete a custom preset."""
-    Tournament.query.get_or_404(tid)
+    db.get_or_404(Tournament, tid)
     preset_name = request.form.get('preset_name', '').strip()
     if not preset_name:
         flash('No preset specified.', 'warning')
@@ -351,7 +351,7 @@ def delete_preset(tid):
 
 @woodboss_bp.route('/<int:tid>/report')
 def report(tid):
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     view = request.args.get('view', 'event')
     report_data = woodboss_svc.get_wood_report(tid)
     share_token = woodboss_svc.generate_share_token(
@@ -370,7 +370,7 @@ def report(tid):
 @woodboss_bp.route('/<int:tid>/report/print')
 @record_print('woodboss_report')
 def report_print(tid):
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     report_data = woodboss_svc.get_wood_report(tid)
     return render_template(
         'woodboss/report_print.html',
@@ -385,7 +385,7 @@ def report_print(tid):
 
 @woodboss_bp.route('/<int:tid>/lottery')
 def lottery(tid):
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     columns = woodboss_svc.get_lottery_view(tid)
     return render_template(
         'woodboss/lottery.html',
@@ -415,7 +415,7 @@ def share(tid):
         token, tid, current_app.config.get('SECRET_KEY', '')
     ):
         abort(403)
-    tournament = Tournament.query.get_or_404(tid)
+    tournament = db.get_or_404(Tournament, tid)
     report_data = woodboss_svc.get_wood_report(tid)
     return render_template(
         'woodboss/report_print.html',

--- a/routes/woodboss.py
+++ b/routes/woodboss.py
@@ -216,7 +216,7 @@ def copy_from(tid):
         flash('Cannot copy from the same tournament.', 'warning')
         return redirect(url_for('woodboss.config_form', tid=tid))
 
-    source = Tournament.query.get(source_tid)
+    source = db.session.get(Tournament, source_tid)
     if not source:
         flash('Source tournament not found.', 'danger')
         return redirect(url_for('woodboss.config_form', tid=tid))

--- a/scripts/ci_build_smoke_db.py
+++ b/scripts/ci_build_smoke_db.py
@@ -39,9 +39,9 @@ with no None guard. A migrated-but-unseeded file would AttributeError on all
 245 tests. So this script migrates AND seeds, reusing the test module's own
 seeding function rather than a second copy of it that could drift.
 
-Run from the repository root:
+Run in CI from the repository root:
 
-    python scripts/ci_build_smoke_db.py
+    PROAM_ALLOW_CI_SMOKE_DB_BUILD=1 python scripts/ci_build_smoke_db.py
 """
 from __future__ import annotations
 
@@ -53,17 +53,50 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-TARGET = PROJECT_ROOT / "instance" / "proam.db"
+DEFAULT_TARGET = PROJECT_ROOT / "instance" / "ci_route_smoke.db"
+BUILD_PERMISSION_ENV = "PROAM_ALLOW_CI_SMOKE_DB_BUILD"
+
+
+def _target_path() -> Path:
+    """Return the dedicated CI smoke database path inside ``instance/``."""
+    configured = os.environ.get("PROAM_CI_SMOKE_DB_PATH", str(DEFAULT_TARGET))
+    target = Path(configured)
+    if not target.is_absolute():
+        target = PROJECT_ROOT / target
+    target = target.resolve()
+    instance_dir = (PROJECT_ROOT / "instance").resolve()
+    if target.parent != instance_dir or target.name == "proam.db":
+        raise ValueError(
+            "PROAM_CI_SMOKE_DB_PATH must name a non-production database directly inside instance/"
+        )
+    return target
+
+
+def _replacement_is_authorized() -> bool:
+    """Require an explicit opt-in before replacing any local database file."""
+    return os.environ.get(BUILD_PERMISSION_ENV) == "1"
 
 
 def main() -> int:
-    TARGET.parent.mkdir(parents=True, exist_ok=True)
-    if TARGET.exists():
-        TARGET.unlink()
+    if not _replacement_is_authorized():
+        print(
+            f"REFUSED: set {BUILD_PERMISSION_ENV}=1 before building the disposable route-smoke database."
+        )
+        return 2
+
+    try:
+        target = _target_path()
+    except ValueError as exc:
+        print(f"REFUSED: {exc}")
+        return 2
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        target.unlink()
 
     # Set before importing app/tests: create_app() reads these at call time,
     # but the test module runs _discover_routes() at import time.
-    os.environ["DATABASE_URL"] = f"sqlite:///{TARGET}"
+    os.environ["DATABASE_URL"] = f"sqlite:///{target}"
     os.environ["SECRET_KEY"] = "route-smoke-secret"
     os.environ["FLASK_ENV"] = "testing"
     os.environ["TESTING"] = "1"
@@ -104,7 +137,7 @@ def main() -> int:
             print(f"FAIL: seeded database is missing: {', '.join(missing)}")
             return 1
 
-    print(f"OK: built {TARGET} ({TARGET.stat().st_size} bytes)")
+    print(f"OK: built {target} ({target.stat().st_size} bytes)")
     return 0
 
 

--- a/scripts/qa_solo_heat_placement.py
+++ b/scripts/qa_solo_heat_placement.py
@@ -36,6 +36,7 @@ sys.path.insert(0, str(ROOT))
 os.environ.setdefault("SECRET_KEY", "qa-solo-heat-secret")
 os.environ.setdefault("WTF_CSRF_ENABLED", "False")
 
+from database import db  # noqa: E402
 from tests.db_test_utils import create_test_app  # noqa: E402
 
 REPORT: list[tuple[str, str, str]] = []
@@ -179,7 +180,7 @@ def _case_stock_saw_19_men(app) -> None:
             max_stands=2,
             competitor_names=comps,
         )
-        ev = Event.query.get(event_id)
+        ev = db.session.get(Event, event_id)
         n_heats = generate_event_heats(ev)
         db.session.commit()
 
@@ -267,7 +268,7 @@ def _case_stock_saw_13_women(app) -> None:
             max_stands=2,
             competitor_names=comps,
         )
-        ev = Event.query.get(event_id)
+        ev = db.session.get(Event, event_id)
         generate_event_heats(ev)
         db.session.commit()
         layout = _heat_sizes(db, Heat, HeatAssignment, event_id)
@@ -302,7 +303,7 @@ def _case_even_field_no_reorder(app) -> None:
             max_stands=2,
             competitor_names=comps,
         )
-        ev = Event.query.get(event_id)
+        ev = db.session.get(Event, event_id)
         generate_event_heats(ev)
         db.session.commit()
         layout = _heat_sizes(db, Heat, HeatAssignment, event_id)
@@ -333,7 +334,7 @@ def _case_underhand_7_on_3(app) -> None:
             max_stands=3,
             competitor_names=comps,
         )
-        ev = Event.query.get(event_id)
+        ev = db.session.get(Event, event_id)
         generate_event_heats(ev)
         db.session.commit()
         layout = _heat_sizes(db, Heat, HeatAssignment, event_id)
@@ -365,7 +366,7 @@ def _case_springboard_5_odd(app) -> None:
             max_stands=2,
             competitor_names=comps,
         )
-        ev = Event.query.get(event_id)
+        ev = db.session.get(Event, event_id)
         generate_event_heats(ev)
         db.session.commit()
         layout = _heat_sizes(db, Heat, HeatAssignment, event_id)

--- a/scripts/repair_springboard_handedness.py
+++ b/scripts/repair_springboard_handedness.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 import logging
 import sys
 
+from database import db
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,7 +68,7 @@ def repair(tournament_id: int, xlsx_path: str, dry_run: bool = False) -> dict:
         "errors": [],
     }
 
-    tournament = Tournament.query.get(tournament_id)
+    tournament = db.session.get(Tournament, tournament_id)
     if tournament is None:
         summary["errors"].append(f"Tournament {tournament_id} not found.")
         return summary

--- a/services/audit.py
+++ b/services/audit.py
@@ -1,7 +1,6 @@
 """Helpers for writing security audit logs."""
 import json
 import logging
-from datetime import datetime
 
 from flask import request
 
@@ -15,6 +14,7 @@ except ModuleNotFoundError:
     current_user = _AnonymousCurrentUser()
 from database import db
 from models.audit_log import AuditLog
+from services.time_utils import utc_now_naive
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ def log_action(action: str, entity_type: str, entity_id: int | None = None, deta
         'details_json': json.dumps(details or {}),
         # Set explicitly. A Core insert does apply the column's Python-side
         # default, but naming it here keeps this independent of the model.
-        'created_at': datetime.utcnow(),
+        'created_at': utc_now_naive(),
     }
 
     if _supports_independent_write():

--- a/services/birling_bracket.py
+++ b/services/birling_bracket.py
@@ -72,17 +72,16 @@ class BirlingBracket:
         fix needs its own approval and its own commit; doing it here would put
         two changes under one commit message.
 
-        The bare ``except`` is open question 6, likewise pending. It is
-        reproduced rather than narrowed because narrowing it is the fix being
-        asked about, and making that call quietly inside an unrelated commit is
-        how a decision gets lost.
+        Malformed or non-string JSON is treated as an absent fallback document.
+        Other failures are allowed to surface so a programming or persistence
+        error cannot silently turn into an empty bracket on race day.
         """
         try:
             data = json.loads(self.event.payouts or '{}')
             if 'bracket' in data:
                 return data
-        except:  # noqa: E722  open question 6
-            pass
+        except (json.JSONDecodeError, TypeError):
+            return None
         return None
 
     def _save_bracket_data(self):

--- a/services/email_delivery.py
+++ b/services/email_delivery.py
@@ -26,12 +26,13 @@ import os
 import re
 import smtplib
 from dataclasses import dataclass
-from datetime import datetime
 from email import encoders
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Iterable, Optional
+
+from services.time_utils import utc_now_naive
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +215,7 @@ def queue_document_email(
         doc_key=doc_key,
         entity_id=entity_id,
         subject=subject[:300],
-        sent_at=datetime.utcnow(),
+        sent_at=utc_now_naive(),
         sent_by_user_id=sent_by_user_id,
         status="queued",
         error=None,

--- a/services/excel_io.py
+++ b/services/excel_io.py
@@ -196,7 +196,7 @@ def _process_standard_entry_form(df: pd.DataFrame, tournament: Tournament, defau
     invalid_count = 0
     valid_count = 0
     for team_id in touched_team_ids:
-        team = Team.query.get(team_id)
+        team = db.session.get(Team, team_id)
         if not team:
             continue
         team_errors = errors_by_team.get(team_id, [])
@@ -707,7 +707,7 @@ def _validate_college_entry_constraints(team_ids: set) -> dict:
     partner_gender_requirements = _partnered_event_gender_requirements()
 
     for team_id in team_ids:
-        team = Team.query.get(team_id)
+        team = db.session.get(Team, team_id)
         if not team:
             continue
 

--- a/services/heat_generator.py
+++ b/services/heat_generator.py
@@ -1370,8 +1370,8 @@ def _delete_event_heats(event_id: int) -> None:
     """Delete all heats for an event, clearing HeatAssignment rows first to satisfy FK constraints."""
     heat_ids = [h.id for h in Heat.query.filter_by(event_id=event_id).with_entities(Heat.id).all()]
     if heat_ids:
-        HeatAssignment.query.filter(HeatAssignment.heat_id.in_(heat_ids)).delete(synchronize_session=False)
-    Heat.query.filter_by(event_id=event_id).delete(synchronize_session=False)
+        HeatAssignment.query.filter(HeatAssignment.heat_id.in_(heat_ids)).delete(synchronize_session='fetch')
+    Heat.query.filter_by(event_id=event_id).delete(synchronize_session='fetch')
 
 
 def check_gear_sharing_conflicts(heats: list) -> list:

--- a/services/judge_sheet.py
+++ b/services/judge_sheet.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import TypedDict
 
+from database import db
 from models.competitor import CollegeCompetitor, ProCompetitor
 from models.event import Event
 from models.heat import Heat
@@ -68,7 +69,7 @@ def get_event_heats_for_judging(event_id: int) -> JudgeSheetData | None:
     the event exists but has no heats (caller handles the "no heats" case, e.g.
     the bulk-PDF route skips events without heats instead of erroring).
     """
-    event = Event.query.get(event_id)
+    event = db.session.get(Event, event_id)
     if event is None:
         return None
 

--- a/services/print_catalog.py
+++ b/services/print_catalog.py
@@ -39,6 +39,7 @@ from typing import Callable, Iterable, Optional
 from flask import g
 
 from database import db
+from services.time_utils import utc_now_naive
 
 logger = logging.getLogger(__name__)
 
@@ -732,7 +733,7 @@ def upsert_tracker(
         q = q.filter(PrintTracker.entity_id == entity_id)
     row = q.first()
 
-    now = datetime.utcnow()
+    now = utc_now_naive()
     if row is None:
         row = PrintTracker(
             tournament_id=tournament_id,

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -561,7 +561,7 @@ def compute_team_health(team_data: dict, tournament) -> dict:
     inactive_names = []
 
     def _member_status(member, model_cls):
-        obj = model_cls.query.get(member['id'])
+        obj = db.session.get(model_cls, member['id'])
         if obj is None:
             return 'unknown'
         return obj.status

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -49,7 +49,9 @@ class ProAmRelay:
                 raw = relay_event.payouts
             try:
                 return json.loads(raw or '{}')
-            except:
+            except (json.JSONDecodeError, TypeError):
+                # A legacy state field may be empty or malformed. Other
+                # decoder failures are operational errors and must surface.
                 pass
 
         return {

--- a/services/scoring_engine.py
+++ b/services/scoring_engine.py
@@ -488,7 +488,7 @@ def calculate_positions(event: Event) -> None:
         for r in all_results:
             awarded = float(r.payout_amount or 0)
             if awarded:
-                comp = ProCompetitor.query.get(r.competitor_id)
+                comp = db.session.get(ProCompetitor, r.competitor_id)
                 if comp:
                     comp.total_earnings = max(0.0, comp.total_earnings - awarded)
             r.payout_amount = 0.0
@@ -510,7 +510,7 @@ def calculate_positions(event: Event) -> None:
             )
             stripped_team_ids = {c.team_id for c in stripped_comps if c.team_id}
             for tid in stripped_team_ids:
-                team = Team.query.get(tid)
+                team = db.session.get(Team, tid)
                 if team:
                     team.recalculate_points()
         return
@@ -641,7 +641,7 @@ def calculate_positions(event: Event) -> None:
         )
         touched_team_ids = {c.team_id for c in all_touched_comps if c.team_id}
         for team_id in touched_team_ids:
-            team = Team.query.get(team_id)
+            team = db.session.get(Team, team_id)
             if team:
                 team.recalculate_points()
 
@@ -977,7 +977,7 @@ def record_throwoff_result(event: Event, position_map: dict[int, int]) -> None:
             new_pay = event.get_payout_for_position(position)
             diff = new_pay - old_pay
             result.payout_amount = new_pay
-            comp = ProCompetitor.query.get(result.competitor_id)
+            comp = db.session.get(ProCompetitor, result.competitor_id)
             if comp:
                 comp.total_earnings = max(0.0, comp.total_earnings + diff)
 
@@ -993,7 +993,7 @@ def record_throwoff_result(event: Event, position_map: dict[int, int]) -> None:
         )
         touched_team_ids = {c.team_id for c in comp_rows if getattr(c, 'team_id', None)}
         for team_id in touched_team_ids:
-            team = Team.query.get(team_id)
+            team = db.session.get(Team, team_id)
             if team:
                 team.recalculate_points()
 
@@ -1394,7 +1394,7 @@ def apply_payout_template(event: Event, template_id: int) -> bool:
     the new payout amounts propagate to EventResult.payout_amount and
     ProCompetitor.total_earnings immediately.  Returns True on success.
     """
-    template = PayoutTemplate.query.get(template_id)
+    template = db.session.get(PayoutTemplate, template_id)
     if template is None:
         return False
     event.set_payouts(template.get_payouts())
@@ -1407,7 +1407,7 @@ def apply_payout_template(event: Event, template_id: int) -> bool:
 
 def delete_payout_template(template_id: int) -> bool:
     """Delete a payout template. Returns True if deleted."""
-    template = PayoutTemplate.query.get(template_id)
+    template = db.session.get(PayoutTemplate, template_id)
     if template is None:
         return False
     db.session.delete(template)

--- a/services/scratch_cascade.py
+++ b/services/scratch_cascade.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from database import db
 from services.time_utils import utc_now_naive
 
 if TYPE_CHECKING:
@@ -170,14 +171,14 @@ def compute_scratch_effects(competitor, tournament) -> list[CascadeEffect]:
                 partner_effect_rows.append((fr, fr.partner_name, fr.event_id))
 
     for pr, partner_display_name, event_id in partner_effect_rows:
-        ev = events_by_id.get(event_id) or Event.query.get(event_id)
+        ev = events_by_id.get(event_id) or db.session.get(Event, event_id)
         event_name = ev.name if ev else f"Event #{event_id}"
 
         # Resolve the partner competitor's status.
         if pr.competitor_type == "college":
-            owning_comp = CollegeCompetitor.query.get(pr.competitor_id)
+            owning_comp = db.session.get(CollegeCompetitor, pr.competitor_id)
         else:
-            owning_comp = ProCompetitor.query.get(pr.competitor_id)
+            owning_comp = db.session.get(ProCompetitor, pr.competitor_id)
 
         # For forward-ref rows the "owning_comp" is this competitor, not the
         # partner — resolve the partner instead when we have a partner name.
@@ -373,16 +374,16 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
                 partner_result_id = effect.affected_entity_id
                 pr = event_result_map.get(partner_result_id)
                 if pr is None:
-                    pr = EventResult.query.get(partner_result_id)
+                    pr = db.session.get(EventResult, partner_result_id)
                 # Both name forms, for the reason documented on the Direction A
                 # query above: college partner_name carries the team suffix.
                 if pr is not None and pr.partner_name in (
                     competitor.name, competitor.display_name
                 ):
                     if pr.competitor_type == "college":
-                        partner_comp = CollegeCompetitor.query.get(pr.competitor_id)
+                        partner_comp = db.session.get(CollegeCompetitor, pr.competitor_id)
                     else:
-                        partner_comp = ProCompetitor.query.get(pr.competitor_id)
+                        partner_comp = db.session.get(ProCompetitor, pr.competitor_id)
 
                     # This effect is scoped to ONE event: the one this partner
                     # result belongs to.  partners is event_id -> partner_name
@@ -434,7 +435,7 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
 
             elif effect.effect_type == "relay_team":
                 relay_event_id = effect.affected_entity_id
-                relay_event = Event.query.get(relay_event_id)
+                relay_event = db.session.get(Event, relay_event_id)
                 if relay_event is not None:
                     relay = ProAmRelay(tournament)
                     # Remove the competitor from all member lists in all teams.
@@ -451,7 +452,7 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
             elif effect.effect_type == "standings":
                 finalized_event_ids = effect.metadata.get("finalized_event_ids", [])
                 for ev_id in finalized_event_ids:
-                    ev = Event.query.get(ev_id)
+                    ev = db.session.get(Event, ev_id)
                     if ev is not None and ev.is_finalized:
                         ev.is_finalized = False
                         affected_event_ids.add(ev_id)
@@ -555,7 +556,7 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
             try:
                 from services.heat_generator import rebalance_stock_saw_solo_stands
                 for ev_id in touched_event_ids:
-                    ev = Event.query.get(ev_id)
+                    ev = db.session.get(Event, ev_id)
                     if ev is not None:
                         rebalance_stock_saw_solo_stands(ev)
             except Exception:
@@ -736,7 +737,7 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
         # --- Restore competitor status ---------------------------------------
         comp_type = competitor_type or snapshot.get("competitor_type", "pro")
         CompModel = CollegeCompetitor if comp_type == "college" else ProCompetitor
-        comp = CompModel.query.get(competitor_id)
+        comp = db.session.get(CompModel, competitor_id)
 
         if comp is not None:
             comp.status = snapshot.get("competitor_status", "active")
@@ -758,7 +759,7 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
         # the judge re-paired the partner during the undo window, that new
         # pairing is the current truth and must survive the undo.
         for p_snap in snapshot.get("partners", []):
-            p_result = EventResult.query.get(p_snap.get("result_id"))
+            p_result = db.session.get(EventResult, p_snap.get("result_id"))
             if p_result is not None and not p_result.partner_name:
                 p_result.partner_name = p_snap.get("result_partner_name")
 
@@ -771,7 +772,7 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
                 if p_snap.get("competitor_type") == "college"
                 else ProCompetitor
             )
-            p_comp = PartnerModel.query.get(p_comp_id)
+            p_comp = db.session.get(PartnerModel, p_comp_id)
             if p_comp is None:
                 continue
             p_data = p_comp.get_partners()
@@ -785,7 +786,7 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
         previously_finalized_event_ids: set[int] = set()
 
         for r_snap in snapshot.get("results", []):
-            r = EventResult.query.get(r_snap["id"])
+            r = db.session.get(EventResult, r_snap["id"])
             if r is not None:
                 r.status = r_snap["status"]
                 r.points_awarded = r_snap.get("points_awarded")
@@ -838,9 +839,9 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
         # status, restore finalization to True — but that's risky.  Instead we track
         # which events were un-finalized via the effects metadata.
         for r_snap in snapshot.get("results", []):
-            r = EventResult.query.get(r_snap["id"])
+            r = db.session.get(EventResult, r_snap["id"])
             if r is not None:
-                ev = Event.query.get(r.event_id)
+                ev = db.session.get(Event, r.event_id)
                 if ev is not None and not ev.is_finalized:
                     # Only re-finalize if the original result was in a completed state
                     # (meaning the event was finalized at scratch time).
@@ -866,7 +867,7 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
 
         restored_event_ids: set[int] = set()
         for h_snap in snapshot.get("heats", []):
-            heat = Heat.query.get(h_snap.get("heat_id"))
+            heat = db.session.get(Heat, h_snap.get("heat_id"))
             if heat is None:
                 continue
             comp_ids = heat.get_competitors()
@@ -913,7 +914,7 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
             try:
                 from services.heat_generator import rebalance_stock_saw_solo_stands
                 for ev_id in restored_event_ids:
-                    ev = Event.query.get(ev_id)
+                    ev = db.session.get(Event, ev_id)
                     if ev is not None:
                         rebalance_stock_saw_solo_stands(ev)
             except Exception:

--- a/services/scratch_cascade.py
+++ b/services/scratch_cascade.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import TYPE_CHECKING
+
+from services.time_utils import utc_now_naive
 
 if TYPE_CHECKING:
     from models.competitor import CollegeCompetitor, ProCompetitor
@@ -622,7 +624,7 @@ def find_undoable_scratch(competitor_id: int, competitor_type: str | None = None
     """
     from models.audit_log import AuditLog
 
-    cutoff = datetime.utcnow() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
+    cutoff = utc_now_naive() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
     return next(
         (
             entry
@@ -657,7 +659,7 @@ def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) 
     if not ids:
         return set()
 
-    cutoff = datetime.utcnow() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
+    cutoff = utc_now_naive() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
     return {
         entry.entity_id
         for entry in AuditLog.query.filter(

--- a/services/strathmark_sync.py
+++ b/services/strathmark_sync.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import date, datetime
+from datetime import date
 from typing import Optional
+
+from services.time_utils import utc_now_naive
 
 logger = logging.getLogger(__name__)
 
@@ -280,7 +282,7 @@ def log_skipped_competitor(name: str, event_name: str) -> None:
         data.append({
             'name': name,
             'event': event_name,
-            'skipped_at': datetime.utcnow().isoformat(),
+            'skipped_at': utc_now_naive().isoformat(),
         })
         with open(_SKIPPED_LOG_FILE, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2)
@@ -432,7 +434,7 @@ def _push_rows_validated(rows: list, event_label: str) -> dict:
         inserted = int(result.get('inserted', 0))
         skipped = int(result.get('skipped', 0))
         errors = list(result.get('errors', []) or [])
-        _write_sync_cache(datetime.utcnow().isoformat(), inserted)
+        _write_sync_cache(utc_now_naive().isoformat(), inserted)
         if errors:
             logger.warning(
                 'STRATHMARK: %s push reported %d errors: %s',
@@ -458,7 +460,7 @@ def _push_rows_validated(rows: list, event_label: str) -> dict:
         from strathmark import push_results
         df = pd.DataFrame(rows)
         count = push_results(df, show_name=SHOW_NAME, source_app=SOURCE_APP)
-        _write_sync_cache(datetime.utcnow().isoformat(), count)
+        _write_sync_cache(utc_now_naive().isoformat(), count)
         logger.info('STRATHMARK: %s push -- inserted=%d (legacy API)', event_label, count)
         return {'inserted': int(count), 'skipped': 0, 'errors': []}
     except Exception as exc:

--- a/services/strathmark_sync.py
+++ b/services/strathmark_sync.py
@@ -22,6 +22,7 @@ import os
 from datetime import date
 from typing import Optional
 
+from database import db
 from services.time_utils import utc_now_naive
 
 logger = logging.getLogger(__name__)
@@ -519,7 +520,7 @@ def push_pro_event_results(event, tournament_year: int) -> None:
     for result in event.results.filter_by(status='completed').all():
         if result.result_value is None:
             continue
-        comp = ProCompetitor.query.get(result.competitor_id)
+        comp = db.session.get(ProCompetitor, result.competitor_id)
         if comp is None or not comp.strathmark_id:
             logger.info(
                 'STRATHMARK: pro competitor %s (id=%s) has no strathmark_id; '
@@ -590,7 +591,7 @@ def _record_prediction_residuals_for_pro_event(event, event_code: str) -> None:
             if result.result_value is None:
                 continue
 
-            comp = ProCompetitor.query.get(result.competitor_id)
+            comp = db.session.get(ProCompetitor, result.competitor_id)
             if comp is None or not comp.strathmark_id:
                 # strathmark_id absence already logged by push_pro_event_results().
                 continue
@@ -722,7 +723,7 @@ def push_college_event_results(event, tournament_year: int) -> None:
         if result.result_value is None:
             continue
 
-        comp = CollegeCompetitor.query.get(result.competitor_id)
+        comp = db.session.get(CollegeCompetitor, result.competitor_id)
         if comp is None:
             continue
 

--- a/services/validation.py
+++ b/services/validation.py
@@ -10,6 +10,7 @@ Provides comprehensive validation for:
 from typing import Dict, List, Optional, Tuple
 
 import config
+from database import db
 from models import Event, Heat, HeatAssignment, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 from models.team import Team
@@ -268,7 +269,7 @@ class HeatValidator:
     def validate_gear_sharing(cls, heat: Heat) -> ValidationResult:
         """Check for gear sharing conflicts within a heat."""
         result = ValidationResult()
-        event = Event.query.get(heat.event_id)
+        event = db.session.get(Event, heat.event_id)
         if not event:
             return result
 

--- a/services/woodboss.py
+++ b/services/woodboss.py
@@ -20,6 +20,8 @@ Formulas (per head judge specification):
 import math
 from collections import defaultdict
 
+from database import db
+
 # ---------------------------------------------------------------------------
 # Block event group definitions
 # Maps (fragment_in_event_name, competitor_type, gender) -> config_key
@@ -1020,7 +1022,7 @@ def _detect_friday_feature_springboard(tournament_id):
 
     try:
         from models.tournament import Tournament
-        tournament = Tournament.query.get(tournament_id)
+        tournament = db.session.get(Tournament, tournament_id)
         if tournament:
             fnf_event_ids = {
                 int(event_id)

--- a/templates/ops_dashboard.html
+++ b/templates/ops_dashboard.html
@@ -87,6 +87,19 @@
                 </div>
                 <div class="d-flex gap-2 flex-wrap align-items-center">
                     <span id="refresh-countdown">Refreshing in <span id="rc-num">30</span>s</span>
+                    <a href="{{ url_for('scheduling.preflight_check', tournament_id=tournament.id) }}"
+                       class="btn btn-sm {% if not preflight_summary.available or preflight_summary.has_blockers %}btn-outline-danger{% elif preflight_summary.issue_count %}btn-outline-warning{% else %}btn-outline-success{% endif %}">
+                        <i class="bi bi-shield-check me-1"></i>
+                        {% if not preflight_summary.available %}
+                            Schedule Preflight Unavailable
+                        {% elif preflight_summary.has_blockers %}
+                            Schedule Preflight: {{ preflight_summary.issue_count }} blocker{{ '' if preflight_summary.issue_count == 1 else 's' }}
+                        {% elif preflight_summary.issue_count %}
+                            Schedule Preflight: {{ preflight_summary.issue_count }} issue{{ '' if preflight_summary.issue_count == 1 else 's' }}
+                        {% else %}
+                            Schedule Preflight: Clear
+                        {% endif %}
+                    </a>
                     <button class="btn btn-outline-secondary btn-sm" onclick="location.reload()">
                         <i class="bi bi-arrow-clockwise me-1"></i>Refresh Now
                     </button>

--- a/tests/db_test_utils.py
+++ b/tests/db_test_utils.py
@@ -53,6 +53,16 @@ _pg_template_ready = False
 _pg_counter = [0]
 
 
+def _isolate_report_cache():
+    """Clear process cache state and keep tests out of the production shelf."""
+    from services import report_cache
+
+    with report_cache._lock:
+        report_cache._cache.clear()
+    report_cache._shelf_path = None
+    report_cache._shelf_resolved = True
+
+
 def _pg_run(sql, dbname="postgres"):
     import subprocess
     return subprocess.run(
@@ -197,6 +207,7 @@ def _create_test_app_pg():
         })
         with _app.app_context():
             _db.engine.dispose()
+        _isolate_report_cache()
         return _app, name
     finally:
         if old is None:
@@ -273,6 +284,7 @@ def create_test_app():
             else:
                 upgrade(directory=migrations_dir)
 
+        _isolate_report_cache()
         return _app, db_path
     finally:
         # Restore original DATABASE_URL

--- a/tests/test_birling_bracket.py
+++ b/tests/test_birling_bracket.py
@@ -8,13 +8,12 @@ needed.
 Run:  pytest tests/test_birling_bracket.py -v
 """
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.conftest import patched_bracket_deps
-
 from services.birling_bracket import BirlingBracket
+from tests.conftest import patched_bracket_deps
 
 # ---------------------------------------------------------------------------
 # Helper: create a mock event with a mutable payouts field
@@ -37,6 +36,22 @@ def _bracket(num_competitors=4, seeding=None, event_type='college'):
         comps = [{'id': i, 'name': f'Comp{i}'} for i in range(1, num_competitors + 1)]
         b.generate_bracket(comps, seeding)
     return b
+
+
+class TestStoredDocument:
+    def test_malformed_json_is_treated_as_no_fallback_document(self):
+        bracket = object.__new__(BirlingBracket)
+        bracket.event = _mock_event('{')
+
+        assert bracket._stored_document() is None
+
+    def test_unexpected_json_loader_failure_is_not_silenced(self):
+        bracket = object.__new__(BirlingBracket)
+        bracket.event = _mock_event('{"bracket": {}}')
+
+        with patch('services.birling_bracket.json.loads', side_effect=RuntimeError('broken loader')):
+            with pytest.raises(RuntimeError, match='broken loader'):
+                bracket._stored_document()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_birling_bracket_12.py
+++ b/tests/test_birling_bracket_12.py
@@ -15,9 +15,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tests.conftest import patched_bracket_deps
-
 from services.birling_bracket import BirlingBracket
+from tests.conftest import patched_bracket_deps
 from tests.fixtures.synthetic_data import BIRLING_MEN_BRACKET, BIRLING_WOMEN_BRACKET
 
 # ---------------------------------------------------------------------------

--- a/tests/test_birling_bracket_9.py
+++ b/tests/test_birling_bracket_9.py
@@ -23,12 +23,11 @@ import re
 from unittest.mock import MagicMock
 
 import pytest
-
-from tests.conftest import patched_bracket_deps
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from services.birling_bracket import BirlingBracket
 from services.birling_print import build_birling_print_context
+from tests.conftest import patched_bracket_deps
 
 # ---------------------------------------------------------------------------
 # Helpers (mirror tests/test_birling_bracket_12.py style: no DB, mocked)

--- a/tests/test_birling_bracket_migration.py
+++ b/tests/test_birling_bracket_migration.py
@@ -41,6 +41,10 @@ from tests.conftest import (
     make_tournament,
 )
 
+pytestmark = pytest.mark.filterwarnings(
+    "error:The default datetime adapter is deprecated:DeprecationWarning"
+)
+
 _MIGRATION = (
     pathlib.Path(__file__).resolve().parent.parent
     / "migrations" / "versions" / "u0c4d5e6f7a8_birling_bracket_tables.py"

--- a/tests/test_ci_build_smoke_db.py
+++ b/tests/test_ci_build_smoke_db.py
@@ -1,0 +1,46 @@
+"""Safety checks for the CI route-smoke database bootstrap."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "ci_build_smoke_db.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("ci_build_smoke_db", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_smoke_db_default_never_targets_production_database():
+    module = _load_script_module()
+
+    assert module.DEFAULT_TARGET.name == "ci_route_smoke.db"
+    assert module.DEFAULT_TARGET != module.PROJECT_ROOT / "instance" / "proam.db"
+
+
+def test_smoke_db_builder_refuses_without_explicit_opt_in(monkeypatch, tmp_path, capsys):
+    module = _load_script_module()
+    sentinel = tmp_path / "ci_route_smoke.db"
+    sentinel.write_text("do not replace")
+    monkeypatch.delenv(module.BUILD_PERMISSION_ENV, raising=False)
+    monkeypatch.setattr(module, "_target_path", lambda: sentinel)
+
+    assert module.main() == 2
+    assert sentinel.read_text() == "do not replace"
+    assert "REFUSED" in capsys.readouterr().out
+
+
+def test_smoke_db_target_rejects_production_filename(monkeypatch):
+    module = _load_script_module()
+    monkeypatch.setenv("PROAM_CI_SMOKE_DB_PATH", "instance/proam.db")
+
+    try:
+        module._target_path()
+    except ValueError as exc:
+        assert "non-production" in str(exc)
+    else:
+        raise AssertionError("production database path must be rejected")

--- a/tests/test_day_of_operations.py
+++ b/tests/test_day_of_operations.py
@@ -12,6 +12,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # ---------------------------------------------------------------------------

--- a/tests/test_db_constraints.py
+++ b/tests/test_db_constraints.py
@@ -21,6 +21,7 @@ import os
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from database import db
 from tests.conftest import (
     ensure_competitors,
     make_college_competitor,
@@ -53,7 +54,7 @@ class TestForeignKeyCascades:
         db_session.delete(t)
         db_session.flush()
 
-        assert Event.query.get(eid) is None
+        assert db.session.get(Event, eid) is None
 
     def test_delete_tournament_cascades_to_teams(self, db_session):
         from models.team import Team
@@ -65,7 +66,7 @@ class TestForeignKeyCascades:
         db_session.delete(t)
         db_session.flush()
 
-        assert Team.query.get(team_id) is None
+        assert db.session.get(Team, team_id) is None
 
     def test_delete_tournament_cascades_to_competitors(self, db_session):
         from models.competitor import CollegeCompetitor, ProCompetitor
@@ -79,8 +80,8 @@ class TestForeignKeyCascades:
         db_session.delete(t)
         db_session.flush()
 
-        assert CollegeCompetitor.query.get(cc_id) is None
-        assert ProCompetitor.query.get(pc_id) is None
+        assert db.session.get(CollegeCompetitor, cc_id) is None
+        assert db.session.get(ProCompetitor, pc_id) is None
 
     def test_delete_event_cascades_to_heats_and_results(self, db_session):
         from models.event import EventResult
@@ -97,8 +98,8 @@ class TestForeignKeyCascades:
         db_session.delete(e)
         db_session.flush()
 
-        assert Heat.query.get(hid) is None
-        assert EventResult.query.get(rid) is None
+        assert db.session.get(Heat, hid) is None
+        assert db.session.get(EventResult, rid) is None
 
 
 # ===========================================================================

--- a/tests/test_dq_and_status_reason.py
+++ b/tests/test_dq_and_status_reason.py
@@ -35,7 +35,7 @@ class TestStatusReasonPersistence:
         result.status_reason = "illegal axe"
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert fresh.status == "dq"
         assert fresh.status_reason == "illegal axe"
 
@@ -55,7 +55,7 @@ class TestStatusReasonPersistence:
         result.status_reason = "injury"
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert fresh.status == "dnf"
         assert fresh.status_reason == "injury"
 
@@ -75,7 +75,7 @@ class TestStatusReasonPersistence:
         )
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert fresh.status == "completed"
         assert fresh.status_reason is None
 
@@ -200,7 +200,7 @@ class TestScoringSubmissionAcceptsDq:
         # Re-fetch heat for current version_id after commit.
         from models.heat import Heat
 
-        heat = Heat.query.get(heat.id)
+        heat = db.session.get(Heat, heat.id)
 
         resp = c.post(
             f"/scoring/{t.id}/heat/{heat.id}/enter",

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,5 +1,9 @@
 """Phase 3 edge-case QA tests.
 
+CURRENT: The fixture below uses a disposable database built from migrations
+and synthetic test data. The retained text documents the retired production
+database-copy pattern only.
+
 DEPRECATED FIXTURE PATTERN: this file copies instance/proam.db (production
 data) into a tempfile to seed each test. The 4-layer test isolation defense
 (CLAUDE.md §6) blocks WRITES to the prod DB, but the copy still pulls real
@@ -18,86 +22,38 @@ The tests below now SKIP cleanly when ``instance/proam.db`` is absent
 """
 from __future__ import annotations
 
-import shutil
 import uuid
-from pathlib import Path
 
 import pytest
 
-from app import create_app
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SOURCE_DB = PROJECT_ROOT / "instance" / "proam.db"
-TMP_ROOT = PROJECT_ROOT / ".qa_tmp"
-
 
 @pytest.fixture()
-def qa_env(monkeypatch):
-    """Return a fresh app/client pair backed by a copied real database.
+def qa_env():
+    """Return an authenticated client backed only by a disposable database."""
+    from database import db
+    from models import User
+    from tests.db_test_utils import create_test_app, drop_test_db
 
-    Skips cleanly when SOURCE_DB is absent so CI without prod data passes.
-    See module docstring for the deprecation context.
-    """
-    if not SOURCE_DB.exists():
-        pytest.skip(
-            f"SOURCE_DB ({SOURCE_DB}) is absent; "
-            "test relies on local prod-data copy, see deprecation in module docstring"
-        )
-    # D12-C commit F3: existing is not enough any more, the copy also has to
-    # be migratable. Revision t9b3c4d5e6f7 refuses a database holding a heat
-    # whose roster exists only in heats.competitors, and a database stamped
-    # before D12-C commit E can be exactly that. Unlike
-    # tests/test_route_smoke.py this file has no synthetic seed path to fall
-    # back to, so the honest outcome is a skip that says what is wrong rather
-    # than a setup error that does not.
-    from tests.db_test_utils import source_db_reaches_head
-    stale = source_db_reaches_head(SOURCE_DB)
-    if stale:
-        pytest.skip(
-            f"SOURCE_DB ({SOURCE_DB}) cannot be migrated to chain head, so a "
-            f"copy of it cannot back this test. {stale} Seat the heats named "
-            "in that message through Heat.set_roster, or rebuild the file. "
-            "This module has no synthetic seed path, see the deprecation in "
-            "the module docstring; tests/test_route_smoke.py falls back to "
-            "one."
-        )
-    TMP_ROOT.mkdir(exist_ok=True)
-    temp_dir = TMP_ROOT / f"edge-qa-{uuid.uuid4().hex}"
-    temp_dir.mkdir()
-    db_copy = temp_dir / "proam-copy.db"
-    shutil.copy2(SOURCE_DB, db_copy)
-
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_copy}")
-    monkeypatch.setenv("SECRET_KEY", "edge-qa-secret")
-    monkeypatch.setenv("FLASK_ENV", "testing")
-    monkeypatch.setenv("TESTING", "1")
-
-    app = create_app()
-    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
-
-    # Migrate the copy.  instance/proam.db is stamped at whatever revision the
-    # developer's machine last ran, and a copy that skips the chain runs these
-    # tests against a schema no production database has.  See the same comment
-    # in tests/test_route_smoke.py for how this was found.
-    from flask_migrate import upgrade
+    app, db_handle = create_test_app()
     with app.app_context():
-        upgrade(directory=str(PROJECT_ROOT / "migrations"))
-
-    with app.app_context():
-        from models import User
-
-        admin_user = User.query.order_by(User.id).first()
-        assert admin_user is not None
+        admin_user = User(username="edge_qa_admin", role="admin")
+        admin_user.set_password("testpass")
+        db.session.add(admin_user)
+        db.session.commit()
+        admin_user_id = admin_user.id
 
     client = app.test_client()
     with client.session_transaction() as sess:
-        sess["_user_id"] = str(admin_user.id)
+        sess["_user_id"] = str(admin_user_id)
         sess["_fresh"] = True
 
     try:
         yield {"app": app, "client": client}
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        with app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+        drop_test_db(db_handle)
 
 
 def _seed_boundary_event(app, competitor_count: int, max_stands: int):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -26,6 +26,8 @@ import uuid
 
 import pytest
 
+from database import db
+
 
 @pytest.fixture()
 def qa_env():
@@ -614,7 +616,7 @@ def test_pro_scratch_removes_competitor_from_generated_heat(qa_env):
         from models import EventResult, Heat, HeatAssignment
         from models.competitor import ProCompetitor
 
-        comp = ProCompetitor.query.get(competitor_id)
+        comp = db.session.get(ProCompetitor, competitor_id)
         assert comp is not None and comp.status == "scratched"
 
         # Same conversion as above, and here the join changes what the

--- a/tests/test_empty_state_portals.py
+++ b/tests/test_empty_state_portals.py
@@ -18,6 +18,8 @@ import os
 
 import pytest
 
+from database import db
+
 os.environ.setdefault('SECRET_KEY', 'test-secret-empty')
 os.environ.setdefault('WTF_CSRF_ENABLED', 'False')
 
@@ -230,7 +232,7 @@ class TestPortalLandingNoActive:
         # Restore
         with app.app_context():
             for tid, status in original_statuses.items():
-                t = Tournament.query.get(tid)
+                t = db.session.get(Tournament, tid)
                 if t:
                     t.status = status
             _db.session.commit()

--- a/tests/test_flight_builder_async_spillover.py
+++ b/tests/test_flight_builder_async_spillover.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # D12-C commit E: the roster is `heat_assignments` rows now, so a heat
@@ -274,7 +275,7 @@ class TestAsyncBuildChainsSpillover:
             integrate_college_spillover_into_flights,
         )
 
-        target = Tournament.query.get(tournament_id)
+        target = db.session.get(Tournament, tournament_id)
         if not target:
             raise RuntimeError(f"Tournament {tournament_id} not found.")
         try:
@@ -376,7 +377,7 @@ class TestAsyncBuildChainsSpillover:
                 integrate_college_spillover_into_flights,  # patched
             )
 
-            target = Tournament.query.get(t.id)
+            target = db.session.get(Tournament, t.id)
             try:
                 build_pro_flights(target, num_flights=2, commit=False)
                 integrate_college_spillover_into_flights(

--- a/tests/test_flight_sizing_modes.py
+++ b/tests/test_flight_sizing_modes.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 
+from database import db
 from database import db as _db
 
 
@@ -284,7 +285,7 @@ class TestBuildFlightsRouteModes:
 
         from models import Tournament
 
-        t_reloaded = Tournament.query.get(t.id)
+        t_reloaded = db.session.get(Tournament, t.id)
         cfg = _read_flight_sizing_config(t_reloaded)
         assert cfg["mode"] == "minutes"
         assert cfg["target_minutes_per_flight"] == 60
@@ -308,7 +309,7 @@ class TestBuildFlightsRouteModes:
 
         from models import Tournament
 
-        t_reloaded = Tournament.query.get(t.id)
+        t_reloaded = db.session.get(Tournament, t.id)
         cfg = _read_flight_sizing_config(t_reloaded)
         assert cfg["mode"] == "count"
         assert cfg["num_flights"] == 3
@@ -439,7 +440,7 @@ class TestSizingClamp:
         )
         from models import Tournament
 
-        t_reloaded = Tournament.query.get(t.id)
+        t_reloaded = db.session.get(Tournament, t.id)
         cfg = _read_flight_sizing_config(t_reloaded)
         assert 30 <= cfg["target_minutes_per_flight"] <= 180
         assert 1.0 <= cfg["minutes_per_heat"] <= 15.0

--- a/tests/test_heat_gen_integration.py
+++ b/tests/test_heat_gen_integration.py
@@ -15,8 +15,10 @@ Requirements:
 """
 import json
 import math
+import warnings
 
 import pytest
+from sqlalchemy.exc import SAWarning
 
 from database import db as _db
 
@@ -488,7 +490,9 @@ class TestRegeneration:
         ev.status = 'pending'
         db_session.flush()
 
-        generate_event_heats(ev)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', SAWarning)
+            generate_event_heats(ev)
 
         heats_second = _all_heats_for_event(ev.id)
 

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # ---------------------------------------------------------------------------

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -129,6 +129,17 @@ class TestReportCache:
         assert get('a') is None
         assert get('b') is None
 
+    def test_test_app_isolation_clears_memory_and_disables_disk(self):
+        from services import report_cache
+        from tests.db_test_utils import _isolate_report_cache
+
+        report_cache.set('api:standings-poll:1', {'teams': ['stale']}, 60)
+        _isolate_report_cache()
+
+        assert report_cache.get('api:standings-poll:1') is None
+        assert report_cache._shelf_resolved is True
+        assert report_cache._shelf_path is None
+
     def test_multiple_keys_independent(self):
         from services.report_cache import get, set
         set('key:alpha', 'AAA', ttl_seconds=60)

--- a/tests/test_integration_qa.py
+++ b/tests/test_integration_qa.py
@@ -16,6 +16,8 @@ import uuid
 
 import pytest
 
+from database import db
+
 
 @pytest.fixture()
 def qa_env():

--- a/tests/test_integration_qa.py
+++ b/tests/test_integration_qa.py
@@ -1,5 +1,9 @@
 """Phase 2 workflow integration QA tests.
 
+CURRENT: The fixture below uses a disposable database built from migrations
+and synthetic test data. The retained text documents the retired production
+database-copy pattern only.
+
 DEPRECATED FIXTURE PATTERN: this file copies instance/proam.db (production
 data). See tests/test_edge_cases.py module docstring for the full rationale.
 For new tests, use tests/fixtures/synthetic_data.py + create_test_app().
@@ -8,86 +12,38 @@ The fixture below now SKIPs cleanly when SOURCE_DB is absent (CI default).
 from __future__ import annotations
 
 import re
-import shutil
 import uuid
-from pathlib import Path
 
 import pytest
 
-from app import create_app
-
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SOURCE_DB = PROJECT_ROOT / "instance" / "proam.db"
-TMP_ROOT = PROJECT_ROOT / ".qa_tmp"
-
 
 @pytest.fixture()
-def qa_env(monkeypatch):
-    """Return a fresh app/client pair backed by a copied real database.
+def qa_env():
+    """Return an authenticated client backed only by a disposable database."""
+    from database import db
+    from models import User
+    from tests.db_test_utils import create_test_app, drop_test_db
 
-    Skips cleanly when SOURCE_DB is absent so CI without prod data passes.
-    See module docstring for the deprecation context.
-    """
-    if not SOURCE_DB.exists():
-        pytest.skip(
-            f"SOURCE_DB ({SOURCE_DB}) is absent; "
-            "test relies on local prod-data copy, see deprecation in module docstring"
-        )
-    # D12-C commit F3: existing is not enough any more, the copy also has to
-    # be migratable. Revision t9b3c4d5e6f7 refuses a database holding a heat
-    # whose roster exists only in heats.competitors, and a database stamped
-    # before D12-C commit E can be exactly that. Unlike
-    # tests/test_route_smoke.py this file has no synthetic seed path to fall
-    # back to, so the honest outcome is a skip that says what is wrong rather
-    # than a setup error that does not.
-    from tests.db_test_utils import source_db_reaches_head
-    stale = source_db_reaches_head(SOURCE_DB)
-    if stale:
-        pytest.skip(
-            f"SOURCE_DB ({SOURCE_DB}) cannot be migrated to chain head, so a "
-            f"copy of it cannot back this test. {stale} Seat the heats named "
-            "in that message through Heat.set_roster, or rebuild the file. "
-            "This module has no synthetic seed path, see the deprecation in "
-            "the module docstring; tests/test_route_smoke.py falls back to "
-            "one."
-        )
-    TMP_ROOT.mkdir(exist_ok=True)
-    temp_dir = TMP_ROOT / f"integration-qa-{uuid.uuid4().hex}"
-    temp_dir.mkdir()
-    db_copy = temp_dir / "proam-copy.db"
-    shutil.copy2(SOURCE_DB, db_copy)
-
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_copy}")
-    monkeypatch.setenv("SECRET_KEY", "integration-qa-secret")
-    monkeypatch.setenv("FLASK_ENV", "testing")
-    monkeypatch.setenv("TESTING", "1")
-
-    app = create_app()
-    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
-
-    # Migrate the copy.  instance/proam.db is stamped at whatever revision the
-    # developer's machine last ran, and a copy that skips the chain runs these
-    # tests against a schema no production database has.  See the same comment
-    # in tests/test_route_smoke.py for how this was found.
-    from flask_migrate import upgrade
+    app, db_handle = create_test_app()
     with app.app_context():
-        upgrade(directory=str(PROJECT_ROOT / "migrations"))
-
-    with app.app_context():
-        from models import User
-
-        admin_user = User.query.order_by(User.id).first()
-        assert admin_user is not None, "expected at least one admin-capable user in copied DB"
+        admin_user = User(username="integration_qa_admin", role="admin")
+        admin_user.set_password("testpass")
+        db.session.add(admin_user)
+        db.session.commit()
+        admin_user_id = admin_user.id
 
     client = app.test_client()
     with client.session_transaction() as sess:
-        sess["_user_id"] = str(admin_user.id)
+        sess["_user_id"] = str(admin_user_id)
         sess["_fresh"] = True
 
     try:
-        yield {"app": app, "client": client, "db_copy": db_copy}
+        yield {"app": app, "client": client}
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        with app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+        drop_test_db(db_handle)
 
 
 def _seed_pro_workflow(app, *, event_name: str, max_stands: int = 2):
@@ -775,10 +731,27 @@ def test_ala_membership_report_generates_html_and_pdf(qa_env):
     client = qa_env["client"]
 
     with app.app_context():
+        from database import db
         from models import Tournament
         from models.competitor import ProCompetitor
 
-        tournament = Tournament.query.order_by(Tournament.id).first()
+        tournament = Tournament(
+            name=f"QA ALA {uuid.uuid4().hex[:8]}",
+            year=2026,
+            status="setup",
+        )
+        db.session.add(tournament)
+        db.session.flush()
+        db.session.add(
+            ProCompetitor(
+                tournament_id=tournament.id,
+                name="ALA Report Competitor",
+                gender="M",
+                email="ala-report@qa.test",
+                status="active",
+            )
+        )
+        db.session.commit()
         attendee_count = ProCompetitor.query.filter_by(
             tournament_id=tournament.id,
             status="active",

--- a/tests/test_mark_assignment.py
+++ b/tests/test_mark_assignment.py
@@ -406,12 +406,6 @@ class TestAssignHandicapMarksSuccess:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_marks_stored_on_event_results(self, mock_calc_factory, mock_pull, db_session, tournament):
         """handicap_factor and predicted_time are written from MarkResult mocks."""
         event = _make_event(db_session, tournament,
@@ -446,12 +440,6 @@ class TestAssignHandicapMarksSuccess:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_zero_predicted_time_preserved(self, mock_calc_factory, mock_pull, db_session, tournament):
         """A MarkResult with predicted_time == 0.0 is stored as 0.0, not None.
 
@@ -480,12 +468,6 @@ class TestAssignHandicapMarksSuccess:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_different_marks_per_competitor(self, mock_calc_factory, mock_pull, db_session, tournament):
         """Different competitors can receive different start marks."""
         event = _make_event(db_session, tournament,
@@ -515,12 +497,6 @@ class TestAssignHandicapMarksSuccess:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_calculator_value_error_returns_error_status(self, mock_calc_factory, mock_pull, db_session, tournament):
         """STRATHMARK rejecting the input (e.g. unknown event_code) → status='error'."""
         event = _make_event(db_session, tournament,
@@ -555,12 +531,6 @@ class TestAssignHandicapMarksSkipPaths:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_competitor_not_in_calculator_output_skipped(self, mock_calc_factory, mock_pull, db_session, tournament):
         """When the calculator returns no MarkResult for a competitor (e.g.
         the panel-mark fallback dropped them), that competitor is skipped
@@ -593,12 +563,6 @@ class TestAssignHandicapMarksSkipPaths:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_empty_calculator_output_skips_all(self, mock_calc_factory, mock_pull, db_session, tournament):
         """When calculator.calculate() returns [], every competitor is skipped."""
         event = _make_event(db_session, tournament,
@@ -622,12 +586,6 @@ class TestAssignHandicapMarksSkipPaths:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_no_results_returns_ok_zero(self, mock_calc_factory, mock_pull, db_session, tournament):
         """Event with no EventResult rows short-circuits before the calculator."""
         event = _make_event(db_session, tournament,
@@ -690,12 +648,6 @@ class TestAssignHandicapMarksLogging:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_info_log_on_successful_marks(self, mock_calc_factory, mock_pull, db_session, tournament, caplog):
         """An INFO log line with the assigned/skipped counts is emitted."""
         event = _make_event(db_session, tournament,
@@ -722,12 +674,6 @@ class TestAssignHandicapMarksLogging:
     })
     @patch('services.mark_assignment._pull_global_results_df', return_value=None)
     @patch('services.mark_assignment._get_handicap_calculator')
-    @pytest.mark.xfail(
-        strict=False,
-        reason="D15-B (c42): passes with the full STRATHMARK environment (the "
-               "operator's machine); fails in the minimal cloud rig. Ambient red "
-               "trains people to ignore red. Remove this marker when D14-B "
-               "(Postgres everywhere + STRATHMARK fake) lands.")
     def test_info_log_zero_marks(self, mock_calc_factory, mock_pull, db_session, tournament, caplog):
         """Even with zero marks assigned, the INFO log line is emitted."""
         event = _make_event(db_session, tournament,

--- a/tests/test_migration_event_state.py
+++ b/tests/test_migration_event_state.py
@@ -14,6 +14,7 @@ import json
 
 import pytest
 
+from database import db
 from models.event import Event, EventResult
 from tests.conftest import (
     make_college_competitor,
@@ -36,7 +37,7 @@ class TestEventModelAttributes:
         event = make_event(db_session, t, "Men's Underhand", event_type="pro")
         db_session.flush()
 
-        fresh = Event.query.get(event.id)
+        fresh = db.session.get(Event, event.id)
         assert hasattr(
             fresh, "event_state"
         ), "Event model must have event_state attribute"
@@ -46,7 +47,7 @@ class TestEventModelAttributes:
         event = make_event(db_session, t, "Stock Saw", event_type="pro")
         db_session.flush()
 
-        fresh = Event.query.get(event.id)
+        fresh = db.session.get(Event, event.id)
         assert fresh.event_state is None
 
     def test_event_state_accepts_json_string(self, db_session):
@@ -60,7 +61,7 @@ class TestEventModelAttributes:
         event.event_state = json.dumps(state)
         db_session.flush()
 
-        fresh = Event.query.get(event.id)
+        fresh = db.session.get(Event, event.id)
         assert json.loads(fresh.event_state) == state
 
 
@@ -75,7 +76,7 @@ class TestEventResultModelAttributes:
         result = make_event_result(db_session, event, comp, competitor_type="college")
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert hasattr(
             fresh, "payout_settled"
         ), "EventResult model must have payout_settled attribute"
@@ -88,7 +89,7 @@ class TestEventResultModelAttributes:
         result = make_event_result(db_session, event, comp, competitor_type="college")
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert fresh.payout_settled is False
 
     def test_payout_settled_can_be_toggled_to_true(self, db_session):
@@ -100,7 +101,7 @@ class TestEventResultModelAttributes:
         result.payout_settled = True
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert fresh.payout_settled is True
 
     def test_payout_settled_round_trips_false(self, db_session):
@@ -112,7 +113,7 @@ class TestEventResultModelAttributes:
         result.payout_settled = False
         db_session.flush()
 
-        fresh = EventResult.query.get(result.id)
+        fresh = db.session.get(EventResult, result.id)
         assert fresh.payout_settled is False
 
 
@@ -138,7 +139,7 @@ class TestEventStateMigrationLogic:
         relay.payouts = "{}"
         db_session.flush()
 
-        fresh = Event.query.get(relay.id)
+        fresh = db.session.get(Event, relay.id)
         assert json.loads(fresh.event_state) == relay_state
         assert fresh.payouts == "{}"
 
@@ -153,7 +154,7 @@ class TestEventStateMigrationLogic:
         birling.payouts = "{}"
         db_session.flush()
 
-        fresh = Event.query.get(birling.id)
+        fresh = db.session.get(Event, birling.id)
         assert json.loads(fresh.event_state) == bracket_state
 
     def test_non_state_event_event_state_stays_none(self, db_session):
@@ -162,7 +163,7 @@ class TestEventStateMigrationLogic:
         event = make_event(db_session, t, "Men's Underhand", event_type="pro")
         db_session.flush()
 
-        fresh = Event.query.get(event.id)
+        fresh = db.session.get(Event, event.id)
         assert fresh.event_state is None
 
     def test_event_state_accepts_null(self, db_session):
@@ -172,7 +173,7 @@ class TestEventStateMigrationLogic:
         event.event_state = None
         db_session.flush()
 
-        fresh = Event.query.get(event.id)
+        fresh = db.session.get(Event, event.id)
         assert fresh.event_state is None
 
     def test_multiple_events_independent_state(self, db_session):
@@ -188,9 +189,9 @@ class TestEventStateMigrationLogic:
         birling.event_state = json.dumps({"rounds": [{"match": 1}]})
         db_session.flush()
 
-        fresh_relay = Event.query.get(relay.id)
-        fresh_birling = Event.query.get(birling.id)
-        fresh_underhand = Event.query.get(underhand.id)
+        fresh_relay = db.session.get(Event, relay.id)
+        fresh_birling = db.session.get(Event, birling.id)
+        fresh_underhand = db.session.get(Event, underhand.id)
 
         assert json.loads(fresh_relay.event_state)["teams"] == [1, 2]
         assert json.loads(fresh_birling.event_state)["rounds"][0]["match"] == 1

--- a/tests/test_migration_integrity.py
+++ b/tests/test_migration_integrity.py
@@ -187,16 +187,17 @@ class TestMigrationIntegrity:
     as the ORM models declare."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def schemas(self, request):
+    @classmethod
+    def schemas(cls):
         """Build both schemas once per class (they are expensive)."""
         mig_simple, mig_detail, mig_idx = _build_migration_schema()
         mod_simple, mod_detail, mod_idx = _build_model_schema()
-        request.cls.migration_schema = mig_simple
-        request.cls.model_schema = mod_simple
-        request.cls.migration_detail = mig_detail
-        request.cls.model_detail = mod_detail
-        request.cls.migration_indexes = mig_idx
-        request.cls.model_indexes = mod_idx
+        cls.migration_schema = mig_simple
+        cls.model_schema = mod_simple
+        cls.migration_detail = mig_detail
+        cls.model_detail = mod_detail
+        cls.migration_indexes = mig_idx
+        cls.model_indexes = mod_idx
 
     # -- Table and column existence (original tests) -----------------------
 
@@ -516,7 +517,8 @@ class TestMigrationChain:
     """Verify the migration chain is linear and has no broken links."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def migration_graph(self, request):
+    @classmethod
+    def migration_graph(cls):
         """Parse all migration files to build the revision graph."""
         import glob
         import importlib.util
@@ -545,7 +547,7 @@ class TestMigrationChain:
                     'file': os.path.basename(path),
                     'is_merge': isinstance(down, tuple),
                 }
-        request.cls.graph = graph
+        cls.graph = graph
 
     def test_no_orphan_revisions(self):
         """Every down_revision must point to an existing revision (or None)."""
@@ -614,7 +616,8 @@ class TestModelColumnDeclarations:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def model_metadata(self, request, tmp_path_factory):
+    @classmethod
+    def model_metadata(cls, tmp_path_factory):
         """Load model metadata using a temp DB (never touches production)."""
         tmp_db = tmp_path_factory.mktemp('nullable') / 'test.db'
         old_db_url = os.environ.get('DATABASE_URL')
@@ -624,8 +627,8 @@ class TestModelColumnDeclarations:
             app = create_app()
             from database import db
             with app.app_context():
-                request.cls.metadata = db.metadata
-                request.cls.app = app
+                cls.metadata = db.metadata
+                cls.app = app
         finally:
             if old_db_url is None:
                 os.environ.pop('DATABASE_URL', None)
@@ -684,7 +687,8 @@ class TestMigrationFileQuality:
     """
 
     @pytest.fixture(scope='class', autouse=True)
-    def migration_files(self, request):
+    @classmethod
+    def migration_files(cls):
         """Read all migration file contents."""
         import glob
 
@@ -697,7 +701,7 @@ class TestMigrationFileQuality:
             basename = os.path.basename(path)
             with open(path, 'r', encoding='utf-8') as f:
                 files[basename] = f.read()
-        request.cls.files = files
+        cls.files = files
 
     def test_no_idempotent_hacks(self):
         """Migration files should not use _add_column_if_missing() or similar.

--- a/tests/test_model_json_safety.py
+++ b/tests/test_model_json_safety.py
@@ -7,12 +7,13 @@ Run:
 """
 import json
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 
 from database import db as _db
+from services.time_utils import utc_now_naive
 from tests.conftest import (
     make_college_competitor,
     make_event,
@@ -257,7 +258,7 @@ class TestHeatLocking:
         h = make_heat(db_session, e)
         h.acquire_lock(user_id=u1.id)
         # Force lock to be expired (5+ minutes ago)
-        h.locked_at = datetime.utcnow() - timedelta(seconds=400)
+        h.locked_at = utc_now_naive() - timedelta(seconds=400)
         db_session.flush()
 
         assert h.is_locked() is False

--- a/tests/test_non_empty_dashboard_smokes.py
+++ b/tests/test_non_empty_dashboard_smokes.py
@@ -30,6 +30,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 
@@ -272,7 +273,7 @@ def _seed(app):
     # the trilogy doc warns about (member vs pro_members / college_members).
     # Service requires pros to be entered in the axe event first.
     for pid in pro_ids[:4]:
-        p = ProCompetitor.query.get(pid)
+        p = db.session.get(ProCompetitor, pid)
         entered = list(p.get_events_entered() or [])
         entered.append(str(axe_event.id))
         p.set_events_entered(entered)

--- a/tests/test_one_click_and_fnf.py
+++ b/tests/test_one_click_and_fnf.py
@@ -17,6 +17,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # D12-C commit E: the roster is `heat_assignments` rows now, so a heat
@@ -514,7 +515,7 @@ class TestFNFPerEventStandOverride:
             data = _seed_two_event_show(_db.session)
             t = data["tournament"]
             p1b_id = data["p1b"].id
-            assert Event.query.get(p1b_id).max_stands == 2
+            assert db.session.get(Event, p1b_id).max_stands == 2
             _db.session.commit()
             tid = t.id
 
@@ -531,7 +532,7 @@ class TestFNFPerEventStandOverride:
         assert resp.status_code in (302, 303)
 
         with app.app_context():
-            assert Event.query.get(p1b_id).max_stands == 3
+            assert db.session.get(Event, p1b_id).max_stands == 3
 
     def test_blank_stand_input_preserves_existing(self, app, auth_client):
         from models import Event
@@ -540,7 +541,7 @@ class TestFNFPerEventStandOverride:
             data = _seed_two_event_show(_db.session)
             t = data["tournament"]
             p1b_id = data["p1b"].id
-            Event.query.get(p1b_id).max_stands = 5
+            db.session.get(Event, p1b_id).max_stands = 5
             _db.session.commit()
             tid = t.id
 
@@ -557,7 +558,7 @@ class TestFNFPerEventStandOverride:
         assert resp.status_code in (302, 303)
 
         with app.app_context():
-            assert Event.query.get(p1b_id).max_stands == 5
+            assert db.session.get(Event, p1b_id).max_stands == 5
 
     def test_invalid_stand_input_rejected_without_crash(self, app, auth_client):
         from models import Event
@@ -566,7 +567,7 @@ class TestFNFPerEventStandOverride:
             data = _seed_two_event_show(_db.session)
             t = data["tournament"]
             p1b_id = data["p1b"].id
-            Event.query.get(p1b_id).max_stands = 4
+            db.session.get(Event, p1b_id).max_stands = 4
             _db.session.commit()
             tid = t.id
 
@@ -583,7 +584,7 @@ class TestFNFPerEventStandOverride:
             )
             assert resp.status_code in (302, 303)
             with app.app_context():
-                assert Event.query.get(p1b_id).max_stands == 4
+                assert db.session.get(Event, p1b_id).max_stands == 4
 
     def test_generate_heats_respects_new_cap(self, app, auth_client):
         """Integration: set stands=3 on Pro 1-Board with 9 competitors,
@@ -624,7 +625,7 @@ class TestFNFPerEventStandOverride:
         assert resp.status_code in (302, 303)
 
         with app.app_context():
-            e = Event.query.get(p1b_id)
+            e = db.session.get(Event, p1b_id)
             assert e.max_stands == 3
             heats = Heat.query.filter_by(event_id=p1b_id).all()
             assert len(heats) >= 3

--- a/tests/test_partner_reassignment.py
+++ b/tests/test_partner_reassignment.py
@@ -17,6 +17,8 @@ import os
 
 import pytest
 
+from database import db
+
 os.environ.setdefault("SECRET_KEY", "test-secret-partner-reassign")
 os.environ.setdefault("WTF_CSRF_ENABLED", "False")
 
@@ -391,8 +393,8 @@ class TestReassignPartnerRoute:
         # Verify bidirectional update
         from models.competitor import ProCompetitor
 
-        alice_fresh = ProCompetitor.query.get(alice.id)
-        carol_fresh = ProCompetitor.query.get(carol.id)
+        alice_fresh = db.session.get(ProCompetitor, alice.id)
+        carol_fresh = db.session.get(ProCompetitor, carol.id)
         assert alice_fresh.get_partners().get(str(ev.id)) == "Carol"
         assert carol_fresh.get_partners().get(str(ev.id)) == "Alice"
 
@@ -430,7 +432,7 @@ class TestReassignPartnerRoute:
 
         from models.competitor import ProCompetitor
 
-        alice_fresh = ProCompetitor.query.get(alice.id)
+        alice_fresh = db.session.get(ProCompetitor, alice.id)
         # partner should still be Bob (unchanged)
         assert alice_fresh.get_partners().get(str(ev.id)) == "Bob"
 
@@ -470,7 +472,7 @@ class TestReassignPartnerRoute:
 
         from models.competitor import ProCompetitor
 
-        alice_fresh = ProCompetitor.query.get(alice.id)
+        alice_fresh = db.session.get(ProCompetitor, alice.id)
         assert alice_fresh.get_partners().get(str(ev.id)) == "Bob"
 
     def test_result_partner_name_updated(self, app, db_session, auth_client):

--- a/tests/test_postgres_compat.py
+++ b/tests/test_postgres_compat.py
@@ -19,6 +19,7 @@ import json
 
 import pytest
 
+from database import db
 from database import db as _db
 from tests.conftest import (
     make_college_competitor,
@@ -272,7 +273,7 @@ class TestNumericPrecision:
         db_session.flush()
 
         from models.event import EventResult
-        loaded = EventResult.query.get(r.id)
+        loaded = db.session.get(EventResult, r.id)
         assert abs(loaded.result_value - 15.123456789) < 0.001
 
     def test_handicap_factor_precision(self, db_session, tournament):
@@ -283,7 +284,7 @@ class TestNumericPrecision:
         db_session.flush()
 
         from models.event import EventResult
-        loaded = EventResult.query.get(r.id)
+        loaded = db.session.get(EventResult, r.id)
         assert abs(loaded.handicap_factor - 3.456) < 0.01
 
     def test_payout_amount_zero_default(self, db_session, tournament):
@@ -293,7 +294,7 @@ class TestNumericPrecision:
         db_session.flush()
 
         from models.event import EventResult
-        loaded = EventResult.query.get(r.id)
+        loaded = db.session.get(EventResult, r.id)
         assert loaded.payout_amount == 0.0
 
 

--- a/tests/test_postgres_runtime_smoke.py
+++ b/tests/test_postgres_runtime_smoke.py
@@ -11,6 +11,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 if not os.environ.get('DATABASE_URL', '').startswith('postgresql://'):

--- a/tests/test_pro_event_fees.py
+++ b/tests/test_pro_event_fees.py
@@ -21,6 +21,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 
@@ -178,9 +179,9 @@ class TestEventFeesPostSetsFees:
         with app.app_context():
             from models.competitor import ProCompetitor
 
-            c0 = ProCompetitor.query.get(c0_id)
-            c1 = ProCompetitor.query.get(c1_id)
-            c2 = ProCompetitor.query.get(c2_id)
+            c0 = db.session.get(ProCompetitor, c0_id)
+            c1 = db.session.get(ProCompetitor, c1_id)
+            c2 = db.session.get(ProCompetitor, c2_id)
 
             # c0 and c1 are enrolled in evt_a → fee set
             assert c0.get_entry_fees().get(str(evt_a_id)) == 25
@@ -210,7 +211,7 @@ class TestEventFeesPostSetsFees:
         with app.app_context():
             from models.competitor import ProCompetitor
 
-            c0 = ProCompetitor.query.get(c0_id)
+            c0 = db.session.get(ProCompetitor, c0_id)
             assert c0.get_entry_fees().get(str(evt_a_id)) == 15  # untouched
 
     def test_post_skips_existing_non_zero_fee_by_default(self, app, auth_client):
@@ -234,8 +235,8 @@ class TestEventFeesPostSetsFees:
         with app.app_context():
             from models.competitor import ProCompetitor
 
-            c0 = ProCompetitor.query.get(c0_id)
-            c1 = ProCompetitor.query.get(c1_id)
+            c0 = db.session.get(ProCompetitor, c0_id)
+            c1 = db.session.get(ProCompetitor, c1_id)
             # c0 kept the original 15 (existing, no overwrite)
             assert c0.get_entry_fees().get(str(evt_a_id)) == 15
             # c1 got the new 30 (no existing fee)
@@ -261,7 +262,7 @@ class TestEventFeesPostSetsFees:
         with app.app_context():
             from models.competitor import ProCompetitor
 
-            c0 = ProCompetitor.query.get(c0_id)
+            c0 = db.session.get(ProCompetitor, c0_id)
             assert c0.get_entry_fees().get(str(evt_a_id)) == 30
 
     def test_post_invalid_fee_does_not_crash(self, app, auth_client):

--- a/tests/test_proam_relay.py
+++ b/tests/test_proam_relay.py
@@ -56,6 +56,29 @@ def _make_team(num, total_time=None):
 
 
 # ---------------------------------------------------------------------------
+# Relay state loading
+# ---------------------------------------------------------------------------
+
+class TestRelayStateLoading:
+    def test_malformed_saved_state_falls_back_to_empty_relay(self):
+        relay_event = MagicMock(event_state="{not-json", payouts=None)
+        with patch("services.proam_relay.Event") as mock_event:
+            mock_event.query.filter_by.return_value.first.return_value = relay_event
+            relay = ProAmRelay(MagicMock())
+
+        assert relay.get_status() == "not_drawn"
+        assert relay.get_teams() == []
+
+    def test_unexpected_decoder_failure_is_not_silenced(self):
+        relay_event = MagicMock(event_state="{}", payouts=None)
+        with patch("services.proam_relay.Event") as mock_event:
+            mock_event.query.filter_by.return_value.first.return_value = relay_event
+            with patch("services.proam_relay.json.loads", side_effect=RuntimeError("decoder failed")):
+                with pytest.raises(RuntimeError, match="decoder failed"):
+                    ProAmRelay(MagicMock())
+
+
+# ---------------------------------------------------------------------------
 # get_status / get_teams
 # ---------------------------------------------------------------------------
 

--- a/tests/test_proam_relay_placement.py
+++ b/tests/test_proam_relay_placement.py
@@ -16,6 +16,7 @@ import json
 
 import pytest
 
+from database import db
 from database import db as _db
 
 
@@ -324,7 +325,7 @@ class TestRelayVsChokermanOrdering:
             h.flight_position
             for h in last_flight_heats
             if h.event_id != chokerman.id
-            and Event.query.get(h.event_id).name == "Pro-Am Relay"
+            and db.session.get(Event, h.event_id).name == "Pro-Am Relay"
         ]
         chokerman_positions = [
             h.flight_position for h in last_flight_heats if h.event_id == chokerman.id

--- a/tests/test_relay_lottery_realistic.py
+++ b/tests/test_relay_lottery_realistic.py
@@ -12,6 +12,7 @@ import json
 
 import pytest
 
+from database import db
 from tests.conftest import (
     make_college_competitor,
     make_pro_competitor,
@@ -189,7 +190,7 @@ class TestRelayLotteryDraw:
                 drawn_pro_ids.add(m['id'])
 
         for pid in drawn_pro_ids:
-            comp = ProCompetitor.query.get(pid)
+            comp = db.session.get(ProCompetitor, pid)
             assert comp.pro_am_lottery_opt_in is True, (
                 f"Pro competitor {comp.name} was drawn but not opted in"
             )

--- a/tests/test_relay_team_health.py
+++ b/tests/test_relay_team_health.py
@@ -61,11 +61,10 @@ def _make_full_team():
 
 def _mock_competitor_lookup(status_map):
     """
-    Return a side_effect function that mocks ProCompetitor.query.get() and
-    CollegeCompetitor.query.get() based on {id: status} map.
+    Return a side-effect function for db.session.get(model, id).
     """
 
-    def _get(cid):
+    def _get(_model_cls, cid):
         mock = MagicMock()
         mock.status = status_map.get(cid, "active")
         return mock
@@ -86,12 +85,9 @@ class TestComputeTeamHealthGreen:
         # All 8 members active
         status_map = {i: "active" for i in range(1, 9)}
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "green"
@@ -102,12 +98,9 @@ class TestComputeTeamHealthGreen:
         tournament = MagicMock()
         status_map = {i: "active" for i in range(1, 9)}
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "green"
@@ -137,12 +130,9 @@ class TestComputeTeamHealthYellow:
             8: "active",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "yellow"
@@ -163,12 +153,9 @@ class TestComputeTeamHealthYellow:
             8: "scratched",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "yellow"
@@ -187,12 +174,9 @@ class TestComputeTeamHealthYellow:
             8: "active",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert (
@@ -224,12 +208,9 @@ class TestComputeTeamHealthRed:
             8: "active",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "red"
@@ -250,12 +231,9 @@ class TestComputeTeamHealthRed:
             8: "scratched",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "red"
@@ -275,12 +253,9 @@ class TestComputeTeamHealthRed:
             8: "active",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["status"] == "red"
@@ -299,12 +274,9 @@ class TestComputeTeamHealthRed:
             8: "active",
         }
 
-        with (
-            patch("services.proam_relay.ProCompetitor") as mock_pro,
-            patch("services.proam_relay.CollegeCompetitor") as mock_col,
+        with patch(
+            "services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(status_map)
         ):
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(status_map)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(status_map)
             result = compute_team_health(team, tournament)
 
         assert result["detail"]
@@ -339,11 +311,10 @@ class TestReplaceCompetitorHealthWarning:
         with (
             patch("services.proam_relay.ProCompetitor") as mock_pro,
             patch("services.proam_relay.CollegeCompetitor") as mock_col,
+            patch("services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(all_active)),
             patch.object(relay, "_save_relay_data"),
         ):
             mock_pro.query.filter_by.return_value.first.return_value = new_comp
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(all_active)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(all_active)
             result = relay.replace_competitor(1, 1, 99, "pro")
 
         assert result is not None
@@ -376,11 +347,10 @@ class TestReplaceCompetitorHealthWarning:
         with (
             patch("services.proam_relay.ProCompetitor") as mock_pro,
             patch("services.proam_relay.CollegeCompetitor") as mock_col,
+            patch("services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(post_status)),
             patch.object(relay, "_save_relay_data"),
         ):
             mock_pro.query.filter_by.return_value.first.return_value = new_comp
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(post_status)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(post_status)
             result = relay.replace_competitor(1, 1, 99, "pro")
 
         assert result["health"]["status"] == "red"
@@ -410,11 +380,10 @@ class TestReplaceCompetitorHealthWarning:
         with (
             patch("services.proam_relay.ProCompetitor") as mock_pro,
             patch("services.proam_relay.CollegeCompetitor") as mock_col,
+            patch("services.proam_relay.db.session.get", side_effect=_mock_competitor_lookup(post_status)),
             patch.object(relay, "_save_relay_data"),
         ):
             mock_pro.query.filter_by.return_value.first.return_value = new_comp
-            mock_pro.query.get.side_effect = _mock_competitor_lookup(post_status)
-            mock_col.query.get.side_effect = _mock_competitor_lookup(post_status)
             result = relay.replace_competitor(1, 1, 99, "pro")
 
         # Replacement happened — new comp is in team

--- a/tests/test_relay_team_health.py
+++ b/tests/test_relay_team_health.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from database import db
 from services.proam_relay import ProAmRelay, compute_team_health
 
 # ---------------------------------------------------------------------------

--- a/tests/test_remedial_pr_fixes.py
+++ b/tests/test_remedial_pr_fixes.py
@@ -10,6 +10,7 @@ import tempfile
 
 import pytest
 
+from database import db
 from tests.db_test_utils import create_test_app, skip_unless_sqlite
 
 
@@ -121,7 +122,7 @@ def test_friday_feature_persists_in_schedule_config(app, admin_client):
     assert response.status_code == 302
 
     with app.app_context():
-        tournament = Tournament.query.get(tournament_id)
+        tournament = db.session.get(Tournament, tournament_id)
         saved = tournament.get_schedule_config()
         assert saved['friday_pro_event_ids'] == [event_id]
         assert saved['friday_feature_notes'] == 'Friday showcase'
@@ -141,7 +142,7 @@ def test_activate_competition_requires_post(app, admin_client):
     assert post_response.status_code == 302
 
     with app.app_context():
-        tournament = Tournament.query.get(tournament_id)
+        tournament = db.session.get(Tournament, tournament_id)
         assert tournament.status == 'college_active'
 
 

--- a/tests/test_route_smoke.py
+++ b/tests/test_route_smoke.py
@@ -1,6 +1,7 @@
 """QA route smoke tests over the full Flask URL map."""
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import uuid
@@ -34,7 +35,10 @@ def _discover_routes() -> list[dict[str, object]]:
 
 ROUTE_SPECS = _discover_routes()
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-SOURCE_DB = PROJECT_ROOT / "instance" / "proam.db"
+_SOURCE_DB_ENV = os.environ.get("PROAM_ROUTE_SMOKE_SOURCE_DB", "").strip()
+SOURCE_DB = Path(_SOURCE_DB_ENV) if _SOURCE_DB_ENV else PROJECT_ROOT / "instance" / "proam.db"
+if not SOURCE_DB.is_absolute():
+    SOURCE_DB = PROJECT_ROOT / SOURCE_DB
 TMP_ROOT = PROJECT_ROOT / ".qa_tmp"
 
 

--- a/tests/test_routes_post.py
+++ b/tests/test_routes_post.py
@@ -17,6 +17,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # ---------------------------------------------------------------------------
@@ -446,8 +447,8 @@ class TestCollegeGearMirror:
         _ok(resp)
 
         # Re-fetch to bypass any session caching.
-        a = CollegeCompetitor.query.get(comp_a.id)
-        b = CollegeCompetitor.query.get(comp_b.id)
+        a = db.session.get(CollegeCompetitor, comp_a.id)
+        b = db.session.get(CollegeCompetitor, comp_b.id)
         assert a.get_gear_sharing().get('springboard') == 'G4 Comp B'
         assert b.get_gear_sharing().get('springboard') == 'G4 Comp A', (
             'college gear update did not mirror onto partner row (gear audit G4)'

--- a/tests/test_routes_smoke.py
+++ b/tests/test_routes_smoke.py
@@ -571,6 +571,12 @@ class TestOpsDashboard:
         r = auth_client.get(f'/tournament/{tid}/ops-dashboard')
         assert r.status_code == 200
 
+    def test_dashboard_exposes_schedule_preflight(self, auth_client, tid):
+        r = auth_client.get(f'/tournament/{tid}/ops-dashboard')
+
+        assert r.status_code == 200
+        assert b'Schedule Preflight:' in r.data
+
     def test_auto_refresh_meta_tag_present(self, auth_client, tid):
         """Page must contain an auto-refresh directive."""
         r = auth_client.get(f'/tournament/{tid}/ops-dashboard')

--- a/tests/test_saw_block_assignment.py
+++ b/tests/test_saw_block_assignment.py
@@ -14,6 +14,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 
@@ -107,7 +108,7 @@ def _make_heat(
 
     ensure_competitors(
         db_session,
-        Tournament.query.get(event.tournament_id),
+        db.session.get(Tournament, event.tournament_id),
         competitors,
         event.event_type,
     )

--- a/tests/test_saw_block_integration.py
+++ b/tests/test_saw_block_integration.py
@@ -19,6 +19,8 @@ import tempfile
 
 import pytest
 
+from database import db
+
 os.environ.setdefault("SECRET_KEY", "test-saw-block-integration")
 os.environ.setdefault("WTF_CSRF_ENABLED", "False")
 
@@ -214,7 +216,7 @@ def _seed_heat(
     from tests.conftest import ensure_competitors
 
     ensure_competitors(
-        db.session, Tournament.query.get(event.tournament_id),
+        db.session, db.session.get(Tournament, event.tournament_id),
         competitors, event.event_type,
     )
 
@@ -335,8 +337,8 @@ def test_build_flights_triggers_block_assignment(app, auth_client):
     with app.app_context():
         from models import Heat
 
-        h1 = Heat.query.get(h1_id)
-        h2 = Heat.query.get(h2_id)
+        h1 = db.session.get(Heat, h1_id)
+        h2 = db.session.get(Heat, h2_id)
         # After build_flights, both heats are in flight 1.
         # The first heat in flight_position order gets Block A, the second Block B.
         ordered_by_flight = sorted(
@@ -389,8 +391,8 @@ def test_reorder_flight_heats_triggers_recompute(app, auth_client):
     with app.app_context():
         from models import Heat
 
-        h_a = Heat.query.get(h_a_id)
-        h_b = Heat.query.get(h_b_id)
+        h_a = db.session.get(Heat, h_a_id)
+        h_b = db.session.get(Heat, h_b_id)
         # h_b is now first in flight -> Block A; h_a is second -> Block B
         assert _used_stands(h_b) == BLOCK_A
         assert _used_stands(h_a) == BLOCK_B
@@ -436,9 +438,9 @@ def test_bulk_reorder_moves_heat_between_flights(app, auth_client):
 
     with app.app_context():
         from models import Heat
-        h_a = Heat.query.get(h_a_id)
-        h_b = Heat.query.get(h_b_id)
-        h_c = Heat.query.get(h_c_id)
+        h_a = db.session.get(Heat, h_a_id)
+        h_b = db.session.get(Heat, h_b_id)
+        h_c = db.session.get(Heat, h_c_id)
         assert h_a.flight_id == f1_id and h_a.flight_position == 1
         assert h_b.flight_id == f2_id and h_b.flight_position == 1
         assert h_c.flight_id == f2_id and h_c.flight_position == 2
@@ -504,8 +506,8 @@ def test_move_competitor_happy_path(app, auth_client):
 
     with app.app_context():
         from models import Heat
-        h_a = Heat.query.get(h_a_id)
-        h_b = Heat.query.get(h_b_id)
+        h_a = db.session.get(Heat, h_a_id)
+        h_b = db.session.get(Heat, h_b_id)
         assert 2 not in h_a.get_competitors()
         assert 2 in h_b.get_competitors()
         # Target heat had stands 1 and 2 used; competitor 2 gets next free = 3
@@ -539,8 +541,8 @@ def test_move_competitor_rejects_full_target(app, auth_client):
     # State unchanged
     with app.app_context():
         from models import Heat
-        h_a = Heat.query.get(h_a_id)
-        h_b = Heat.query.get(h_b_id)
+        h_a = db.session.get(Heat, h_a_id)
+        h_b = db.session.get(Heat, h_b_id)
         assert 1 in h_a.get_competitors()
         assert 1 not in h_b.get_competitors()
 
@@ -597,8 +599,8 @@ def test_move_competitor_pair_moves_both(app, auth_client):
 
     with app.app_context():
         from models import Heat
-        h_a = Heat.query.get(h_a_id)
-        h_b = Heat.query.get(h_b_id)
+        h_a = db.session.get(Heat, h_a_id)
+        h_b = db.session.get(Heat, h_b_id)
         assert 10 not in h_a.get_competitors()
         assert 11 not in h_a.get_competitors()
         assert 10 in h_b.get_competitors()
@@ -655,8 +657,8 @@ def test_reorder_friday_events_triggers_recompute(app, auth_client):
     with app.app_context():
         from models import Heat
 
-        h_sb = Heat.query.get(h_sb_id)
-        h_db = Heat.query.get(h_db_id)
+        h_sb = db.session.get(Heat, h_sb_id)
+        h_db = db.session.get(Heat, h_db_id)
         # DB runs first -> Block A (stands 1 and 2 for the pairs)
         assert set(h_db.get_stand_assignments().values()).issubset(set(BLOCK_A))
         # SB runs second -> Block B

--- a/tests/test_saw_blocks_admin.py
+++ b/tests/test_saw_blocks_admin.py
@@ -21,6 +21,8 @@ import tempfile
 
 import pytest
 
+from database import db
+
 os.environ.setdefault("SECRET_KEY", "test-saw-blocks-admin")
 os.environ.setdefault("WTF_CSRF_ENABLED", "False")
 
@@ -164,7 +166,7 @@ def _seed_heat(db, event, heat_number, competitors, stand_assignments):
     from tests.conftest import ensure_competitors
 
     ensure_competitors(
-        db.session, Tournament.query.get(event.tournament_id),
+        db.session, db.session.get(Tournament, event.tournament_id),
         competitors, event.event_type,
     )
 
@@ -225,8 +227,8 @@ def test_recompute_route_succeeds(app, auth_client):
     with app.app_context():
         from models import Heat
 
-        h1 = Heat.query.get(h1_id)
-        h2 = Heat.query.get(h2_id)
+        h1 = db.session.get(Heat, h1_id)
+        h2 = db.session.get(Heat, h2_id)
         # Alternation applied: heat 1 -> Block A, heat 2 -> Block B
         used_1 = sorted({int(v) for v in h1.get_stand_assignments().values()})
         used_2 = sorted({int(v) for v in h2.get_stand_assignments().values()})

--- a/tests/test_scoring_college_points.py
+++ b/tests/test_scoring_college_points.py
@@ -8,6 +8,7 @@ and tied competitors receive identical positions and points.
 import pytest
 
 import config
+from database import db
 from tests.conftest import (
     make_college_competitor,
     make_event,
@@ -372,7 +373,7 @@ class TestCollegeTeamStandings:
                         r.points_awarded = exp_pts
                         # Award individual points to competitor
                         from models.competitor import CollegeCompetitor
-                        comp = CollegeCompetitor.query.get(r.competitor_id)
+                        comp = db.session.get(CollegeCompetitor, r.competitor_id)
                         if comp and exp_pts:
                             comp.individual_points += exp_pts
                 event.status = 'completed'
@@ -428,7 +429,7 @@ class TestCollegeTeamStandings:
                         r.final_position = exp_pos
                         r.points_awarded = exp_pts
                         from models.competitor import CollegeCompetitor
-                        comp = CollegeCompetitor.query.get(r.competitor_id)
+                        comp = db.session.get(CollegeCompetitor, r.competitor_id)
                         if comp and exp_pts:
                             comp.individual_points += exp_pts
                 event.status = 'completed'
@@ -488,7 +489,7 @@ class TestCollegeIndividualStandings:
                         r.final_position = exp_pos
                         r.points_awarded = exp_pts
                         from models.competitor import CollegeCompetitor
-                        comp = CollegeCompetitor.query.get(r.competitor_id)
+                        comp = db.session.get(CollegeCompetitor, r.competitor_id)
                         if comp and exp_pts:
                             comp.individual_points += exp_pts
 

--- a/tests/test_scoring_integrity_phase4.py
+++ b/tests/test_scoring_integrity_phase4.py
@@ -23,6 +23,7 @@ from decimal import Decimal
 
 import pytest
 
+from database import db
 from database import db as _db
 from tests.conftest import seat_roster  # noqa: E402
 
@@ -185,8 +186,8 @@ class TestHeatUndoStripsPoints:
         db_session.flush()
 
         c1_id, c2_id = c1.id, c2.id
-        assert CollegeCompetitor.query.get(c1_id).individual_points == Decimal('10.00')
-        assert CollegeCompetitor.query.get(c2_id).individual_points == Decimal('7.00')
+        assert db.session.get(CollegeCompetitor, c1_id).individual_points == Decimal('10.00')
+        assert db.session.get(CollegeCompetitor, c2_id).individual_points == Decimal('7.00')
 
         # Plant an undo token in the session — undo route requires it.
         with judge_client.session_transaction() as sess:
@@ -203,8 +204,8 @@ class TestHeatUndoStripsPoints:
         # The competitors' cached individual_points should be back to 0
         # because the EventResult rows were deleted and the rebuild SUM
         # finds nothing for them.
-        c1_loaded = CollegeCompetitor.query.get(c1_id)
-        c2_loaded = CollegeCompetitor.query.get(c2_id)
+        c1_loaded = db.session.get(CollegeCompetitor, c1_id)
+        c2_loaded = db.session.get(CollegeCompetitor, c2_id)
         assert c1_loaded.individual_points == Decimal('0.00')
         assert c2_loaded.individual_points == Decimal('0.00')
 
@@ -226,7 +227,7 @@ class TestHeatUndoStripsPoints:
         calculate_positions(event)
         db_session.flush()
         team_id = team.id
-        assert Team.query.get(team_id).total_points == Decimal('17.00')  # 10 + 7
+        assert db.session.get(Team, team_id).total_points == Decimal('17.00')  # 10 + 7
 
         with judge_client.session_transaction() as sess:
             sess[f'undo_heat_{heat.id}'] = {
@@ -238,7 +239,7 @@ class TestHeatUndoStripsPoints:
         r = judge_client.post(f'/scoring/{tid}/heat/{heat.id}/undo')
         assert r.status_code in (200, 302)
 
-        assert Team.query.get(team_id).total_points == Decimal('0.00')
+        assert db.session.get(Team, team_id).total_points == Decimal('0.00')
 
     def test_undo_heat_deletes_event_result_rows(self, db_session, judge_client, tid):
         """The EventResult rows are gone after undo (existing behavior preserved)."""
@@ -309,7 +310,7 @@ class TestRepairPointsRoute:
         assert body['teams_rebuilt'] >= 1
 
         # The cache should now match the SUM of points_awarded.
-        c1_loaded = CollegeCompetitor.query.get(c1_id)
+        c1_loaded = db.session.get(CollegeCompetitor, c1_id)
         assert c1_loaded.individual_points == Decimal('8.50')
 
     def test_repair_rebuilds_team_totals(self, db_session, admin_client, tid):
@@ -334,7 +335,7 @@ class TestRepairPointsRoute:
         resp = admin_client.post(f'/scoring/admin/repair-points/{tid}')
         assert resp.status_code == 200
         # Total should now be 5 + 3 = 8.
-        assert Team.query.get(team_id).total_points == Decimal('8.00')
+        assert db.session.get(Team, team_id).total_points == Decimal('8.00')
 
     def test_repair_requires_admin_role(self, db_session, judge_client, tid):
         """Judge role is rejected — admin only."""
@@ -382,7 +383,7 @@ class TestRepairPointsRoute:
         c1_id = c1.id
 
         admin_client.post(f'/scoring/admin/repair-points/{tid}')
-        first = CollegeCompetitor.query.get(c1_id).individual_points
+        first = db.session.get(CollegeCompetitor, c1_id).individual_points
         admin_client.post(f'/scoring/admin/repair-points/{tid}')
-        second = CollegeCompetitor.query.get(c1_id).individual_points
+        second = db.session.get(CollegeCompetitor, c1_id).individual_points
         assert first == second == Decimal('7.00')

--- a/tests/test_scratch_cascade.py
+++ b/tests/test_scratch_cascade.py
@@ -11,6 +11,8 @@ import tempfile
 
 import pytest
 
+from database import db
+
 os.environ.setdefault("SECRET_KEY", "test-scratch-cascade")
 os.environ.setdefault("WTF_CSRF_ENABLED", "False")
 # NOTE: `TEST_USE_CREATE_ALL` is set inside the `app` fixture, NOT at module
@@ -594,7 +596,7 @@ class TestExecuteCascadeResultStatuses:
             execute_cascade(comp, effects, judge_user_id=1, tournament=t)
             db.session.commit()
 
-            updated = EventResult.query.get(result_id)
+            updated = db.session.get(EventResult, result_id)
             assert updated.status == "scratched"
             assert updated.points_awarded == 0
             assert updated.payout_amount == 0
@@ -686,7 +688,7 @@ class TestReverseCascadeHappyPath:
 
             assert undo["success"] is True
             assert comp.status == original_status
-            restored = EventResult.query.get(result_id)
+            restored = db.session.get(EventResult, result_id)
             assert restored.status == "pending"
 
 
@@ -694,7 +696,7 @@ class TestReverseCascadeExpiredWindow:
     """reverse_cascade() after 30 min returns error."""
 
     def test_expired_window_returns_error(self, app):
-        from datetime import datetime, timedelta
+        from datetime import timedelta
 
         from database import db
         from models.audit_log import AuditLog
@@ -703,6 +705,7 @@ class TestReverseCascadeExpiredWindow:
             execute_cascade,
             reverse_cascade,
         )
+        from services.time_utils import utc_now_naive
 
         with app.app_context():
             t = _seed_base(db)
@@ -722,7 +725,7 @@ class TestReverseCascadeExpiredWindow:
                 .order_by(AuditLog.id.desc())
                 .first()
             )
-            entry.created_at = datetime.utcnow() - timedelta(minutes=31)
+            entry.created_at = utc_now_naive() - timedelta(minutes=31)
             db.session.commit()
 
             undo = reverse_cascade(comp.id, judge_user_id=1, tournament=t)
@@ -786,11 +789,11 @@ class TestExecuteReverseRoundTrip:
             reverse_cascade(comp.id, judge_user_id=1, tournament=t)
             db.session.commit()
 
-            final_comp = ProCompetitor.query.get(comp.id)
+            final_comp = db.session.get(ProCompetitor, comp.id)
             assert final_comp.status == original_comp_status
 
-            final_r1 = EventResult.query.get(r1_id)
-            final_r2 = EventResult.query.get(r2_id)
+            final_r1 = db.session.get(EventResult, r1_id)
+            final_r2 = db.session.get(EventResult, r2_id)
             assert final_r1.status == original_r1_status
             assert final_r2.status == original_r2_status
 

--- a/tests/test_scratch_routes.py
+++ b/tests/test_scratch_routes.py
@@ -19,6 +19,8 @@ import tempfile
 
 import pytest
 
+from database import db
+
 os.environ.setdefault("SECRET_KEY", "test-scratch-routes")
 os.environ.setdefault("WTF_CSRF_ENABLED", "False")
 # NOTE: `TEST_USE_CREATE_ALL` is set inside the `app` fixture, NOT at module
@@ -301,10 +303,10 @@ class TestScratchConfirmPost:
             assert resp.status_code in (302, 303)
 
             # Verify DB state
-            comp_reloaded = ProCompetitor.query.get(comp_id)
+            comp_reloaded = db.session.get(ProCompetitor, comp_id)
             assert comp_reloaded.status == "scratched"
 
-            result_reloaded = EventResult.query.get(result_id)
+            result_reloaded = db.session.get(EventResult, result_id)
             assert result_reloaded.status == "scratched"
 
     def test_happy_path_partial_effects_only_checked_execute(self, app):
@@ -346,11 +348,11 @@ class TestScratchConfirmPost:
             assert resp.status_code in (302, 303)
 
             # Competitor should still be scratched (status is always set)
-            comp_reloaded = ProCompetitor.query.get(comp_id)
+            comp_reloaded = db.session.get(ProCompetitor, comp_id)
             assert comp_reloaded.status == "scratched"
 
             # EventResult should NOT be scratched (effect was unchecked)
-            result_reloaded = EventResult.query.get(result_id)
+            result_reloaded = db.session.get(EventResult, result_id)
             assert result_reloaded.status == "pending"
 
     def test_no_effects_checked_flashes_no_changes(self, app):
@@ -455,7 +457,7 @@ class TestScratchUndoPost:
             )
             assert undo_resp.status_code in (302, 303)
 
-            comp_reloaded = ProCompetitor.query.get(comp_id)
+            comp_reloaded = db.session.get(ProCompetitor, comp_id)
             assert comp_reloaded.status == "active"
 
     def test_undo_after_window_flashes_expired(self, app):

--- a/tests/test_settlement.py
+++ b/tests/test_settlement.py
@@ -14,6 +14,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # ---------------------------------------------------------------------------
@@ -168,7 +169,7 @@ class TestToggleSettlementHappyPath:
         with app.app_context():
             from models.event import EventResult
 
-            fresh = EventResult.query.get(result.id)
+            fresh = db.session.get(EventResult, result.id)
             assert fresh.payout_settled is True
 
     def test_toggle_settled_to_unsettled(self, app, auth_client, db_session):
@@ -193,7 +194,7 @@ class TestToggleSettlementHappyPath:
         with app.app_context():
             from models.event import EventResult
 
-            fresh = EventResult.query.get(result.id)
+            fresh = db.session.get(EventResult, result.id)
             assert fresh.payout_settled is False
 
 

--- a/tests/test_split_tie_scoring.py
+++ b/tests/test_split_tie_scoring.py
@@ -23,6 +23,7 @@ from decimal import Decimal
 
 import pytest
 
+from database import db
 from database import db as _db
 
 # ---------------------------------------------------------------------------
@@ -214,9 +215,9 @@ class TestCalculatePositionsSplitTie:
 
         # individual_points reflects the SUM rebuild
         from models.competitor import CollegeCompetitor
-        c1_loaded = CollegeCompetitor.query.get(c1.id)
-        c2_loaded = CollegeCompetitor.query.get(c2.id)
-        c3_loaded = CollegeCompetitor.query.get(c3.id)
+        c1_loaded = db.session.get(CollegeCompetitor, c1.id)
+        c2_loaded = db.session.get(CollegeCompetitor, c2.id)
+        c3_loaded = db.session.get(CollegeCompetitor, c3.id)
         assert c1_loaded.individual_points == Decimal('8.50')
         assert c2_loaded.individual_points == Decimal('8.50')
         assert c3_loaded.individual_points == Decimal('5.00')
@@ -267,7 +268,7 @@ class TestCalculatePositionsSplitTie:
         calculate_positions(event)
         db_session.flush()
 
-        team_loaded = Team.query.get(team.id)
+        team_loaded = db.session.get(Team, team.id)
         # Two competitors tied for 1st: each gets 8.5, team gets 17.0
         assert team_loaded.total_points == Decimal('17.00')
 
@@ -293,14 +294,14 @@ class TestRebuildIdempotency:
 
         calculate_positions(event)
         db_session.flush()
-        c1_first = CollegeCompetitor.query.get(c1.id).individual_points
-        c2_first = CollegeCompetitor.query.get(c2.id).individual_points
+        c1_first = db.session.get(CollegeCompetitor, c1.id).individual_points
+        c2_first = db.session.get(CollegeCompetitor, c2.id).individual_points
 
         # Second run — should produce identical results.
         calculate_positions(event)
         db_session.flush()
-        c1_second = CollegeCompetitor.query.get(c1.id).individual_points
-        c2_second = CollegeCompetitor.query.get(c2.id).individual_points
+        c1_second = db.session.get(CollegeCompetitor, c1.id).individual_points
+        c2_second = db.session.get(CollegeCompetitor, c2.id).individual_points
 
         assert c1_second == c1_first
         assert c2_second == c2_first
@@ -344,15 +345,15 @@ class TestPartnerEventDualCredit:
         db_session.flush()
 
         # Both Pair A members get full 1st-place points (10 each).
-        assert CollegeCompetitor.query.get(mike.id).individual_points == Decimal('10.00')
-        assert CollegeCompetitor.query.get(mary.id).individual_points == Decimal('10.00')
+        assert db.session.get(CollegeCompetitor, mike.id).individual_points == Decimal('10.00')
+        assert db.session.get(CollegeCompetitor, mary.id).individual_points == Decimal('10.00')
         # Both Pair B members get full 2nd-place points (7 each).
-        assert CollegeCompetitor.query.get(bob.id).individual_points == Decimal('7.00')
-        assert CollegeCompetitor.query.get(beth.id).individual_points == Decimal('7.00')
+        assert db.session.get(CollegeCompetitor, bob.id).individual_points == Decimal('7.00')
+        assert db.session.get(CollegeCompetitor, beth.id).individual_points == Decimal('7.00')
 
         # The team total reflects ALL FOUR contributions: 10 + 10 + 7 + 7 = 34
         # (this is the AWFC "team gets points twice" rule from ProAM requirements).
-        assert Team.query.get(team.id).total_points == Decimal('34.00')
+        assert db.session.get(Team, team.id).total_points == Decimal('34.00')
 
     def test_partner_event_with_two_pairs_tied_for_first(self, db_session, tid):
         """Two pairs tie for 1st: all 4 competitors get the split value (8.5)."""
@@ -380,10 +381,10 @@ class TestPartnerEventDualCredit:
         db_session.flush()
 
         for c in (a1, a2, b1, b2):
-            assert CollegeCompetitor.query.get(c.id).individual_points == Decimal('8.50')
+            assert db.session.get(CollegeCompetitor, c.id).individual_points == Decimal('8.50')
 
         # Team total: 8.5 * 4 = 34.0
-        assert Team.query.get(team.id).total_points == Decimal('34.00')
+        assert db.session.get(Team, team.id).total_points == Decimal('34.00')
 
 
 # ===========================================================================
@@ -421,8 +422,8 @@ class TestRecordThrowoffResultRebuild:
         db_session.flush()
 
         # individual_points must equal each row's points_awarded after rebuild.
-        c1_loaded = CollegeCompetitor.query.get(c1.id)
-        c2_loaded = CollegeCompetitor.query.get(c2.id)
+        c1_loaded = db.session.get(CollegeCompetitor, c1.id)
+        c2_loaded = db.session.get(CollegeCompetitor, c2.id)
         assert c1_loaded.individual_points == r1.points_awarded
         assert c2_loaded.individual_points == r2.points_awarded
         assert c1_loaded.individual_points == Decimal('10.00')  # 1st place

--- a/tests/test_stock_saw_stand_rebalance.py
+++ b/tests/test_stock_saw_stand_rebalance.py
@@ -19,6 +19,7 @@ import os
 
 import pytest
 
+from database import db
 from database import db as _db
 
 
@@ -96,7 +97,7 @@ def _make_heat(
     from tests.conftest import ensure_competitors
 
     ensure_competitors(
-        db_session, Tournament.query.get(event.tournament_id),
+        db_session, db.session.get(Tournament, event.tournament_id),
         competitors, event.event_type,
     )
 

--- a/tests/test_team_override_persistence.py
+++ b/tests/test_team_override_persistence.py
@@ -19,6 +19,7 @@ import uuid
 
 import pytest
 
+from database import db
 from tests.conftest import make_college_competitor, make_team, make_tournament
 
 
@@ -127,7 +128,7 @@ class TestOverrideTeamValidationRoute:
         db_session.expire_all()
         from models.team import Team
 
-        team = Team.query.get(team.id)
+        team = db.session.get(Team, team.id)
         assert team.is_override is True
         assert team.status == "active"
         assert len(team.get_validation_errors()) > 0, "errors preserved for display"
@@ -151,7 +152,7 @@ class TestOverrideTeamValidationRoute:
         db_session.expire_all()
         from models.team import Team
 
-        team = Team.query.get(team.id)
+        team = db.session.get(Team, team.id)
         assert team.is_override is True, "revalidate must not clear override"
         assert team.status == "active", "overridden team stays active after revalidate"
 
@@ -170,7 +171,7 @@ class TestOverrideTeamValidationRoute:
         db_session.expire_all()
         from models.team import Team
 
-        team = Team.query.get(team.id)
+        team = db.session.get(Team, team.id)
         assert team.is_override is False
         assert (
             team.status == "invalid"
@@ -192,7 +193,7 @@ class TestOverrideTeamValidationRoute:
         db_session.expire_all()
         from models.team import Team
 
-        team = Team.query.get(team.id)
+        team = db.session.get(Team, team.id)
         assert team.is_override is False
         assert team.status == "invalid", "nothing should change"
 

--- a/tests/test_tournament_lifecycle_portals.py
+++ b/tests/test_tournament_lifecycle_portals.py
@@ -21,6 +21,8 @@ import os
 
 import pytest
 
+from database import db
+
 os.environ.setdefault('SECRET_KEY', 'test-secret-lifecycle')
 os.environ.setdefault('WTF_CSRF_ENABLED', 'False')
 
@@ -148,7 +150,7 @@ def _ok(r):
 def _set_status(app, tid, status):
     with app.app_context():
         from models import Tournament
-        t = Tournament.query.get(tid)
+        t = db.session.get(Tournament, tid)
         t.status = status
         _db.session.commit()
 

--- a/tests/test_transaction_composability.py
+++ b/tests/test_transaction_composability.py
@@ -21,6 +21,7 @@ import json
 
 import pytest
 
+from database import db
 from database import db as _db
 from tests.conftest import make_event, make_tournament
 


### PR DESCRIPTION
## Summary

- harden relay decoding, UTC timestamp handling, background jobs, and heat regeneration
- isolate workflow and report-cache tests from production and cross-test state
- restore covered CI checks and modernize SQLAlchemy primary-key lookups
- update openpyxl and make deprecations and unexpected xpasses fail the suite
- preserve and strengthen Birling migration compatibility on SQLite and Python 3.12+

## Why

The application had accumulated race-day reliability risks across runtime timestamp handling, stale SQLAlchemy APIs, heat regeneration session state, test database isolation, and warning suppression. These changes remove those known failure modes and turn the compatibility issues into enforced test failures.

## Validation

- isolated local suite: 3,818 passed, 11 skipped
- GitHub Actions on this exact head: test, PostgreSQL smoke, PostgreSQL unit suite, lint, migration safety, and dependency audit all passed
- repository-wide Ruff checks passed
- focused heat regeneration coverage promotes SQLAlchemy warnings to errors
- PR review found no actionable release blocker

## Deployment Notes

- no production database, Railway configuration, variables, or schema migration operation was performed during validation
- merging to `main` triggers the existing Railway deployment

## Post-Deploy Monitoring & Validation

- Owner: Alex or the operator on duty, for 30 minutes after the Railway deploy completes.
- Healthy signals: successful Railway deploy and GitHub Production Health Monitor; no new application errors; normal page and API response behavior.
- Watch logs for: `Traceback`, `ProjectionRefused`, `SAWarning`, `LegacyAPIWarning`, `Heat generation failed`, and relay decoding errors.
- Rollback trigger: any repeated 5xx response, deployment failure, or new scheduling/relay runtime error. Mitigation: revert this merge commit, then investigate from the captured log event.
