### PR TITLE
Make Relay tables authoritative

### DIFF
--- a/models/event.py
+++ b/models/event.py
@@ -70,10 +70,9 @@ class Event(db.Model):
     # Payout configuration (pro only) - stored as JSON
     payouts = db.Column(db.Text, nullable=False, default='{}')  # Dict: position -> amount
 
-    # State-machine storage for events that overload payouts (Pro-Am Relay,
-    # Partnered Axe Throw, Birling bracket).  Nullable TEXT — NULL means no
-    # state has been written yet.  Populated by migration b1c2d3e4f5a6 for
-    # pre-existing events and by their respective services going forward.
+    # State-machine storage for Partnered Axe Throw, Birling, and legacy Relay.
+    # NULL means no JSON fallback is needed; projected Relay state is stored
+    # in its dedicated tables instead.
     event_state = db.Column(db.Text, nullable=True)
 
     # Status

--- a/routes/main.py
+++ b/routes/main.py
@@ -855,12 +855,9 @@ def ops_dashboard(tid):
     team_health = []
     if relay_event:
         try:
-            import json as _json
+            from services.proam_relay import ProAmRelay, compute_team_health
 
-            from services.proam_relay import compute_team_health
-            raw = relay_event.event_state or relay_event.payouts or '{}'
-            relay_data = _json.loads(raw)
-            for team in relay_data.get('teams', []):
+            for team in ProAmRelay(tournament).get_teams():
                 health = compute_team_health(team, tournament)
                 team_health.append({'team': team, 'health': health})
         except Exception:

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -36,8 +36,8 @@ class ProAmRelay:
     def _load_relay_data(self) -> dict:
         """Load relay data from tournament or create new.
 
-        Reads from event_state (primary) with fallback to payouts for
-        backward compatibility during the migration transition.
+        Reads normalized Relay tables first, then event_state or payouts only
+        for legacy documents that could not be projected safely.
         """
         relay_event = Event.query.filter_by(
             tournament_id=self.tournament.id,
@@ -159,7 +159,12 @@ class ProAmRelay:
         }
 
     def _save_relay_data(self, commit: bool = True):
-        """Save relay data to the relay event.
+        """Save relay data to normalized tables when its shape is complete.
+
+        A successful table projection clears ``event_state`` so new Relay
+        writes have one authoritative store. An incomplete legacy document
+        stays in JSON because it cannot yet be represented without losing
+        data. Payouts are never used for Relay state on this path.
 
         Args:
             commit: When True (default) commits immediately so existing
@@ -182,11 +187,15 @@ class ProAmRelay:
             )
             db.session.add(relay_event)
 
-        member_uids = self._relay_member_uids() if self._has_projectable_teams() else None
-        relay_event.event_state = json.dumps(self.relay_data)
+        # A first write creates the Event above, so establish its id before
+        # creating RelayState with the event foreign key.
         db.session.flush()
-        if member_uids is not None:
+        if self._has_projectable_teams():
+            member_uids = self._relay_member_uids()
             self._sync_relay_tables(relay_event, member_uids)
+            relay_event.event_state = None
+        else:
+            relay_event.event_state = json.dumps(self.relay_data)
         if commit:
             db.session.commit()
         else:

--- a/tests/test_relay_table_sync.py
+++ b/tests/test_relay_table_sync.py
@@ -7,7 +7,7 @@ from services.proam_relay import ProAmRelay
 from tests.conftest import make_college_competitor, make_pro_competitor, make_team, make_tournament
 
 
-def test_manual_teams_dual_write_to_normalized_relay_tables(db_session):
+def test_manual_teams_persist_only_to_normalized_relay_tables(db_session):
     tournament = make_tournament(db_session)
     school = make_team(db_session, tournament)
     pro = make_pro_competitor(db_session, tournament, "Pro One", gender="M")
@@ -35,11 +35,20 @@ def test_manual_teams_dual_write_to_normalized_relay_tables(db_session):
     assert db_session.execute(sa.text(
         "SELECT count(*) FROM relay_team_events")).scalar() == 4
 
+    from models.event import Event
+
+    relay_event = Event.query.filter_by(
+        tournament_id=tournament.id, name="Pro-Am Relay"
+    ).one()
+    assert relay_event.event_state is None
+    assert relay_event.results.count() == 0
+
     relay.record_event_result(1, "partnered_sawing", 20.5)
     assert db_session.execute(sa.text(
         "SELECT result, status FROM relay_team_events "
         "WHERE event_key = 'partnered_sawing'"
     )).one() == (20.5, "completed")
+    assert relay_event.event_state is None
 
 
 def test_replacement_rejects_competitor_already_on_another_relay_team(db_session):
@@ -102,3 +111,27 @@ def test_reader_prefers_normalized_rows_over_malformed_legacy_json(db_session):
         "result": 20.5,
         "status": "completed",
     }
+
+
+def test_ops_dashboard_reads_normalized_relay_rows(auth_client, db_session):
+    tournament = make_tournament(db_session)
+    school = make_team(db_session, tournament)
+    pro = make_pro_competitor(db_session, tournament, "Pro One", gender="M")
+    college = make_college_competitor(
+        db_session, tournament, school, "College One", gender="F"
+    )
+    pro.pro_am_lottery_opt_in = True
+    college.pro_am_lottery_opt_in = True
+    db_session.flush()
+
+    ProAmRelay(tournament).set_teams_manually([{
+        "pro_member_ids": [pro.id],
+        "college_member_ids": [college.id],
+    }])
+
+    response = auth_client.get(f"/tournament/{tournament.id}/ops-dashboard")
+
+    assert response.status_code == 200
+    assert b"Relay Team Health" in response.data
+    assert b"1 teams" in response.data
+    assert b"Team 1" in response.data

--- a/tests/test_transaction_composability.py
+++ b/tests/test_transaction_composability.py
@@ -134,16 +134,17 @@ class TestRelayCommitTrue:
 
 class TestRelayCommitFalse:
     def test_no_commit_allows_rollback(self, db_session, tournament, relay_event):
-        """commit=False: event_state is flushed to the DB session but not
-        committed; a subsequent rollback must restore the original value."""
+        """commit=False flushes normalized Relay rows without committing them."""
+        from models.relay import RelayState
+
         relay = _relay_instance(tournament, relay_event)
         event_id = relay_event.id
 
         relay.relay_data["status"] = "drawn"
         relay._save_relay_data(commit=False)
 
-        # The object in-session should have the new value
-        assert relay_event.event_state is not None
+        assert relay_event.event_state is None
+        assert RelayState.query.filter_by(event_id=event_id).one().status == "drawn"
 
         # Rolling back must discard the pending write.
         # The relay_event row was added inside db_session (a savepoint), so
@@ -153,8 +154,8 @@ class TestRelayCommitFalse:
         from models.event import Event as _Event
         fresh = _db.session.get(_Event, event_id)
         if fresh is not None:
-            state = json.loads(fresh.event_state) if fresh.event_state else {}
-            assert state.get("status") != "drawn"
+            state = RelayState.query.filter_by(event_id=event_id).first()
+            assert state is None or state.status != "drawn"
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +238,8 @@ class TestRelayOuterSavepointRollback:
         self, db_session, tournament, relay_event
     ):
         """Outer savepoint wraps _save_relay_data(commit=False); rollback restores."""
+        from models.relay import RelayState
+
         relay = _relay_instance(tournament, relay_event)
         relay.relay_data["status"] = "drawn"
 
@@ -244,17 +247,16 @@ class TestRelayOuterSavepointRollback:
         sp = _db.session.begin_nested()
         relay._save_relay_data(commit=False)
 
-        assert relay_event.event_state is not None
-        drawn = json.loads(relay_event.event_state).get("status")
-        assert drawn == "drawn"
+        assert relay_event.event_state is None
+        assert RelayState.query.filter_by(event_id=relay_event.id).one().status == "drawn"
 
         # Roll back the inner savepoint
         sp.rollback()
         _db.session.expire(relay_event)
         fresh = _db.session.get(relay_event.__class__, relay_event.id)
         if fresh is not None:
-            state = json.loads(fresh.event_state) if fresh.event_state else {}
-            assert state.get("status") != "drawn"
+            state = RelayState.query.filter_by(event_id=relay_event.id).first()
+            assert state is None or state.status != "drawn"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary: Complete Relay documents now save only to normalized Relay tables and clear event_state. Legacy documents that cannot project remain JSON fallback data. The operations dashboard now reads Relay state through the service. Relay legs remain team-level and do not create EventResult rows. Validation: 182 focused compatibility tests passed; full local suite reached 74 percent with no failures before the runner limit; Ruff passed.