### PR TITLE
feat(relay): read normalized team state with JSON fallback

### DIFF
--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -12,6 +12,8 @@ import copy
 import json
 import random
 
+from flask import has_app_context
+
 from database import db
 from models import Event, EventResult, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
@@ -43,6 +45,10 @@ class ProAmRelay:
         ).first()
 
         if relay_event:
+            if has_app_context():
+                table_data = self._load_table_relay_data(relay_event)
+                if table_data is not None:
+                    return table_data
             # Primary: event_state column (new path)
             raw = relay_event.event_state
             if not raw:
@@ -62,6 +68,94 @@ class ProAmRelay:
             'eligible_pro': [],
             'drawn_college': [],
             'drawn_pro': []
+        }
+
+    def _load_table_relay_data(self, relay_event: Event) -> dict | None:
+        """Rebuild the existing relay view payload from its row projection.
+
+        A missing or incomplete projection remains a JSON-reader case. This is
+        deliberate during the staged migration: a legacy document that could
+        not safely project is still usable, rather than becoming an empty
+        relay because it lacks rows.
+        """
+        state = RelayState.query.filter_by(event_id=relay_event.id).first()
+        if state is None:
+            return None
+
+        teams = RelayTeam.query.filter_by(relay_state_id=state.id).order_by(
+            RelayTeam.team_number
+        ).all()
+        team_ids = [team.id for team in teams]
+        members_by_team = {team_id: [] for team_id in team_ids}
+        for member in RelayTeamMember.query.filter(
+            RelayTeamMember.relay_team_id.in_(team_ids)
+        ).order_by(RelayTeamMember.id):
+            members_by_team[member.relay_team_id].append(member.uid)
+
+        all_uids = {uid for uids in members_by_team.values() for uid in uids}
+        pro_by_uid = {
+            competitor.uid: competitor
+            for competitor in ProCompetitor.query.filter(ProCompetitor.uid.in_(all_uids)).all()
+        }
+        college_by_uid = {
+            competitor.uid: competitor
+            for competitor in CollegeCompetitor.query.filter(
+                CollegeCompetitor.uid.in_(all_uids)
+            ).all()
+        }
+        if len(pro_by_uid) + len(college_by_uid) != len(all_uids):
+            return None
+
+        events_by_team = {team_id: {} for team_id in team_ids}
+        for team_event in RelayTeamEvent.query.filter(
+            RelayTeamEvent.relay_team_id.in_(team_ids)
+        ).all():
+            events_by_team[team_event.relay_team_id][team_event.event_key] = {
+                'result': team_event.result,
+                'status': team_event.status,
+            }
+
+        rendered_teams = []
+        drawn_pro = []
+        drawn_college = []
+        for team in teams:
+            event_data = events_by_team[team.id]
+            if set(event_data) != set(self.RELAY_EVENTS):
+                return None
+            pro_members = []
+            college_members = []
+            for uid in members_by_team[team.id]:
+                pro = pro_by_uid.get(uid)
+                if pro is not None:
+                    member = {'id': pro.id, 'name': pro.name, 'gender': pro.gender}
+                    pro_members.append(member)
+                    drawn_pro.append(member)
+                    continue
+                college = college_by_uid[uid]
+                member = {
+                    'id': college.id,
+                    'name': college.name,
+                    'gender': college.gender,
+                    'team': college.team.team_code if college.team else 'N/A',
+                }
+                college_members.append(member)
+                drawn_college.append(member)
+            rendered_teams.append({
+                'team_number': team.team_number,
+                'name': team.name,
+                'pro_members': pro_members,
+                'college_members': college_members,
+                'events': event_data,
+                'total_time': team.total_time,
+            })
+
+        return {
+            'status': state.status,
+            'teams': rendered_teams,
+            'eligible_college': [],
+            'eligible_pro': [],
+            'drawn_college': drawn_college,
+            'drawn_pro': drawn_pro,
         }
 
     def _save_relay_data(self, commit: bool = True):

--- a/tests/test_relay_table_sync.py
+++ b/tests/test_relay_table_sync.py
@@ -65,3 +65,40 @@ def test_replacement_rejects_competitor_already_on_another_relay_team(db_session
 
     with pytest.raises(ValueError, match="already assigned"):
         relay.replace_competitor(1, pros[0].id, pros[1].id, "pro")
+
+
+def test_reader_prefers_normalized_rows_over_malformed_legacy_json(db_session):
+    from models.event import Event
+
+    tournament = make_tournament(db_session)
+    school = make_team(db_session, tournament)
+    pro = make_pro_competitor(db_session, tournament, "Pro One", gender="M")
+    college = make_college_competitor(
+        db_session, tournament, school, "College One", gender="F"
+    )
+    pro.pro_am_lottery_opt_in = True
+    college.pro_am_lottery_opt_in = True
+    db_session.flush()
+
+    relay = ProAmRelay(tournament)
+    relay.set_teams_manually([{
+        "pro_member_ids": [pro.id],
+        "college_member_ids": [college.id],
+    }])
+    relay.record_event_result(1, "partnered_sawing", 20.5)
+
+    relay_event = Event.query.filter_by(
+        tournament_id=tournament.id, name="Pro-Am Relay"
+    ).one()
+    relay_event.event_state = "{not valid json"
+    db_session.commit()
+
+    reloaded = ProAmRelay(tournament)
+    assert reloaded.get_status() == "in_progress"
+    team = reloaded.get_teams()[0]
+    assert [member["id"] for member in team["pro_members"]] == [pro.id]
+    assert [member["id"] for member in team["college_members"]] == [college.id]
+    assert team["events"]["partnered_sawing"] == {
+        "result": 20.5,
+        "status": "completed",
+    }


### PR DESCRIPTION
## Summary
- read Pro-Am Relay teams, memberships, and team-level leg results from normalized rows when a complete projection exists
- retain event-state JSON as the fallback for legacy state that was intentionally not projected
- keep relay leg records team-level with no competitor identity

## Validation
- full isolated suite passed
- focused relay, transaction, and migration tests passed
- Ruff and diff checks passed

## Post-Deploy Monitoring & Validation
Compare the relay dashboard and standings after deployment. If a legacy relay document lacks a complete normalized projection, the service continues to read that JSON unchanged; no operator action is required for fallback cases.