### PR TITLE
feat(relay): normalize team state with identity-safe rows

### DIFF
--- a/migrations/versions/v1a2b3c4d5e6_relay_tables.py
+++ b/migrations/versions/v1a2b3c4d5e6_relay_tables.py
@@ -1,0 +1,327 @@
+"""Project Pro-Am Relay state into normalized tables (D13-C, commit B1).
+
+Revision ID: v1a2b3c4d5e6
+Revises: u0c4d5e6f7a8
+Create Date: 2026-08-11
+
+Relay state has lived in ``events.event_state`` as a single JSON document. It
+holds the draw status, teams, roster snapshots, four team-level leg results,
+and aggregate times. This revision creates a validated row projection while
+leaving that document untouched and still authoritative. Later commits can
+dual-write and then switch readers only after their parity checks are proven.
+
+Team memberships reference ``competitors.uid``. Relay legs deliberately do
+not: a team decides who performs each leg, and relay results must not become
+individual EventResult rows or college-score inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import sqlalchemy as sa
+from alembic import op
+
+from models._types import BIG_ID
+
+
+revision = "v1a2b3c4d5e6"
+down_revision = "u0c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+RELAY_EVENT_KEYS = (
+    "partnered_sawing",
+    "standing_butcher_block",
+    "underhand_butcher_block",
+    "team_axe_throw",
+)
+TABLES = ("relay_states", "relay_teams", "relay_team_members", "relay_team_events")
+_STATE_STATUSES = frozenset(("not_drawn", "drawn", "in_progress", "completed"))
+_TEAM_EVENT_STATUSES = frozenset(("pending", "completed"))
+_MEMBER_FIELDS = (("pro_members", "pro"), ("college_members", "college"))
+
+
+class _Plan:
+    """Validated rows for one legacy relay document, or refusal reasons."""
+
+    def __init__(self, event_id, tournament_id):
+        self.event_id = event_id
+        self.tournament_id = tournament_id
+        self.status = "not_drawn"
+        self.teams = []
+        self.reasons = set()
+
+    @property
+    def valid(self):
+        return not self.reasons
+
+    def reject(self, reason):
+        self.reasons.add(reason)
+
+
+def _integer(value):
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _number(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    value = float(value)
+    return value if math.isfinite(value) and value >= 0 else None
+
+
+def _competitor_pool(connection, tournament_id):
+    """Return legacy ``(kind, id)`` references mapped to identity uids."""
+    pool = {}
+    for kind, table in (("pro", "pro_competitors"), ("college", "college_competitors")):
+        rows = connection.execute(sa.text(
+            f"SELECT id, uid FROM {table} WHERE tournament_id = :tournament_id"),
+            {"tournament_id": tournament_id}).fetchall()
+        pool.update({(kind, row.id): row.uid for row in rows})
+    return pool
+
+
+def _plan(connection, event_id, tournament_id, raw):
+    plan = _Plan(event_id, tournament_id)
+    try:
+        document = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        plan.reject("relay state is not valid JSON")
+        return plan
+
+    if not isinstance(document, dict):
+        plan.reject("relay state is not an object")
+        return plan
+
+    status = document.get("status", "not_drawn")
+    if status not in _STATE_STATUSES:
+        plan.reject("relay state has an invalid status")
+    else:
+        plan.status = status
+
+    teams = document.get("teams", [])
+    if not isinstance(teams, list):
+        plan.reject("relay state has a non-list team collection")
+        return plan
+
+    pool = _competitor_pool(connection, tournament_id)
+    team_numbers = set()
+    used_uids = set()
+    for raw_team in teams:
+        if not isinstance(raw_team, dict):
+            plan.reject("relay state contains a non-object team")
+            continue
+
+        team_number = _integer(raw_team.get("team_number"))
+        if team_number is None or team_number < 1 or team_number in team_numbers:
+            plan.reject("relay state has a missing or duplicate team number")
+            continue
+        team_numbers.add(team_number)
+
+        name = raw_team.get("name")
+        if not isinstance(name, str) or not name:
+            plan.reject("relay state has a team without a name")
+            continue
+
+        total_raw = raw_team.get("total_time")
+        total_time = None if total_raw is None else _number(total_raw)
+        if total_raw is not None and total_time is None:
+            plan.reject("relay state has an invalid total time")
+            continue
+
+        members = []
+        for field, kind in _MEMBER_FIELDS:
+            raw_members = raw_team.get(field, [])
+            if not isinstance(raw_members, list):
+                plan.reject("relay state has a non-list roster")
+                continue
+            for raw_member in raw_members:
+                member_id = _integer(raw_member.get("id")) if isinstance(raw_member, dict) else None
+                uid = pool.get((kind, member_id))
+                if uid is None:
+                    plan.reject("a relay member reference names nobody in its tournament pool")
+                    continue
+                if uid in used_uids:
+                    plan.reject("a relay member is assigned to more than one team")
+                    continue
+                used_uids.add(uid)
+                members.append(uid)
+
+        raw_events = raw_team.get("events")
+        if not isinstance(raw_events, dict) or set(raw_events) != set(RELAY_EVENT_KEYS):
+            plan.reject("relay state does not contain exactly the four relay events")
+            continue
+
+        events = []
+        for event_key in RELAY_EVENT_KEYS:
+            raw_event = raw_events[event_key]
+            if not isinstance(raw_event, dict):
+                plan.reject("relay state contains a non-object team event")
+                continue
+            event_status = raw_event.get("status", "pending")
+            result_raw = raw_event.get("result")
+            result = None if result_raw is None else _number(result_raw)
+            if event_status not in _TEAM_EVENT_STATUSES:
+                plan.reject("relay state has an invalid team event status")
+            elif result_raw is not None and result is None:
+                plan.reject("relay state has an invalid team event result")
+            elif event_status == "completed" and result is None:
+                plan.reject("relay state marks a team event complete without a result")
+            else:
+                events.append({"event_key": event_key, "result": result, "status": event_status})
+
+        plan.teams.append({
+            "team_number": team_number,
+            "name": name,
+            "total_time": total_time,
+            "members": members,
+            "events": events,
+        })
+    return plan
+
+
+def _tables(connection):
+    metadata = sa.MetaData()
+    return {
+        name: sa.Table(name, metadata, autoload_with=connection)
+        for name in TABLES
+    }
+
+
+def _write(connection, plan):
+    tables = _tables(connection)
+    state_id = connection.execute(tables["relay_states"].insert().values(
+        event_id=plan.event_id,
+        status=plan.status,
+    )).inserted_primary_key[0]
+
+    for team in plan.teams:
+        team_id = connection.execute(tables["relay_teams"].insert().values(
+            relay_state_id=state_id,
+            team_number=team["team_number"],
+            name=team["name"],
+            total_time=team["total_time"],
+            payout_settled=False,
+        )).inserted_primary_key[0]
+        for uid in team["members"]:
+            connection.execute(tables["relay_team_members"].insert().values(
+                relay_state_id=state_id,
+                relay_team_id=team_id,
+                uid=uid,
+            ))
+        for event in team["events"]:
+            connection.execute(tables["relay_team_events"].insert().values(
+                relay_team_id=team_id,
+                event_key=event["event_key"],
+                result=event["result"],
+                status=event["status"],
+            ))
+
+
+def _backfill(connection):
+    """Project resolvable relay state; refuse a whole event rather than part of it."""
+    rows = connection.execute(sa.text(
+        "SELECT id, tournament_id, event_state FROM events "
+        "WHERE name = 'Pro-Am Relay' AND event_state IS NOT NULL")).fetchall()
+    loaded = 0
+    skipped = 0
+    reasons = set()
+    for row in rows:
+        already_loaded = connection.execute(sa.text(
+            "SELECT 1 FROM relay_states WHERE event_id = :event_id"),
+            {"event_id": row.id}).scalar()
+        if already_loaded:
+            continue
+        plan = _plan(connection, row.id, row.tournament_id, row.event_state)
+        if not plan.valid:
+            skipped += 1
+            reasons |= plan.reasons
+            continue
+        _write(connection, plan)
+        loaded += 1
+
+    if skipped:
+        print(
+            f"v1a2b3c4d5e6: loaded {loaded} relay state projection(s); "
+            f"left {skipped} legacy document(s) untouched. reasons: "
+            f"{'; '.join(sorted(reasons))}"
+        )
+    elif loaded:
+        print(f"v1a2b3c4d5e6: loaded {loaded} relay state projection(s).")
+
+
+def upgrade():
+    op.create_table(
+        "relay_states",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("event_id", name="uq_relay_states_event"),
+        sa.CheckConstraint(
+            "status IN ('not_drawn', 'drawn', 'in_progress', 'completed')",
+            name="ck_relay_states_status_valid",
+        ),
+    )
+    op.create_table(
+        "relay_teams",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("relay_state_id", sa.Integer(), nullable=False),
+        sa.Column("team_number", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("total_time", sa.Float(), nullable=True),
+        sa.Column("payout_settled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.ForeignKeyConstraint(["relay_state_id"], ["relay_states.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("relay_state_id", "team_number", name="uq_relay_teams_state_number"),
+        sa.UniqueConstraint("relay_state_id", "id", name="uq_relay_teams_state_id"),
+        sa.CheckConstraint("team_number >= 1", name="ck_relay_teams_number_positive"),
+        sa.CheckConstraint(
+            "total_time IS NULL OR total_time >= 0", name="ck_relay_teams_time_nonnegative"
+        ),
+    )
+    op.create_table(
+        "relay_team_members",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("relay_state_id", sa.Integer(), nullable=False),
+        sa.Column("relay_team_id", sa.Integer(), nullable=False),
+        sa.Column("uid", BIG_ID, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["relay_state_id", "relay_team_id"],
+            ["relay_teams.relay_state_id", "relay_teams.id"],
+        ),
+        sa.ForeignKeyConstraint(["uid"], ["competitors.uid"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("relay_state_id", "uid", name="uq_relay_members_state_uid"),
+    )
+    op.create_table(
+        "relay_team_events",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("relay_team_id", sa.Integer(), nullable=False),
+        sa.Column("event_key", sa.String(length=40), nullable=False),
+        sa.Column("result", sa.Float(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.ForeignKeyConstraint(["relay_team_id"], ["relay_teams.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("relay_team_id", "event_key", name="uq_relay_team_events_key"),
+        sa.CheckConstraint(
+            "event_key IN ('partnered_sawing', 'standing_butcher_block', "
+            "'underhand_butcher_block', 'team_axe_throw')",
+            name="ck_relay_team_events_key_valid",
+        ),
+        sa.CheckConstraint("status IN ('pending', 'completed')", name="ck_relay_team_events_status_valid"),
+        sa.CheckConstraint(
+            "result IS NULL OR result >= 0", name="ck_relay_team_events_result_nonnegative"
+        ),
+    )
+    _backfill(op.get_bind())
+
+
+def downgrade():
+    op.drop_table("relay_team_events")
+    op.drop_table("relay_team_members")
+    op.drop_table("relay_teams")
+    op.drop_table("relay_states")

--- a/migrations/versions/v1a2b3c4d5e6_relay_tables.py
+++ b/migrations/versions/v1a2b3c4d5e6_relay_tables.py
@@ -293,7 +293,7 @@ def upgrade():
             ["relay_state_id", "relay_team_id"],
             ["relay_teams.relay_state_id", "relay_teams.id"],
         ),
-        sa.ForeignKeyConstraint(["uid"], ["competitors.uid"]),
+        sa.ForeignKeyConstraint(["uid"], ["competitors.uid"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("relay_state_id", "uid", name="uq_relay_members_state_uid"),
     )

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -18,6 +18,7 @@ from .payout_template import PayoutTemplate
 from .print_email_log import PrintEmailLog
 from .print_tracker import PrintTracker
 from .pro_event_rank import ProEventRank
+from .relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
 from .school_captain import SchoolCaptain
 from .team import Team
 from .tournament import Tournament
@@ -44,6 +45,10 @@ __all__ = [
     'PayoutTemplate',
     'PrintTracker',
     'PrintEmailLog',
+    'RelayState',
+    'RelayTeam',
+    'RelayTeamMember',
+    'RelayTeamEvent',
     'Competitor',
     'TournamentEvent',
     'BirlingSeed',

--- a/models/relay.py
+++ b/models/relay.py
@@ -89,7 +89,7 @@ class RelayTeamMember(db.Model):
             ["relay_state_id", "relay_team_id"],
             ["relay_teams.relay_state_id", "relay_teams.id"],
         ),
-        db.ForeignKeyConstraint(["uid"], ["competitors.uid"]),
+        db.ForeignKeyConstraint(["uid"], ["competitors.uid"], ondelete="CASCADE"),
         db.UniqueConstraint("relay_state_id", "uid", name="uq_relay_members_state_uid"),
     )
 

--- a/models/relay.py
+++ b/models/relay.py
@@ -1,0 +1,129 @@
+"""Normalized Pro-Am Relay state.
+
+The relay is scored by team. Team members carry a competitor identity so the
+roster cannot silently point to the wrong college or pro record, but a relay
+leg deliberately has no competitor reference: teams arrange their own legs.
+"""
+
+import sqlalchemy as sa
+
+from database import db
+
+from ._types import BIG_ID
+
+RELAY_EVENT_KEYS = (
+    "partnered_sawing",
+    "standing_butcher_block",
+    "underhand_butcher_block",
+    "team_axe_throw",
+)
+
+
+class RelayState(db.Model):
+    """One relay draw and result set for one Pro-Am Relay event."""
+
+    __tablename__ = "relay_states"
+    __table_args__ = (
+        db.UniqueConstraint("event_id", name="uq_relay_states_event"),
+        db.CheckConstraint(
+            "status IN ('not_drawn', 'drawn', 'in_progress', 'completed')",
+            name="ck_relay_states_status_valid",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    event_id = db.Column(db.Integer, db.ForeignKey("events.id"), nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="not_drawn")
+
+    teams = db.relationship(
+        "RelayTeam",
+        back_populates="relay_state",
+        cascade="all, delete-orphan",
+        order_by="RelayTeam.team_number",
+    )
+
+
+class RelayTeam(db.Model):
+    """One eight-person relay team, its aggregate time, and payout state."""
+
+    __tablename__ = "relay_teams"
+    __table_args__ = (
+        db.UniqueConstraint("relay_state_id", "team_number", name="uq_relay_teams_state_number"),
+        db.UniqueConstraint("relay_state_id", "id", name="uq_relay_teams_state_id"),
+        db.CheckConstraint("team_number >= 1", name="ck_relay_teams_number_positive"),
+        db.CheckConstraint(
+            "total_time IS NULL OR total_time >= 0", name="ck_relay_teams_time_nonnegative"
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    relay_state_id = db.Column(db.Integer, db.ForeignKey("relay_states.id"), nullable=False)
+    team_number = db.Column(db.Integer, nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    total_time = db.Column(db.Float, nullable=True)
+    payout_settled = db.Column(
+        db.Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
+
+    relay_state = db.relationship("RelayState", back_populates="teams")
+    members = db.relationship(
+        "RelayTeamMember",
+        back_populates="relay_team",
+        cascade="all, delete-orphan",
+        order_by="RelayTeamMember.id",
+    )
+    events = db.relationship(
+        "RelayTeamEvent",
+        back_populates="relay_team",
+        cascade="all, delete-orphan",
+        order_by="RelayTeamEvent.event_key",
+    )
+
+
+class RelayTeamMember(db.Model):
+    """A roster assignment, unique across a relay draw."""
+
+    __tablename__ = "relay_team_members"
+    __table_args__ = (
+        db.ForeignKeyConstraint(
+            ["relay_state_id", "relay_team_id"],
+            ["relay_teams.relay_state_id", "relay_teams.id"],
+        ),
+        db.ForeignKeyConstraint(["uid"], ["competitors.uid"]),
+        db.UniqueConstraint("relay_state_id", "uid", name="uq_relay_members_state_uid"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    relay_state_id = db.Column(db.Integer, nullable=False)
+    relay_team_id = db.Column(db.Integer, nullable=False)
+    uid = db.Column(BIG_ID, nullable=False)
+
+    relay_team = db.relationship("RelayTeam", back_populates="members")
+
+
+class RelayTeamEvent(db.Model):
+    """A team-level relay leg result, intentionally without a competitor uid."""
+
+    __tablename__ = "relay_team_events"
+    __table_args__ = (
+        db.UniqueConstraint("relay_team_id", "event_key", name="uq_relay_team_events_key"),
+        db.CheckConstraint(
+            "event_key IN ('partnered_sawing', 'standing_butcher_block', "
+            "'underhand_butcher_block', 'team_axe_throw')",
+            name="ck_relay_team_events_key_valid",
+        ),
+        db.CheckConstraint(
+            "status IN ('pending', 'completed')", name="ck_relay_team_events_status_valid"
+        ),
+        db.CheckConstraint(
+            "result IS NULL OR result >= 0", name="ck_relay_team_events_result_nonnegative"
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    relay_team_id = db.Column(db.Integer, db.ForeignKey("relay_teams.id"), nullable=False)
+    event_key = db.Column(db.String(40), nullable=False)
+    result = db.Column(db.Float, nullable=True)
+    status = db.Column(db.String(20), nullable=False, default="pending")
+
+    relay_team = db.relationship("RelayTeam", back_populates="events")

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -15,6 +15,7 @@ import random
 from database import db
 from models import Event, EventResult, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
+from models.relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
 
 
 class ProAmRelay:
@@ -87,9 +88,97 @@ class ProAmRelay:
             )
             db.session.add(relay_event)
 
+        member_uids = self._relay_member_uids()
         relay_event.event_state = json.dumps(self.relay_data)
+        db.session.flush()
+        self._sync_relay_tables(relay_event, member_uids)
         if commit:
             db.session.commit()
+        else:
+            db.session.flush()
+
+    def _relay_member_uids(self) -> dict[str, dict[int, int]]:
+        """Resolve legacy member ids to identity uids before mutating either store."""
+        member_ids = {"pro": set(), "college": set()}
+        for team in self.relay_data.get("teams", []):
+            for member in team.get("pro_members", []):
+                member_ids["pro"].add(member.get("id"))
+            for member in team.get("college_members", []):
+                member_ids["college"].add(member.get("id"))
+
+        resolved = {"pro": {}, "college": {}}
+        for kind, model in (("pro", ProCompetitor), ("college", CollegeCompetitor)):
+            ids = {member_id for member_id in member_ids[kind] if isinstance(member_id, int)}
+            if not ids:
+                continue
+            rows = model.query.filter(
+                model.id.in_(ids), model.tournament_id == self.tournament.id
+            ).all()
+            resolved[kind] = {row.id: row.uid for row in rows}
+            missing = ids - set(resolved[kind])
+            if missing:
+                raise ValueError("Relay roster contains a competitor outside this tournament")
+        return resolved
+
+    def _sync_relay_tables(self, relay_event: Event, member_uids: dict[str, dict[int, int]]):
+        """Replace the row projection in the same transaction as legacy state.
+
+        Membership records carry durable competitor identities. A team-event
+        record deliberately carries only the team, event key, result, and
+        completion state: teams choose their own relay legs and those results
+        never enter individual or college scoring.
+        """
+        state = RelayState.query.filter_by(event_id=relay_event.id).first()
+        if state is None:
+            state = RelayState(event_id=relay_event.id)
+            db.session.add(state)
+            db.session.flush()
+
+        state.status = self.relay_data.get("status", "not_drawn")
+        team_ids = [row.id for row in RelayTeam.query.filter_by(relay_state_id=state.id).all()]
+        if team_ids:
+            RelayTeamEvent.query.filter(RelayTeamEvent.relay_team_id.in_(team_ids)).delete(
+                synchronize_session=False
+            )
+            RelayTeamMember.query.filter(RelayTeamMember.relay_team_id.in_(team_ids)).delete(
+                synchronize_session=False
+            )
+            RelayTeam.query.filter(RelayTeam.id.in_(team_ids)).delete(synchronize_session=False)
+            db.session.flush()
+
+        seen_uids = set()
+        for team_data in self.relay_data.get("teams", []):
+            team = RelayTeam(
+                relay_state_id=state.id,
+                team_number=team_data["team_number"],
+                name=team_data["name"],
+                total_time=team_data.get("total_time"),
+            )
+            db.session.add(team)
+            db.session.flush()
+
+            for key, kind in (("pro_members", "pro"), ("college_members", "college")):
+                for member in team_data.get(key, []):
+                    uid = member_uids[kind].get(member.get("id"))
+                    if uid is None:
+                        raise ValueError("Relay roster contains an unresolved competitor")
+                    if uid in seen_uids:
+                        raise ValueError("A relay competitor cannot appear on multiple teams")
+                    seen_uids.add(uid)
+                    db.session.add(RelayTeamMember(
+                        relay_state_id=state.id,
+                        relay_team_id=team.id,
+                        uid=uid,
+                    ))
+
+            for event_key in self.RELAY_EVENTS:
+                event_data = team_data["events"][event_key]
+                db.session.add(RelayTeamEvent(
+                    relay_team_id=team.id,
+                    event_key=event_key,
+                    result=event_data.get("result"),
+                    status=event_data.get("status", "pending"),
+                ))
 
     def get_eligible_pro_competitors(self) -> list:
         """Get pro competitors who opted into the lottery."""
@@ -523,6 +612,15 @@ class ProAmRelay:
                             raise ValueError("Replacement pro competitor must be opted into Pro-Am lottery")
                         if competitor_type == 'college' and not new_comp.pro_am_lottery_opt_in:
                             raise ValueError("Replacement college competitor must be opted into Pro-Am lottery")
+                        for existing_team in teams:
+                            for existing_member in existing_team.get(member_key, []):
+                                if (
+                                    existing_member.get('id') == new_competitor_id
+                                    and existing_member is not member
+                                ):
+                                    raise ValueError(
+                                        "Replacement competitor is already assigned to a relay team"
+                                    )
                         team[member_key][i] = new_comp_data
                         affected_team = team
                         break

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -88,14 +88,37 @@ class ProAmRelay:
             )
             db.session.add(relay_event)
 
-        member_uids = self._relay_member_uids()
+        member_uids = self._relay_member_uids() if self._has_projectable_teams() else None
         relay_event.event_state = json.dumps(self.relay_data)
         db.session.flush()
-        self._sync_relay_tables(relay_event, member_uids)
+        if member_uids is not None:
+            self._sync_relay_tables(relay_event, member_uids)
         if commit:
             db.session.commit()
         else:
             db.session.flush()
+
+    def _has_projectable_teams(self) -> bool:
+        """Return whether current state has the complete team shape for row sync.
+
+        The service's transaction API also supports saving a deliberately
+        minimal state document before a draw exists. It remains valid legacy
+        state, but it is not a roster that normalized tables can represent.
+        """
+        teams = self.relay_data.get("teams", [])
+        if not isinstance(teams, list):
+            return False
+        for team in teams:
+            if not isinstance(team, dict) or not isinstance(team.get("name"), str):
+                return False
+            if not isinstance(team.get("pro_members"), list):
+                return False
+            if not isinstance(team.get("college_members"), list):
+                return False
+            events = team.get("events")
+            if not isinstance(events, dict) or set(events) != set(self.RELAY_EVENTS):
+                return False
+        return True
 
     def _relay_member_uids(self) -> dict[str, dict[int, int]]:
         """Resolve legacy member ids to identity uids before mutating either store."""

--- a/tests/test_relay_table_sync.py
+++ b/tests/test_relay_table_sync.py
@@ -1,0 +1,67 @@
+"""Service-level parity checks for the normalized relay projection."""
+
+import pytest
+import sqlalchemy as sa
+
+from services.proam_relay import ProAmRelay
+from tests.conftest import make_college_competitor, make_pro_competitor, make_team, make_tournament
+
+
+def test_manual_teams_dual_write_to_normalized_relay_tables(db_session):
+    tournament = make_tournament(db_session)
+    school = make_team(db_session, tournament)
+    pro = make_pro_competitor(db_session, tournament, "Pro One", gender="M")
+    college = make_college_competitor(
+        db_session, tournament, school, "College One", gender="F"
+    )
+    pro.pro_am_lottery_opt_in = True
+    college.pro_am_lottery_opt_in = True
+    db_session.flush()
+
+    relay = ProAmRelay(tournament)
+    relay.set_teams_manually([{
+        "pro_member_ids": [pro.id],
+        "college_member_ids": [college.id],
+    }])
+
+    state = db_session.execute(sa.text(
+        "SELECT id, status FROM relay_states")).one()
+    assert state.status == "drawn"
+    assert db_session.execute(sa.text(
+        "SELECT uid FROM relay_team_members WHERE relay_state_id = :state_id "
+        "ORDER BY uid"), {"state_id": state.id}).scalars().all() == sorted([
+            pro.uid, college.uid,
+        ])
+    assert db_session.execute(sa.text(
+        "SELECT count(*) FROM relay_team_events")).scalar() == 4
+
+    relay.record_event_result(1, "partnered_sawing", 20.5)
+    assert db_session.execute(sa.text(
+        "SELECT result, status FROM relay_team_events "
+        "WHERE event_key = 'partnered_sawing'"
+    )).one() == (20.5, "completed")
+
+
+def test_replacement_rejects_competitor_already_on_another_relay_team(db_session):
+    tournament = make_tournament(db_session)
+    school = make_team(db_session, tournament)
+    pros = [
+        make_pro_competitor(db_session, tournament, f"Pro {number}", gender="M")
+        for number in (1, 2)
+    ]
+    colleges = [
+        make_college_competitor(db_session, tournament, school, f"College {number}", gender="F")
+        for number in (1, 2)
+    ]
+    for competitor in pros + colleges:
+        competitor.pro_am_lottery_opt_in = True
+    db_session.flush()
+
+    relay = ProAmRelay(tournament)
+    relay.set_teams_manually([
+        {"pro_member_ids": [pros[0].id], "college_member_ids": [colleges[0].id]},
+        {"pro_member_ids": [pros[1].id], "college_member_ids": [colleges[1].id]},
+    ])
+
+    with pytest.raises(ValueError, match="already assigned"):
+        relay.replace_competitor(1, pros[0].id, pros[1].id, "pro")

--- a/tests/test_relay_tables_migration.py
+++ b/tests/test_relay_tables_migration.py
@@ -94,9 +94,8 @@ class TestRelayTableMigration:
             "ORDER BY event_key")).fetchall()
         assert len(leg) == 4
         assert {row[0] for row in leg} == set(mig.RELAY_EVENT_KEYS)
-        columns = db_session.connection().execute(sa.text(
-            "PRAGMA table_info('relay_team_events')")).fetchall()
-        assert "uid" not in {column[1] for column in columns}
+        columns = sa.inspect(db_session.connection()).get_columns("relay_team_events")
+        assert "uid" not in {column["name"] for column in columns}
 
     def test_unresolvable_member_leaves_every_table_empty(self, db_session):
         relay_event, pro, college = _world(db_session)

--- a/tests/test_relay_tables_migration.py
+++ b/tests/test_relay_tables_migration.py
@@ -1,0 +1,112 @@
+"""Tests for the first no-data-loss Pro-Am Relay table migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+import sqlalchemy as sa
+
+from tests.conftest import (
+    make_college_competitor,
+    make_event,
+    make_pro_competitor,
+    make_team,
+    make_tournament,
+)
+
+_MIGRATION = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "versions"
+    / "v1a2b3c4d5e6_relay_tables.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("mig_v1a2b3c4d5e6", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mig = _load()
+
+
+def _relay_document(pro, college):
+    return {
+        "status": "drawn",
+        "teams": [{
+            "team_number": 1,
+            "name": "Team 1",
+            "pro_members": [{"id": pro.id, "name": pro.name, "gender": "M"}],
+            "college_members": [{"id": college.id, "name": college.name, "gender": "F"}],
+            "events": {
+                "partnered_sawing": {"result": 20.0, "status": "completed"},
+                "standing_butcher_block": {"result": None, "status": "pending"},
+                "underhand_butcher_block": {"result": None, "status": "pending"},
+                "team_axe_throw": {"result": None, "status": "pending"},
+            },
+            "total_time": None,
+        }],
+    }
+
+
+def _world(session):
+    tournament = make_tournament(session)
+    school = make_team(session, tournament)
+    pro = make_pro_competitor(session, tournament, "Pro One", gender="M")
+    college = make_college_competitor(session, tournament, school, "College One", gender="F")
+    session.flush()
+    relay_event = make_event(
+        session,
+        tournament,
+        "Pro-Am Relay",
+        event_type="pro",
+        scoring_type="time",
+    )
+    relay_event.event_state = json.dumps(_relay_document(pro, college))
+    session.flush()
+    return relay_event, pro, college
+
+
+@pytest.mark.usefixtures("reference_gate_disarmed")
+class TestRelayTableMigration:
+    def test_resolvable_legacy_state_projects_to_team_rows(self, db_session):
+        relay_event, pro, college = _world(db_session)
+
+        mig._backfill(db_session.connection())
+
+        state = db_session.connection().execute(sa.text(
+            "SELECT id, status FROM relay_states WHERE event_id = :event_id"),
+            {"event_id": relay_event.id}).one()
+        assert state.status == "drawn"
+
+        members = db_session.connection().execute(sa.text(
+            "SELECT uid FROM relay_team_members WHERE relay_state_id = :state_id "
+            "ORDER BY uid"), {"state_id": state.id}).scalars().all()
+        assert members == sorted([pro.uid, college.uid])
+
+        leg = db_session.connection().execute(sa.text(
+            "SELECT event_key, result, status FROM relay_team_events "
+            "ORDER BY event_key")).fetchall()
+        assert len(leg) == 4
+        assert {row[0] for row in leg} == set(mig.RELAY_EVENT_KEYS)
+        columns = db_session.connection().execute(sa.text(
+            "PRAGMA table_info('relay_team_events')")).fetchall()
+        assert "uid" not in {column[1] for column in columns}
+
+    def test_unresolvable_member_leaves_every_table_empty(self, db_session):
+        relay_event, pro, college = _world(db_session)
+        raw = json.loads(relay_event.event_state)
+        raw["teams"][0]["college_members"][0]["id"] = 999999
+        relay_event.event_state = json.dumps(raw)
+        db_session.flush()
+
+        mig._backfill(db_session.connection())
+
+        for table in mig.TABLES:
+            assert db_session.connection().execute(
+                sa.text(f"SELECT count(*) FROM {table}")).scalar() == 0


### PR DESCRIPTION
## Summary
- project Pro-Am Relay state into normalized state, team, membership, and team-event tables
- keep the legacy event-state document as the active reader while every normal relay write updates both stores atomically
- store competitor identity only on team membership, never on relay legs or EventResult rows
- preserve registration deletion and transaction-composability behavior

## Tournament Rules Applied
- relay results remain team-level and do not enter individual or college scoring
- relay teams choose their own leg assignments; leg rows carry no competitor identity

## Validation
- full isolated suite passed
- Ruff passed
- migration integrity, legacy projection, relay workflow, replacement, transaction, and registration-delete coverage passed

## Post-Deploy Monitoring & Validation
After migration, compare the relay dashboard and standings with the legacy event-state document. This release still reads JSON, so a malformed or unresolved legacy document is skipped whole and remains intact; the normalized rows are a projection until a later parity-verified reader switch.