### PR TITLE
Preserve Birling pre-seeds on fallback

### DIFF
--- a/services/birling_bracket.py
+++ b/services/birling_bracket.py
@@ -63,14 +63,10 @@ class BirlingBracket:
     def _stored_document(self):
         """The JSON document in ``events.payouts``, or None if there is none.
 
-        Behaviour preserved exactly from the pre-A3b ``_load_bracket_data``,
-        including two things that are wrong and are not this commit's to fix:
-
-        The payload is discarded whole when it carries no ``bracket`` key
-        rather than being merged, which is the c63 defect that destroys
-        ``pre_seedings`` the first time a bracket is generated over them. That
-        fix needs its own approval and its own commit; doing it here would put
-        two changes under one commit message.
+        A pre-seeding can be saved before any bracket exists. Preserve that
+        input by merging it into the normal empty bracket skeleton, so fallback
+        generation cannot discard the school seed order before rows exist.
+        Other payout-shaped JSON remains non-bracket data and is ignored.
 
         Malformed or non-string JSON is treated as an absent fallback document.
         Other failures are allowed to surface so a programming or persistence
@@ -78,8 +74,15 @@ class BirlingBracket:
         """
         try:
             data = json.loads(self.event.payouts or '{}')
+            if not isinstance(data, dict):
+                return None
             if 'bracket' in data:
                 return data
+            pre_seedings = data.get('pre_seedings')
+            if isinstance(pre_seedings, dict):
+                document = birling_rows.empty_document()
+                document['pre_seedings'] = pre_seedings
+                return document
         except (json.JSONDecodeError, TypeError):
             return None
         return None

--- a/tests/test_birling_bracket.py
+++ b/tests/test_birling_bracket.py
@@ -45,6 +45,12 @@ class TestStoredDocument:
 
         assert bracket._stored_document() is None
 
+    def test_json_list_is_not_a_fallback_document(self):
+        bracket = object.__new__(BirlingBracket)
+        bracket.event = _mock_event('[]')
+
+        assert bracket._stored_document() is None
+
     def test_unexpected_json_loader_failure_is_not_silenced(self):
         bracket = object.__new__(BirlingBracket)
         bracket.event = _mock_event('{"bracket": {}}')

--- a/tests/test_birling_rows.py
+++ b/tests/test_birling_rows.py
@@ -726,38 +726,29 @@ class TestPreSeedsComeFromTheRankingsPage:
 
     def test_the_first_generate_keeps_the_pre_seedings_once_rows_exist(
             self, db_session):
-        """The c63 defect, and the one arrangement in which it stops firing.
-
-        Written in an earlier session to pin the defect. It now records the
-        opposite outcome, and the change of outcome is the point.
-
-        ``BirlingBracket._stored_document`` returns the stored document only if
-        it carries a ``bracket`` key, and otherwise throws the whole thing away
-        and starts from a fresh skeleton. The production order of operations is
-        exactly the losing one: the ability rankings page writes
-        ``pre_seedings`` onto an event that has no bracket yet, and before A3b
-        the first generate then silently dropped it. What was lost is the
-        record of what each school actually asked for, which is what a later
-        regenerate would need.
-
-        A3b flipped the reader onto the row tables, and the rows do not have
-        that hole: the pre-seed rows load whether or not a bracket sits beside
-        them. So on any event the ability rankings page has touched, and that
-        page has projected rows alongside the JSON since A2, the pre-seedings
-        now survive the first generate.
-
-        This is behaviour A3b happens to change, not the c63 fix. c63 stays
-        open. ``_stored_document`` is untouched and still discards a
-        bracket-less payload whole, so an event whose rows were never projected
-        still loses its pre-seedings through the fallback path. Fixing that is
-        a modification nobody has approved.
-        """
+        """Projected pre-seeds survive the first bracket generation."""
         _tour, event, people = _world(db_session, "Clobbered")
         pre = {str(people[0].id): 1, str(people[1].id): 2}
         event.payouts = json.dumps({"pre_seedings": pre})
         rows.project(event)
         db.session.flush()
         assert _counts(event.id)["pre_seeds"] == 2
+
+        BirlingBracket(event).generate_bracket(_entrants(people[:4]))
+
+        assert json.loads(event.payouts)["pre_seedings"] == pre
+        counts = _counts(event.id)
+        assert counts["pre_seeds"] == 2
+        assert counts["seeds"] == 4
+
+    def test_the_first_generate_keeps_pre_seedings_without_projected_rows(
+            self, db_session):
+        """Fallback generation keeps a pre-seeding-only payload intact."""
+        _tour, event, people = _world(db_session, "FallbackPreSeeds")
+        pre = {str(people[0].id): 1, str(people[1].id): 2}
+        event.payouts = json.dumps({"pre_seedings": pre})
+        db.session.flush()
+        assert _counts(event.id)["pre_seeds"] == 0
 
         BirlingBracket(event).generate_bracket(_entrants(people[:4]))
 


### PR DESCRIPTION
## Summary
- Preserve valid Birling pre-seedings when fallback JSON has no bracket yet.
- Keep payout-shaped and list JSON outside the bracket fallback path.
- Cover unprojected pre-seeding generation, projected generation, and list JSON.

## Verification
- 209 tests: bracket, rows, reader flip, inverse, and refusal surfaces.
- 94 tests: migration/backfill, stale-shape, index route, and print route.

No production or Railway database access occurred.