### PR TITLE
Fix Partnered Axe flight finalists

### DIFF
--- a/services/flight_builder.py
+++ b/services/flight_builder.py
@@ -385,9 +385,10 @@ def _prepare_partnered_axe_show_heats(event: Event | None) -> list[Heat]:
 
 def _get_partnered_axe_qualifier_pairs(event: Event, count: int) -> list[dict]:
     """Read prelim standings from partnered axe event state and return top N pairs."""
+    raw_state = getattr(event, 'event_state', None) or event.payouts
     try:
-        state = json.loads(event.payouts or '{}')
-    except Exception:
+        state = json.loads(raw_state or '{}')
+    except (json.JSONDecodeError, TypeError):
         return []
 
     prelim_results = state.get('prelim_results')

--- a/tests/test_flight_builder.py
+++ b/tests/test_flight_builder.py
@@ -36,8 +36,8 @@ def _heat_data(event, competitors, heat_number=1):
     return {'heat': heat, 'event': event, 'competitors': set(competitors)}
 
 
-def _axe_event(payouts_json='{}'):
-    ev = SimpleNamespace(payouts=payouts_json)
+def _axe_event(payouts_json='{}', event_state=None):
+    ev = SimpleNamespace(payouts=payouts_json, event_state=event_state)
     return ev
 
 
@@ -234,6 +234,18 @@ class TestGetPartneredAxeQualifierPairs:
         ev = _axe_event(payouts_json=json.dumps(state))
         result = _get_partnered_axe_qualifier_pairs(ev, 4)
         assert len(result) == 4
+
+    def test_prefers_event_state_over_legacy_payouts(self):
+        current_pairs = [self._make_pair(1, 2, score=30), self._make_pair(3, 4, score=29)]
+        legacy_pairs = [self._make_pair(5, 6, score=99)]
+        ev = _axe_event(
+            payouts_json=json.dumps({'prelim_results': legacy_pairs}),
+            event_state=json.dumps({'prelim_results': current_pairs}),
+        )
+
+        result = _get_partnered_axe_qualifier_pairs(ev, 4)
+
+        assert [pair['competitor1']['id'] for pair in result] == [1, 3]
 
     def test_uses_pairs_when_no_prelim_results(self):
         """Falls back to 'pairs' key sorted by prelim_score."""


### PR DESCRIPTION
## Summary
- Read Partnered Axe finalist state from event_state before legacy payouts.
- Preserve payouts fallback for pre-migration events.
- Add a regression test for conflicting current and legacy state.

## Verification
- pytest tests/test_flight_builder.py -q -p no:cacheprovider
- pytest tests/test_flight_builder.py tests/test_transaction_composability.py tests/test_axe_throw_qualifiers.py -q -p no:cacheprovider
- Full isolated suite reached 69% without failure before the local runner timeout; hosted CI will run the complete matrix.

No production or Railway resources were accessed.