### PR TITLE
Enable Partnered Axe payout configuration

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -121,13 +121,14 @@ class Event(db.Model):
 
     @property
     def uses_payouts_for_state(self):
-        """True when the payouts column stores state-machine data instead of
-        payout amounts (Partnered Axe Throw, Birling bracket).
+        """True when the payouts column still stores state-machine data.
 
-        Pro-Am Relay is excluded: its state-machine data moved to event_state
-        (migration b1c2d3e4f5a6), so payouts is now free for payout amounts.
+        Partnered Axe Throw and Pro-Am Relay now store their state in
+        ``event_state`` (migration b1c2d3e4f5a6), so their purses can use the
+        payouts column. Birling remains guarded while legacy bracket fallback
+        data can still be read from that column.
         """
-        return self.has_prelims or self.scoring_type == 'bracket'
+        return self.scoring_type == 'bracket'
 
     def get_payouts(self):
         """Return dict of position -> payout amount."""

--- a/tests/test_partnered_axe_state.py
+++ b/tests/test_partnered_axe_state.py
@@ -173,6 +173,29 @@ class TestPartneredAxeLifecycle:
         # Top 4 from finals + 2 non-finalists from prelims
         assert len(standings) == 6
 
+    def test_payout_configuration_preserves_pair_state(
+            self, auth_client, db_session, tournament, axe_event):
+        """Purses and Partnered Axe state occupy separate columns."""
+        from services.partnered_axe import PartneredAxeThrow
+
+        pat = PartneredAxeThrow(axe_event)
+        c1, c2 = _make_pair(
+            db_session, tournament, 'Payout State A', 'Payout State B',
+            event_id=axe_event.id,
+        )
+        pat.register_pair(c1.id, c2.id)
+        state_before = axe_event.event_state
+
+        response = auth_client.post(
+            f'/scoring/{tournament.id}/event/{axe_event.id}/payouts',
+            data={'payout_1': '500', 'payout_2': '300'},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        assert axe_event.get_payouts() == {'1': 500.0, '2': 300.0}
+        assert axe_event.event_state == state_before
+
 
 # ---------------------------------------------------------------------------
 # Edge cases

--- a/tests/test_proam_relay.py
+++ b/tests/test_proam_relay.py
@@ -292,9 +292,9 @@ class TestUsesPayoutsForState:
         ev = self._make_event(scoring_type='bracket')
         assert ev.uses_payouts_for_state is True
 
-    def test_has_prelims_returns_true(self):
+    def test_has_prelims_returns_false_after_state_migration(self):
         ev = self._make_event(has_prelims=True)
-        assert ev.uses_payouts_for_state is True
+        assert ev.uses_payouts_for_state is False
 
     def test_ordinary_event_returns_false(self):
         ev = self._make_event(name='Underhand Speed', scoring_type='time')


### PR DESCRIPTION
Summary: Partnered Axe state now stays in event_state, which frees payouts for payout schedules. Birling remains guarded for legacy fallback data. Tests cover saving an Axe payout schedule without changing pair state. Local validation: 101 focused tests plus Ruff passed.