### PR TITLE
Complete Relay payout settlement

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -969,6 +969,11 @@ def ops_dashboard(tid):
         if row:
             total_purse = float(row.total or 0.0)
             total_settled = float(row.settled or 0.0)
+    from services.proam_relay import relay_payout_summary
+
+    relay_payouts = relay_payout_summary(tournament)
+    total_purse += relay_payouts['total_owed']
+    total_settled += relay_payouts['total_settled']
     payout_outstanding = total_purse - total_settled
     payout_pct = int(total_settled / total_purse * 100) if total_purse > 0 else 0
     payout_summary = {

--- a/routes/proam_relay.py
+++ b/routes/proam_relay.py
@@ -7,8 +7,15 @@ from sqlalchemy.orm.exc import StaleDataError
 from database import db
 from models import Tournament
 from models.event import Event
+from models.relay import RelayTeam
+from services.audit import log_action
 from services.cache_invalidation import invalidate_tournament_caches
-from services.proam_relay import compute_team_health, create_proam_relay_event, get_proam_relay
+from services.proam_relay import (
+    compute_team_health,
+    create_proam_relay_event,
+    get_proam_relay,
+    relay_payout_summary,
+)
 
 # Shared message for the concurrent-edit case — surfaced when SQLAlchemy
 # version_id detects a parallel update has advanced the row. Without this
@@ -298,6 +305,42 @@ def save_relay_payouts(tournament_id):
     invalidate_tournament_caches(tournament_id)
     flash('Relay payouts saved.', 'success')
     return redirect(url_for('proam_relay.relay_payouts', tournament_id=tournament_id))
+
+
+@bp.route('/team/<int:team_id>/toggle-settled', methods=['POST'])
+def toggle_relay_settlement(tournament_id, team_id):
+    """Toggle payment status for one final, payable Relay team."""
+    tournament = db.get_or_404(Tournament, tournament_id)
+    payout_row = next(
+        (
+            row for row in relay_payout_summary(tournament)['rows']
+            if row['team'].id == team_id
+        ),
+        None,
+    )
+    if payout_row is None:
+        abort(404)
+
+    team = db.get_or_404(RelayTeam, team_id)
+    team.payout_settled = not team.payout_settled
+    db.session.commit()
+    invalidate_tournament_caches(tournament_id)
+    log_action(
+        'relay_payout_settlement_toggled',
+        'relay_team',
+        team.id,
+        {
+            'settled': team.payout_settled,
+            'team_name': team.name,
+            'team_number': team.team_number,
+            'payout_amount': payout_row['payout_amount'],
+        },
+    )
+
+    is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    if is_ajax:
+        return jsonify({'ok': True, 'settled': team.payout_settled})
+    return redirect(url_for('reporting.pro_payout_summary', tournament_id=tournament_id))
 
 
 # API endpoints for AJAX calls

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -244,7 +244,7 @@ def event_results_print(tournament_id, event_id):
 
 @reporting_bp.route('/<int:tournament_id>/pro/payouts', methods=['GET', 'POST'])
 def pro_payout_summary(tournament_id):
-    """View pro competitor payout summary with settlement tracking."""
+    """View individual pro and team Relay payouts with settlement tracking."""
     tournament = db.get_or_404(Tournament, tournament_id)
     from models.competitor import ProCompetitor
 
@@ -269,8 +269,16 @@ def pro_payout_summary(tournament_id):
     total_competitors = len(competitors)
 
     earners = [c for c in competitors if c.total_earnings and c.total_earnings > 0]
-    total_owed = sum(c.total_earnings for c in earners)
-    total_settled = sum(c.total_earnings for c in earners if c.payout_settled)
+    individual_total_owed = sum(c.total_earnings for c in earners)
+    individual_total_settled = sum(
+        c.total_earnings for c in earners if c.payout_settled
+    )
+
+    from services.proam_relay import relay_payout_summary
+
+    relay_payouts = relay_payout_summary(tournament)
+    total_owed = individual_total_owed + relay_payouts['total_owed']
+    total_settled = individual_total_settled + relay_payouts['total_settled']
     total_outstanding = total_owed - total_settled
 
     # Build a mapping of competitor_id → first EventResult id with payout_amount > 0
@@ -306,6 +314,8 @@ def pro_payout_summary(tournament_id):
                            total_outstanding=total_outstanding,
                            earners_count=len(earners),
                            total_competitors=total_competitors,
+                           individual_total_owed=individual_total_owed,
+                           relay_payouts=relay_payouts,
                            result_id_map=result_id_map)
 
 
@@ -318,11 +328,16 @@ def pro_payout_summary_print(tournament_id):
     competitors = tournament.pro_competitors.filter_by(status='active').all()
     competitors = sorted(competitors, key=lambda c: c.total_earnings, reverse=True)
     competitors = [c for c in competitors if c.total_earnings and c.total_earnings > 0]
-    total_paid = sum(c.total_earnings for c in competitors)
+    individual_total_paid = sum(c.total_earnings for c in competitors)
+    from services.proam_relay import relay_payout_summary
+
+    relay_payouts = relay_payout_summary(tournament)
+    total_paid = individual_total_paid + relay_payouts['total_owed']
 
     return render_template('reports/payout_summary_print.html',
                            tournament=tournament,
                            competitors=competitors,
+                           relay_payouts=relay_payouts,
                            total_paid=total_paid)
 
 

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -20,6 +20,65 @@ from models.competitor import CollegeCompetitor, ProCompetitor
 from models.relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
 
 
+def relay_payout_summary(tournament: Tournament) -> dict:
+    """Return payable, team-level Relay awards for a completed Relay.
+
+    Relay money is intentionally separate from individual EventResult payouts.
+    A team earns the configured amount for its final placement, and its
+    RelayTeam row carries the binary settlement state.
+    """
+    relay_event = Event.query.filter_by(
+        tournament_id=tournament.id,
+        name='Pro-Am Relay',
+    ).first()
+    if relay_event is None:
+        return _empty_relay_payout_summary()
+
+    state = RelayState.query.filter_by(event_id=relay_event.id).first()
+    # Partial relay times are provisional. Do not expose a payable placement
+    # until the whole relay has a final ordering.
+    if state is None or state.status != 'completed':
+        return _empty_relay_payout_summary()
+
+    payouts = relay_event.get_payouts()
+    rows = []
+    teams = RelayTeam.query.filter_by(relay_state_id=state.id).filter(
+        RelayTeam.total_time.isnot(None)
+    ).order_by(RelayTeam.total_time, RelayTeam.team_number).all()
+    for placement, team in enumerate(teams, start=1):
+        try:
+            amount = float(payouts.get(str(placement), 0) or 0)
+        except (TypeError, ValueError):
+            amount = 0.0
+        if amount <= 0:
+            continue
+        rows.append({
+            'team': team,
+            'placement': placement,
+            'payout_amount': amount,
+        })
+
+    total_owed = sum(row['payout_amount'] for row in rows)
+    total_settled = sum(
+        row['payout_amount'] for row in rows if row['team'].payout_settled
+    )
+    return {
+        'rows': rows,
+        'total_owed': total_owed,
+        'total_settled': total_settled,
+        'total_outstanding': total_owed - total_settled,
+    }
+
+
+def _empty_relay_payout_summary() -> dict:
+    return {
+        'rows': [],
+        'total_owed': 0.0,
+        'total_settled': 0.0,
+        'total_outstanding': 0.0,
+    }
+
+
 class ProAmRelay:
     """Manages the Pro-Am Relay lottery and teams."""
     RELAY_EVENTS = (
@@ -261,24 +320,40 @@ class ProAmRelay:
             db.session.flush()
 
         state.status = self.relay_data.get("status", "not_drawn")
-        team_ids = [row.id for row in RelayTeam.query.filter_by(relay_state_id=state.id).all()]
-        if team_ids:
-            RelayTeamEvent.query.filter(RelayTeamEvent.relay_team_id.in_(team_ids)).delete(
-                synchronize_session=False
-            )
-            RelayTeamMember.query.filter(RelayTeamMember.relay_team_id.in_(team_ids)).delete(
-                synchronize_session=False
-            )
-            RelayTeam.query.filter(RelayTeam.id.in_(team_ids)).delete(synchronize_session=False)
+        existing_teams = RelayTeam.query.filter_by(relay_state_id=state.id).all()
+        existing_uids = {row.id: set() for row in existing_teams}
+        for member in RelayTeamMember.query.filter(
+            RelayTeamMember.relay_team_id.in_(existing_uids)
+        ):
+            existing_uids[member.relay_team_id].add(member.uid)
+        existing_settlements = {
+            row.team_number: (row.payout_settled, existing_uids[row.id])
+            for row in existing_teams
+        }
+        if existing_teams:
+            # Use ORM deletion so the identity map cannot keep a deleted team
+            # under an id SQLite may immediately reuse for its replacement.
+            # Relationships own the member and leg cascades.
+            for existing_team in existing_teams:
+                db.session.delete(existing_team)
             db.session.flush()
 
         seen_uids = set()
         for team_data in self.relay_data.get("teams", []):
+            incoming_uids = set()
+            for key, kind in (("pro_members", "pro"), ("college_members", "college")):
+                for member in team_data.get(key, []):
+                    uid = member_uids[kind].get(member.get("id"))
+                    if uid is None:
+                        raise ValueError("Relay roster contains an unresolved competitor")
+                    incoming_uids.add(uid)
+            previous = existing_settlements.get(team_data["team_number"])
             team = RelayTeam(
                 relay_state_id=state.id,
                 team_number=team_data["team_number"],
                 name=team_data["name"],
                 total_time=team_data.get("total_time"),
+                payout_settled=bool(previous and previous[0] and previous[1] == incoming_uids),
             )
             db.session.add(team)
             db.session.flush()
@@ -286,8 +361,6 @@ class ProAmRelay:
             for key, kind in (("pro_members", "pro"), ("college_members", "college")):
                 for member in team_data.get(key, []):
                     uid = member_uids[kind].get(member.get("id"))
-                    if uid is None:
-                        raise ValueError("Relay roster contains an unresolved competitor")
                     if uid in seen_uids:
                         raise ValueError("A relay competitor cannot appear on multiple teams")
                     seen_uids.add(uid)

--- a/templates/reports/payout_summary.html
+++ b/templates/reports/payout_summary.html
@@ -73,8 +73,8 @@
                             <strong>{{ total_competitors }}</strong>
                         </li>
                         <li class="d-flex justify-content-between">
-                            <span>Avg Earnings</span>
-                            <strong>${{ "%.2f"|format(total_owed / (earners_count or 1)) }}</strong>
+                            <span>Avg Individual</span>
+                            <strong>${{ "%.2f"|format(individual_total_owed / (earners_count or 1)) }}</strong>
                         </li>
                     </ul>
                 </div>
@@ -181,6 +181,61 @@
             {% endif %}
         </div>
     </div>
+
+    {% if relay_payouts.rows %}
+    <div class="card mt-4">
+        <div class="card-header bg-warning text-dark d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="bi bi-people-fill"></i> Pro-Am Relay Team Payouts</h5>
+            <strong>${{ "%.2f"|format(relay_payouts.total_owed) }}</strong>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Place</th>
+                            <th>Team</th>
+                            <th class="text-end">Time</th>
+                            <th class="text-end">Payout</th>
+                            <th class="text-center">Status</th>
+                            {% if current_user.is_authenticated and current_user.is_admin %}
+                            <th class="text-center">Action</th>
+                            {% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in relay_payouts.rows %}
+                        {% set team = row.team %}
+                        <tr class="{% if team.payout_settled %}table-success{% endif %}">
+                            <td>{{ row.placement }}</td>
+                            <td><strong>{{ team.name }}</strong></td>
+                            <td class="text-end">{{ "%.2f"|format(team.total_time) }}s</td>
+                            <td class="text-end"><strong>${{ "%.2f"|format(row.payout_amount) }}</strong></td>
+                            <td class="text-center">
+                                {% if team.payout_settled %}
+                                <span class="badge bg-success"><i class="bi bi-check-circle-fill"></i> Paid</span>
+                                {% else %}
+                                <span class="badge bg-warning text-dark">Pending</span>
+                                {% endif %}
+                            </td>
+                            {% if current_user.is_authenticated and current_user.is_admin %}
+                            <td class="text-center">
+                                <form method="POST" action="{{ url_for('proam_relay.toggle_relay_settlement', tournament_id=tournament.id, team_id=team.id) }}" style="display:inline;">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-sm {% if team.payout_settled %}btn-outline-warning{% else %}btn-outline-success{% endif %}">
+                                        {% if team.payout_settled %}Unmark{% else %}Mark Paid{% endif %}
+                                    </button>
+                                </form>
+                            </td>
+                            {% endif %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 </div>
 
 <script>

--- a/templates/reports/payout_summary_print.html
+++ b/templates/reports/payout_summary_print.html
@@ -144,6 +144,32 @@
         </tfoot>
     </table>
 
+    {% if relay_payouts.rows %}
+    <h2 style="margin-top: 24px;">Pro-Am Relay Team Payouts</h2>
+    <table>
+        <thead>
+            <tr>
+                <th class="rank">Place</th>
+                <th>Team</th>
+                <th class="earnings">Time</th>
+                <th class="earnings">Payout</th>
+                <th style="text-align: center; width: 110px;">Signature</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in relay_payouts.rows %}
+            <tr>
+                <td class="rank">{{ row.placement }}</td>
+                <td><strong>{{ row.team.name }}</strong></td>
+                <td class="earnings">{{ "%.2f"|format(row.team.total_time) }}s</td>
+                <td class="earnings">${{ "%.2f"|format(row.payout_amount) }}</td>
+                <td></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+
     <div class="signature-line">
         <div class="signature-block">Tournament Director</div>
         <div class="signature-block">Date</div>

--- a/tests/test_relay_payout_settlement.py
+++ b/tests/test_relay_payout_settlement.py
@@ -1,0 +1,158 @@
+"""Relay payout ranking and team-level settlement coverage."""
+
+import pytest
+
+from database import db
+from models.relay import RelayState, RelayTeam
+from services.proam_relay import ProAmRelay, relay_payout_summary
+from tests.conftest import make_event, make_pro_competitor, make_tournament
+
+
+def _completed_relay(session, tournament, payouts=None):
+    event = make_event(
+        session,
+        tournament,
+        'Pro-Am Relay',
+        event_type='pro',
+        scoring_type='time',
+        payouts=payouts or {'1': 500.0, '2': 250.0},
+        status='completed',
+    )
+    state = RelayState(event_id=event.id, status='completed')
+    session.add(state)
+    session.flush()
+    first = RelayTeam(
+        relay_state_id=state.id,
+        team_number=1,
+        name='Team One',
+        total_time=85.2,
+    )
+    second = RelayTeam(
+        relay_state_id=state.id,
+        team_number=2,
+        name='Team Two',
+        total_time=79.4,
+    )
+    session.add_all([first, second])
+    session.flush()
+    return event, state, first, second
+
+
+def test_relay_payout_summary_ranks_completed_teams_and_uses_team_settlement(db_session):
+    tournament = make_tournament(db_session)
+    _, _, first, second = _completed_relay(db_session, tournament)
+    first.payout_settled = True
+    db_session.commit()
+
+    summary = relay_payout_summary(tournament)
+
+    assert [row['team'].id for row in summary['rows']] == [second.id, first.id]
+    assert [row['placement'] for row in summary['rows']] == [1, 2]
+    assert [row['payout_amount'] for row in summary['rows']] == [500.0, 250.0]
+    assert summary['total_owed'] == pytest.approx(750.0)
+    assert summary['total_settled'] == pytest.approx(250.0)
+    assert summary['total_outstanding'] == pytest.approx(500.0)
+
+
+def test_relay_payout_summary_excludes_provisional_results(db_session):
+    tournament = make_tournament(db_session)
+    _, state, _, _ = _completed_relay(db_session, tournament)
+    state.status = 'in_progress'
+    db_session.commit()
+
+    assert relay_payout_summary(tournament)['rows'] == []
+
+
+def test_relay_resave_keeps_settlement_for_same_team_number(db_session):
+    tournament = make_tournament(db_session)
+    _, state, first, _ = _completed_relay(db_session, tournament)
+    first.payout_settled = True
+    db_session.commit()
+
+    relay = ProAmRelay(tournament)
+    relay.relay_data = {
+        'status': 'completed',
+        'teams': [{
+            'team_number': 1,
+            'name': 'Team One',
+            'pro_members': [],
+            'college_members': [],
+            'events': {
+                key: {'result': 20.0, 'status': 'completed'}
+                for key in ProAmRelay.RELAY_EVENTS
+            },
+            'total_time': 80.0,
+        }],
+    }
+    relay._save_relay_data()
+
+    fresh = RelayTeam.query.filter_by(relay_state_id=state.id, team_number=1).one()
+    assert fresh.payout_settled is True
+
+
+def test_relay_resave_resets_settlement_when_roster_changes(db_session):
+    tournament = make_tournament(db_session)
+    _, state, first, _ = _completed_relay(db_session, tournament)
+    replacement = make_pro_competitor(db_session, tournament, 'Replacement Pro')
+    first.payout_settled = True
+    db_session.commit()
+
+    relay = ProAmRelay(tournament)
+    relay.relay_data = {
+        'status': 'completed',
+        'teams': [{
+            'team_number': 1,
+            'name': 'Team One',
+            'pro_members': [{'id': replacement.id}],
+            'college_members': [],
+            'events': {
+                key: {'result': 20.0, 'status': 'completed'}
+                for key in ProAmRelay.RELAY_EVENTS
+            },
+            'total_time': 80.0,
+        }],
+    }
+    relay._save_relay_data()
+
+    fresh = RelayTeam.query.filter_by(relay_state_id=state.id, team_number=1).one()
+    assert fresh.payout_settled is False
+
+
+def test_report_includes_relay_rows_and_toggle_settles_team(auth_client, db_session):
+    tournament = make_tournament(db_session)
+    _, _, _, payable_team = _completed_relay(db_session, tournament)
+    db.session.commit()
+
+    page = auth_client.get(f'/reporting/{tournament.id}/pro/payouts')
+    assert page.status_code == 200
+    assert b'Pro-Am Relay Team Payouts' in page.data
+    assert b'Team Two' in page.data
+    assert b'$500.00' in page.data
+
+    printable = auth_client.get(f'/reporting/{tournament.id}/pro/payouts/print')
+    assert printable.status_code == 200
+    assert b'Pro-Am Relay Team Payouts' in printable.data
+
+    ops_dashboard = auth_client.get(f'/tournament/{tournament.id}/ops-dashboard')
+    assert ops_dashboard.status_code == 200
+    assert b'$750.00' in ops_dashboard.data
+
+    response = auth_client.post(
+        f'/tournament/{tournament.id}/proam-relay/team/{payable_team.id}/toggle-settled',
+        headers={'X-Requested-With': 'XMLHttpRequest'},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {'ok': True, 'settled': True}
+    assert db.session.get(RelayTeam, payable_team.id).payout_settled is True
+
+    state = RelayState.query.filter_by(event_id=payable_team.relay_state.event_id).one()
+    state.status = 'in_progress'
+    db.session.commit()
+
+    response = auth_client.post(
+        f'/tournament/{tournament.id}/proam-relay/team/{payable_team.id}/toggle-settled',
+        headers={'X-Requested-With': 'XMLHttpRequest'},
+    )
+
+    assert response.status_code == 404

--- a/tests/test_route_smoke.py
+++ b/tests/test_route_smoke.py
@@ -51,6 +51,7 @@ def _seed_minimal_smoke_data(app):
     and one EventResult for settlement-toggle routes.
     """
     from database import db as _db
+    from models.relay import RelayState, RelayTeam, RelayTeamEvent
     from models.user import User
     from tests.conftest import (
         make_college_competitor,
@@ -92,11 +93,35 @@ def _seed_minimal_smoke_data(app):
             _db.session, tournament, name="Birling", event_type="college",
             gender="M", scoring_type="bracket", stand_type="birling",
         )
-        # Pro-Am Relay event needed for relay_payouts routes (they 404 without it)
-        make_event(
+        # Relay payout routes require a final, payable relay team rather than
+        # the generic college Team record used by other routes.
+        relay_event = make_event(
             _db.session, tournament, name="Pro-Am Relay", event_type="pro",
-            scoring_type="time", stand_type="underhand",
+            scoring_type="time", stand_type="underhand", payouts={"1": 100.0},
         )
+        relay_state = RelayState(event_id=relay_event.id, status="completed")
+        _db.session.add(relay_state)
+        _db.session.flush()
+        relay_team = RelayTeam(
+            relay_state_id=relay_state.id,
+            team_number=1,
+            name="Smoke Relay Team",
+            total_time=100.0,
+        )
+        _db.session.add(relay_team)
+        _db.session.flush()
+        for event_key in (
+            "partnered_sawing",
+            "standing_butcher_block",
+            "underhand_butcher_block",
+            "team_axe_throw",
+        ):
+            _db.session.add(RelayTeamEvent(
+                relay_team_id=relay_team.id,
+                event_key=event_key,
+                result=25.0,
+                status="completed",
+            ))
         make_heat(_db.session, event, heat_number=1, competitors=[pro.id])
         # EventResult needed for toggle_settlement route
         make_event_result(
@@ -169,6 +194,7 @@ def smoke_env(monkeypatch):
     with app.app_context():
         from models import Event, EventResult, Heat, Team, Tournament, User
         from models.competitor import CollegeCompetitor, ProCompetitor
+        from models.relay import RelayTeam
 
         first_tournament = Tournament.query.order_by(Tournament.id).first()
         first_event = Event.query.order_by(Event.id).first()
@@ -182,6 +208,7 @@ def smoke_env(monkeypatch):
         # Route-specific event lookups (some routes 404 on wrong event type)
         partnered_event = Event.query.filter_by(is_partnered=True).order_by(Event.id).first()
         relay_event = Event.query.filter_by(name="Pro-Am Relay").order_by(Event.id).first()
+        relay_team = RelayTeam.query.order_by(RelayTeam.id).first()
 
         ids = {
             "tournament_id": first_tournament.id,
@@ -200,6 +227,7 @@ def smoke_env(monkeypatch):
             "partnered_event_id": partnered_event.id if partnered_event else None,
             "relay_event_id": relay_event.id if relay_event else None,
             "relay_tournament_id": relay_event.tournament_id if relay_event else None,
+            "relay_team_id": relay_team.id if relay_team else None,
             "result_id": first_result.id if first_result else None,
             "flight_id": None,
             "job_id": None,
@@ -241,6 +269,7 @@ def _build_path(rule: str, ids: dict[str, object]) -> str:
     tournament_id = ids["tournament_id"]
     competitor_id = ids["competitor_id"]
     competitor_type = ids["competitor_type"]
+    team_id = ids["team_id"]
 
     if "/birling" in rule and ids["birling_event_id"] is not None:
         event_id = ids["birling_event_id"]
@@ -248,6 +277,8 @@ def _build_path(rule: str, ids: dict[str, object]) -> str:
         event_id = ids["partnered_event_id"]
     if "/proam-relay/payouts" in rule and ids.get("relay_tournament_id") is not None:
         tournament_id = ids["relay_tournament_id"]
+    if "/proam-relay/team/" in rule:
+        team_id = ids["relay_team_id"]
     if "/delete-heat/" in rule:
         event_id = ids["heat_event_id"]
     if "/pro/" in rule:
@@ -266,7 +297,7 @@ def _build_path(rule: str, ids: dict[str, object]) -> str:
         "<int:heat_id>": str(ids["heat_id"]),
         "<int:source_heat_id>": str(ids["heat_id"]),
         "<int:user_id>": str(ids["user_id"]),
-        "<int:team_id>": str(ids["team_id"]) if ids["team_id"] is not None else "",
+        "<int:team_id>": str(team_id) if team_id is not None else "",
         "<int:competitor_id>": str(competitor_id) if competitor_id is not None else "",
         "<int:flight_id>": str(ids["flight_id"]) if ids["flight_id"] is not None else "",
         "<int:result_id>": str(ids["result_id"]) if ids.get("result_id") is not None else "",
@@ -312,6 +343,8 @@ def _should_skip(rule: str, ids: dict[str, object]) -> str | None:
         return "no partnered event exists in Phase 0B database state"
     if "/proam-relay/payouts" in rule and ids.get("relay_event_id") is None:
         return "no Pro-Am Relay event exists in Phase 0B database state"
+    if "/proam-relay/team/" in rule and ids.get("relay_team_id") is None:
+        return "no final Pro-Am Relay team exists in Phase 0B database state"
 
     # Generic backstop.  _build_path resolves parameters through a fixed
     # lookup table, so any route carrying a parameter name that is not in that


### PR DESCRIPTION
## Summary
- add final Relay team placement payouts from the existing placement schedule
- show and settle Relay team awards in the payout and printable reports
- include Relay awards in race-day payout totals
- preserve a paid flag only when a Relay team keeps the same roster

## Verification
- pytest targeted Relay, settlement, report, and dashboard coverage: 168 passed
- ruff check on changed Python modules: passed