### PR TITLE
fix(rig): honor configured python in bootstrap guidance

### DIFF
--- a/scripts/rig_bootstrap.sh
+++ b/scripts/rig_bootstrap.sh
@@ -88,4 +88,4 @@ fi
 
 say "done. run the suite:"
 echo "  PROAM_APP_ROOT=$REPO PROAM_RIG_TEMPLATE=proam_prod_mirror_p0 \\"
-echo "  SECRET_KEY=\$(python3 -c 'print(\"x\"*64)') $PY -m pytest proam_regression -p no:randomly -q"
+echo "  SECRET_KEY=\$(\"$PY\" -c 'print(\"x\"*64)') $PY -m pytest proam_regression -p no:randomly -q"

--- a/tests/test_rig_bootstrap.py
+++ b/tests/test_rig_bootstrap.py
@@ -1,0 +1,16 @@
+"""Regression checks for the parity-rig bootstrap script.
+
+These checks inspect the operator guidance only. They never invoke the script,
+which would create local PostgreSQL mirrors from a private dump.
+"""
+
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "rig_bootstrap.sh"
+
+
+def test_printed_regression_command_uses_configured_python():
+    script = _SCRIPT.read_text(encoding="utf-8")
+
+    assert 'SECRET_KEY=\\$(\\"$PY\\" -c' in script
+    assert 'SECRET_KEY=\\$(python3 -c' not in script


### PR DESCRIPTION
## Summary
- make the printed parity-rig command use RIG_PYTHON consistently
- add a static regression check that never executes the private-dump bootstrap

## Why
The script accepts a configured interpreter for its own steps but its printed test command still hardcoded python3. That breaks the handoff on hosts that use a different interpreter path.

## Validation
- focused bootstrap regression passed
- shell syntax check passed without executing the bootstrap
- full isolated suite passed
- Ruff passed

## Post-Deploy Monitoring & Validation
No additional operational monitoring is required: this corrects developer-facing bootstrap guidance and adds a source-inspection regression test. It does not change runtime code, configuration, migrations, or deployment behavior.