### PR TITLE
Make show generation fail closed and atomic

### DIFF
--- a/docs/DOMAIN_CONTRACT.md
+++ b/docs/DOMAIN_CONTRACT.md
@@ -59,7 +59,11 @@ Allowed partner-event shapes:
 - Jack and Jill: mixed-gender saw pair.
 - Double Buck: same-event saw pair; gender rules come from event config.
 - Partnered Axe Throw: managed by its dedicated prelim/final state machine, not
-  standard heat generation.
+  standard heat generation. Its authoritative pairs live in `Event.event_state`;
+  competitor partner fields are not a duplicate source of truth. Preflight must
+  prove that every entered competitor appears in exactly one state-machine pair,
+  every pair has a prelim score, and the finalists have been advanced before a
+  show card is built.
 - College partnered events: same enforcement standard as pro partnered events.
 
 ## Heat Generation
@@ -70,11 +74,22 @@ Heat generation owns event-level placement only. It must:
 - Respect event-specific capacity.
 - Use ability ordering before resource spreading when rankings exist.
 - Keep reciprocal partner units together as one stand unit.
-- Hold back invalid partnered entrants instead of placing them solo.
-- Write `Heat.competitors`, stand assignments, and `HeatAssignment` rows in sync.
+- Reject generation when a partnered entrant is invalid; do not publish a
+  partial event or show with that entrant omitted or placed solo.
+- Keep every competitor or partnered unit that shares the same declared gear in
+  a different heat. Expand the heat count when needed rather than forcing a
+  same-heat conflict.
+- Treat `HeatAssignment` as the authoritative roster and stand-assignment store;
+  use the `Heat` roster APIs rather than writing a second representation.
+- For dual-run events, assign every entrant to a different physical stand or
+  course in run 2, including a one-person heat.
 
-If code updates `Heat.competitors` directly, it must sync `HeatAssignment` before
-the state is considered valid.
+Generation must prove that every eligible entrant can be placed without a
+same-heat gear conflict before replacing an existing schedule. If event-specific
+constraints make a valid placement impossible, it fails without mutating the
+current heats. Direct event generation validates declarations relevant to the
+event and its gear family; malformed declarations for unrelated events remain a
+Preflight concern and do not block the current event.
 
 ## Flight Generation
 
@@ -134,18 +149,37 @@ Springboard rule:
 
 - Left-handed springboard cutters use the configured left-handed dummy stand.
 - The generator spreads left-handed cutters before the general fill.
-- Overflow is allowed only with an explicit operator warning.
+- The generator adds heats until no heat needs the left-handed dummy more than
+  once. It fails before replacement if the configured stand set cannot support
+  that layout.
 
 ## Preflight And Blocking
 
 Preflight is a safety gate, not a substitute for service-layer validation.
 
+Every synchronous and background full-show build runs a fresh pre-generation
+preflight while holding the schedule-writer lock. The pre-generation phase
+checks configured inputs; it must not treat not-yet-generated flights, relay,
+spillover, or saw blocks as input blockers. After generation, the same build
+validates the completed show before its one final commit. A failure in any phase
+rolls the entire request back.
+
 Blocking for generation:
 
 - Partnered-event blank, unresolved, self-reference, or nonreciprocal pairs.
+- Partnered Axe state that has missing/duplicate entrants, incomplete prelims,
+  or no confirmed finals bracket.
+- Invalid, unknown, self-referential, or unmapped gear-sharing declarations.
 - Invalid event capacity.
 - Missing required event configuration.
-- Heat/assignment sync corruption that would make printouts or scoring wrong.
+- Any placement that would put competitors sharing declared gear in the same
+  heat.
+- Generated-show corruption that would make printouts or scoring wrong.
+
+Completed Partnered Axe prelim rows are qualifier evidence, not immutable finals
+history. A first finals-card build may replace the preliminary show heats. Once a
+final score exists, a finals heat is completed, or the state reaches `completed`,
+the finals card is protected like every other scored event.
 
 Warning-only:
 

--- a/docs/HEAT_FLIGHT_AUDIT.md
+++ b/docs/HEAT_FLIGHT_AUDIT.md
@@ -60,7 +60,7 @@
 1. Competitors are sorted by **ProEventRank** ability ranking (rank 1 = best) via `_sort_by_ability()`. Unranked competitors sort to the end alphabetically. College events and pro events without rankings use registration order.
 2. For **partnered events**, `_build_partner_units()` groups recognized pairs into 2-person units. Units are then re-sorted by composite rank via `_sort_units_by_ability()` (best member's rank drives position).
 3. Units are placed using a snake draft: heat index bounces 0→N→0→N. Direction reverses at each end.
-4. **Gear-sharing conflict avoidance**: first pass tries to find a heat with capacity AND no gear conflict. If all heats conflict or are full, a fallback pass places despite conflict and records the violation for the route to surface as a warning.
+4. **Gear-sharing separation**: placement considers only heats with capacity and no declared gear conflict. College competitors are matched by their bare names rather than team-suffixed display names. When all existing heats conflict, generation expands the heat count and continues the snake draft. It never forces competitors sharing gear into the same heat; an invalid current-event declaration or unsatisfiable event fails before its existing schedule is replaced.
 
 **Springboard variant** (`_generate_springboard_heats`, lines 435-533):
 - Left-handed cutters are placed first into a dedicated heat (heat index 0).
@@ -126,9 +126,9 @@ See the Flight Builder section below.
 
 1. Calls `_get_event_competitors(event)` which re-scans ALL active competitors (not just existing EventResult rows) — catches new registrations.
 2. Creates missing `EventResult` rows for new entrants.
-3. Calls `_delete_event_heats(event.id)` which deletes all HeatAssignment rows then all Heat rows for the event.
-4. Generates new heats from scratch.
-5. Calls `flush()` — does NOT commit. The calling route owns the transaction.
+3. Builds and validates a complete conflict-free placement plan.
+4. Calls `_delete_event_heats(event.id)` only after that plan succeeds, deleting all HeatAssignment rows then all Heat rows for the event.
+5. Writes the new heats and calls `flush()` — it does NOT commit. The calling route owns the transaction.
 
 **Important:** Regeneration preserves EventResult data (scores, marks, positions) but replaces heat assignments. Every generation call joins the
 tournament schedule-writer lock. Standalone and bulk regeneration refuse any
@@ -178,7 +178,7 @@ the sync-check/sync-fix repair path have been removed, so there is no second cop
 
 Default 8 heats per flight. Can be overridden by the judge via `num_flights` form field — `heats_per_flight = ceil(total / num_flights)`.
 
-Partnered Axe Throw heats are inserted AFTER flight creation (one per flight, not counted in the 8-heat cap).
+Partnered Axe Throw heats are inserted AFTER flight creation (one per flight, not counted in the 8-heat cap). Pair coverage, prelim completion, and finalist advancement are validated from `Event.event_state`; ordinary competitor partner fields do not govern this state-machine event. Completed prelim result rows do not protect the first finals-card build, but any finals score, completed finals heat, or completed state does.
 
 #### C. College spillover integration
 
@@ -196,7 +196,12 @@ Partnered Axe Throw heats are inserted AFTER flight creation (one per flight, no
 
 `build_pro_flights()` can still commit when invoked as a standalone service. Every active route that builds the complete Saturday show passes `commit=False` through flight build, relay placement, and college spillover, then commits once after all three phases succeed. A spillover or closer-invariant failure therefore restores the pre-request flight assignments instead of leaving a rebuilt show without mandatory closing heats.
 
-Background builds use the same single-commit sequence. Operator success messages and build-diff snapshots are emitted only after that commit; failure paths roll back and discard success flashes from the failed attempt.
+Synchronous and background full-show builds use the same service sequence: a
+fresh input-phase preflight, heat generation, flight build, Pro-Am Relay,
+college spillover, saw-block assignment, and completed-show validation. They
+commit once after every phase succeeds. Operator success messages and build-diff
+snapshots are emitted only after that commit; any blocker or downstream failure
+rolls the whole build back and discards success messages from the failed attempt.
 
 ---
 
@@ -264,9 +269,10 @@ The only supported day-of competitor movement operation:
 | Rule | Intent | Actual Enforcement |
 |------|--------|--------------------|
 | **Heat size maximum** | Competitors per heat ≤ max_stands | Enforced during generation AND on move/add operations via `_max_per_heat()`. |
+| **Same-heat gear separation** | Every competitor or partnered unit sharing declared gear must run in a different heat | **ENFORCED.** Generation expands heat count instead of forcing a conflict and fails before replacing existing heats if no valid plan exists. Manual move, add, and flight-board drag reject conflicts. |
 | **Gear conflict in destination** | Moving/adding a competitor must not create a shared-gear conflict | **ENFORCED.** Manual move, add, and flight-board drag reject the conflict. |
 | **Cookie Stack / Standing Block shared stands** | Keep an eight-heat separation whenever another heat is available | The flight builder blocks the close placement while alternatives remain; if only conflicts remain, it deliberately schedules sequentially because a flight has one heat per slot. Heat generation is event-local. |
-| **Event.is_finalized guard on regeneration** | Finalized or scored events should not have heats regenerated | **ENFORCED.** Finalized and completed-result events are hard blocks. |
+| **Event.is_finalized guard on regeneration** | Finalized or scored events should not have heats regenerated | **ENFORCED.** Finalized and completed-result events are hard blocks. Partnered Axe prelim results are the deliberate exception until finals scoring starts. |
 | **Heat lock on mutations** | Locked heats should not be mutated by other judges | **ENFORCED** on scratch, add, delete, manual move, and flight-board drag operations. |
 | **HeatAssignment roster authority** | One durable roster source | Generation, move, scratch, add, and scoring readers use normalized rows directly. |
 | **Competitor spacing in college overflow** | College overflow should respect spacing | Implemented in `integrate_college_spillover_into_flights` with MIN_HEAT_SPACING check and fallback. |
@@ -355,7 +361,7 @@ Need to completely redo heat assignments for an event?
 
 ### Regeneration After Scoring
 
-Regeneration of a completed, finalized, or scored event is rejected by both the route and service.
+Regeneration of a completed, finalized, or scored event is rejected by both the route and service. Partnered Axe prelim scores remain mutable qualifier history for the first finals-card build; its card locks as soon as finals scoring or completed finals heat history exists.
 Completed heat placements and EventResult rows remain immutable. Use scratch for no-shows; before
 operations start, use add or move for roster corrections. After a flight starts, manual roster and
 running-order edits are also frozen.

--- a/docs/plans/2026-08-17-fail-closed-show-readiness.md
+++ b/docs/plans/2026-08-17-fail-closed-show-readiness.md
@@ -1,0 +1,264 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+title: Fail-Closed Show Readiness
+date: 2026-08-17
+owner: Codex
+---
+
+# Fail-Closed Show Readiness
+
+## Direction
+
+Make the tournament schedule impossible to report as successfully built when
+partner, gear-sharing, or downstream field-preparation invariants were skipped.
+The implementation must preserve the owner-authored show order and existing
+scored/finalized-history protections.
+
+## Authority
+
+- `docs/DOMAIN_CONTRACT.md` owns the canonical workflow and requires preflight,
+  heat generation, pro flights, relay, spillover, and dependent field-prep in
+  that order.
+- `docs/Alex's Docs/GEAR_SHARING_DOMAIN.md` requires competitors sharing gear
+  to be placed in different heats, including cross-event and multi-person
+  sharing groups.
+- `docs/Alex's Docs/ProAM requirements` owns event format, physical stands,
+  partnered-event, dual-run, relay, and Saturday-spillover rules.
+- `FlightLogic.md` owns flight ordering detail not repeated in the domain
+  contract.
+
+## Product Contract
+
+### In Scope
+
+1. Heat generation expands the heat count when necessary to separate feasible
+   gear-sharing conflicts. It never silently places sharing competitors in the
+   same heat.
+2. When a safe layout cannot be produced, generation raises a structured safety
+   error before deleting or replacing an existing layout.
+3. Partnered-event entrants with blank, unresolved, self-referential,
+   nonreciprocal, or gender-invalid declarations block the affected event. They
+   are not silently held back while the remaining schedule is committed.
+4. Full-show web and background generation use one application service and the
+   same transaction boundary.
+5. Full-show generation runs fresh pre-generation blockers before mutation and
+   validates generated schedule blockers before commit.
+6. Every successful full-show build performs heat generation, pro-flight build,
+   relay placement, college spillover, and saw-block assignment in canonical
+   order.
+7. Operator messages identify blocking issue codes, affected events or people,
+   and the Preflight repair path without exposing raw exception text.
+8. Partnered Axe readiness is evaluated from its state-machine pairs and stages,
+   not duplicate registration partner fields. Prelim result rows permit the
+   first finals-card build; finals scores and completed finals history do not.
+9. Every dual-run entrant changes physical stand or course between runs, even in
+   a one-person heat, and College gear checks use bare names rather than team-
+   suffixed display labels.
+
+### Out Of Scope
+
+- Redesigning free-text gear parsing.
+- Adding an operator override that permits an unsafe schedule.
+- Changing scoring, payouts, event rules, physical stand allocations, or flight
+  ordering policy.
+- Accessing production, private mirror data, or PII.
+- Adding a persisted preflight approval receipt. Every build instead runs a
+  fresh gate against current database state, avoiding stale approvals.
+
+## Key Technical Decisions
+
+### KTD-1: Fresh gate, not a persisted approval
+
+- Decision: full builds evaluate current preflight input blockers immediately
+  after taking the tournament schedule lock.
+- Provenance: user-approved through the standing request to execute repository
+  rules and the canonical domain contract.
+- Rejected alternative: store an operator-approved preflight fingerprint in
+  `Tournament.schedule_config`.
+- Reason: fresh evaluation is stronger, avoids a schema/config lifecycle, and
+  cannot become stale between approval and generation.
+
+### KTD-2: Expand before blocking
+
+- Decision: event-local placement may add heats to separate gear-sharing units,
+  while preserving event capacity, partnered units, ability ordering, slow
+  springboard grouping, and left-handed dummy rules.
+- Provenance: user-directed owner requirements in
+  `docs/Alex's Docs/GEAR_SHARING_DOMAIN.md`.
+- Rejected alternative: retain the current fallback and merely warn after
+  forcing a same-heat conflict.
+- Reason: the warned schedule still violates the operating rule and may be
+  physically unusable.
+
+### KTD-3: One full-build service
+
+- Decision: synchronous and asynchronous full-show entry points delegate to one
+  orchestration service with a single commit.
+- Provenance: user-approved through `docs/DOMAIN_CONTRACT.md` and the request
+  for an ambitious unattended workflow.
+- Rejected alternative: patch every route independently.
+- Reason: independent call chains already drifted; the background path omits
+  saw-block assignment.
+
+### KTD-4: No production-shaped claim from SQLite alone
+
+- Decision: local verification includes focused SQLite tests and every available
+  disposable PostgreSQL CI lane; standard pytest is reported separately from
+  `proam_regression/`.
+- Provenance: user-approved repository validation boundary.
+- Rejected alternative: treat the ordinary green pytest suite as PostgreSQL
+  and private-mirror evidence.
+- Reason: `pytest.ini` excludes `proam_regression/`, and SQLite does not prove
+  PostgreSQL behavior.
+
+## Implementation Units
+
+### U1: Gear-Safe Event Generation
+
+Owned files:
+
+- `services/heat_generator.py`
+- `tests/test_heat_generator.py`
+- `tests/test_heat_gen_integration.py`
+- focused gear-sharing generator tests as needed
+
+Work:
+
+1. Replace forced-conflict fallback placement with deterministic safe heat
+   expansion for standard, saw, and springboard events.
+2. Treat partnered pairs as one placement unit and check gear conflicts between
+   units, never within the pair itself.
+3. Ensure left-handed springboard and slow-heat constraints remain valid when
+   extra heats are required.
+4. Validate the final candidate layout before `_delete_event_heats()`.
+5. Raise `HeatGenerationSafetyError` with actionable, non-sensitive details if
+   the layout remains unsafe or an entrant cannot be represented.
+6. Replace contradictory warning-acceptance tests with fail-closed or expanded-
+   layout assertions.
+
+Red evidence:
+
+- Two sharing competitors on a two-stand event currently rebuild into one heat
+  and log a warning.
+- A larger sharing group can currently be accepted with same-heat conflicts.
+
+Acceptance:
+
+- No generated heat contains a gear-sharing conflict.
+- Every eligible entrant appears exactly once in run 1, except no entrant may be
+  omitted as a successful outcome.
+- Existing layouts survive a failed regeneration unchanged.
+- Dual-run rosters remain mirrored and stand assignments remain valid.
+
+### U2: Shared Full-Show Build And Preflight Gates
+
+Owned files:
+
+- `services/preflight.py`
+- `services/schedule_generation.py`
+- `routes/scheduling/events.py`
+- `routes/scheduling/flights.py`
+- `routes/scheduling/preflight.py`
+- `routes/scheduling/__init__.py` only where route-only orchestration is removed
+- `tests/test_schedule_generation.py`
+- `tests/test_one_click_and_fnf.py`
+- `tests/test_workflow_e2e.py`
+- focused route tests as needed
+
+Work:
+
+1. Split blocking codes into pre-generation input blockers and post-generation
+   schedule blockers while preserving the aggregate `BLOCKING_CODES` contract.
+2. Add a structured readiness exception/result carrying issue codes and concise
+   repair details.
+3. Move route-owned bulk heat orchestration into the schedule-generation
+   service and return a structured summary for UI flashes and background jobs.
+4. Route Run Show, Flights one-click, and asynchronous generation through that
+   same service.
+5. Run saw-block assignment before the service commits.
+6. Roll back the whole build on heat, flight, relay, spillover, saw-block, or
+   post-build readiness failure.
+7. Make background jobs return failure semantics that the polling UI reports as
+   failure, not a successful job with `ok: false` hidden in the payload.
+
+Red evidence:
+
+- `get_blocking_issues()` is not called by generation entry points.
+- background generation omits `assign_saw_blocks()`.
+- unresolved partnered entrants can be held back while the remaining show is
+  committed.
+
+Acceptance:
+
+- All full-build entry points reject the same blockers before mutation.
+- All entry points produce equivalent heats, flights, relay, spillover, and
+  saw-block artifacts for the same fixture.
+- A failure in any phase leaves the pre-request schedule unchanged.
+- Completed/finalized history remains protected and unchanged.
+
+### U3: Operator Surface And Durable Documentation
+
+Owned files:
+
+- `templates/scheduling/events.html`
+- `templates/scheduling/preflight.html`
+- `docs/DOMAIN_CONTRACT.md`
+- `docs/HEAT_FLIGHT_AUDIT.md`
+- `docs/RELEASE_CHECKLIST.md` only if commands or gates change
+- focused presentation/route tests
+
+Work:
+
+1. Present Preflight before Generate in the workflow sequence.
+2. Show a blocking state with a direct repair path and avoid success language
+   when generation was rolled back.
+3. Update audit documentation to remove the intentional forced-conflict and
+   held-back-success behavior.
+4. Document sync/background equivalence and saw-block completion.
+
+Acceptance:
+
+- Buttons and labels match real command behavior.
+- Blocking messages fit mobile and desktop layouts and use existing design
+  tokens/components.
+- No public CDN or new frontend dependency is introduced.
+
+## Verification
+
+### Focused
+
+- Heat generator unit and integration tests.
+- Preflight, schedule-generation, one-click, workflow E2E, route, and operator
+  presentation tests.
+- Regression tests for rollback preserving prior heat/flight state.
+
+### Repository Gates
+
+- `ruff check .`
+- Python 3.10 AST parse for changed Python files.
+- standard `python -m pytest` with an isolated base temp; report explicitly that
+  it excludes `proam_regression/`.
+- `tests/test_postgres_runtime_smoke.py`
+- `tests/test_pg_migration_safety.py`
+- `tests/test_migration_integrity.py::TestMigrationIntegrity`
+- affected disposable PostgreSQL unit tests when the local service is available;
+  otherwise require the repository `unit-postgres` CI job before merge.
+- `git diff --check`.
+
+### Browser QA
+
+- Migrated synthetic database only.
+- Events page and Preflight page at desktop and mobile widths.
+- Confirm blockers prevent generation, success appears only after a clean build,
+  and no console error, overlap, horizontal overflow, or inaccessible action is
+  introduced.
+
+## Shipping Gate
+
+Open a feature PR only after focused and standard local gates pass. Merge only
+after all required GitHub checks pass on the exact head. Because `main`
+auto-deploys to Railway, verify `/health`, one authenticated judge page, and one
+public page after deploy. Do not use production credentials or mutate production
+data during verification.

--- a/routes/scheduling/events.py
+++ b/routes/scheduling/events.py
@@ -19,13 +19,18 @@ from services.flight_builder import (
     lock_tournament_schedule,
     serialize_sqlite_schedule_writer,
 )
+from services.schedule_generation import (
+    ScheduleBuildError,
+    generate_tournament_schedule_artifacts,
+    normalize_flight_sizing_input,
+    schedule_operator_messages,
+)
 
 from . import (
     _build_assignment_details,
     _build_pro_flights_if_possible,
     _build_signup_rows,
     _competitor_entered_event,
-    _generate_all_heats,
     _is_list_only_event,
     _load_competitor_lookup,
     _normalize_name,
@@ -130,7 +135,12 @@ def _resolve_num_flights_from_form(tournament, form):
     return resolved
 
 
-def _handle_event_list_post(tournament, saturday_college_event_ids, generate_event_heats, build_pro_flights, integrate_college_spillover_into_flights):
+def _handle_event_list_post(
+    tournament,
+    saturday_college_event_ids,
+    build_pro_flights,
+    integrate_college_spillover_into_flights,
+):
     """Handle POST actions for event_list: generate_all, rebuild_flights, integrate_spillover.
 
     The active generate/rebuild pipelines flush each scheduling phase and commit
@@ -143,65 +153,43 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
 
     from services.flight_builder import integrate_proam_relay_into_final_flight
 
-    if action in {'generate_all', 'rebuild_flights', 'integrate_spillover'}:
+    if action == 'generate_all':
+        flash_checkpoint = len(session.get('_flashes', []))
+        sizing = normalize_flight_sizing_input(request.form)
+        try:
+            summary = generate_tournament_schedule_artifacts(
+                tournament_id,
+                flight_sizing=sizing,
+            )
+        except ScheduleBuildError as exc:
+            _discard_success_flashes_since(flash_checkpoint)
+            flash(str(exc), 'error')
+        except Exception:
+            db.session.rollback()
+            _discard_success_flashes_since(flash_checkpoint)
+            from flask import current_app
+            current_app.logger.exception(
+                'Run Show generation failed for tournament %s', tournament_id,
+            )
+            flash(
+                'Run Show generation failed and was rolled back. Open '
+                'Preflight to review the show, then run Generate again.',
+                'error',
+            )
+        else:
+            for message in schedule_operator_messages(summary):
+                flash(message['message'], message['category'])
+            flash_spillover_result(summary.get('spillover'))
+            session[f'build_diff_{tournament_id}'] = summary['build_diff']
+            session.modified = True
+            invalidate_tournament_caches(tournament_id)
+        return
+
+    if action in {'rebuild_flights', 'integrate_spillover'}:
         tournament = lock_tournament_schedule(tournament)
     num_flights_override = _resolve_num_flights_from_form(tournament, request.form)
 
-    if action == 'generate_all':
-        flash_checkpoint = len(session.get('_flashes', []))
-        try:
-            _generate_all_heats(tournament, generate_event_heats)
-            raw_sizing_mode = (request.form.get('flight_sizing_mode') or '').strip().lower()
-            if raw_sizing_mode and raw_sizing_mode != 'count':
-                from .flights import _resolve_num_flights_from_persisted_config
-                num_flights_override = _resolve_num_flights_from_persisted_config(tournament)
-            pre_snap = _snapshot_flights(tournament_id)
-            flights = _build_pro_flights_if_possible(
-                tournament,
-                build_pro_flights,
-                num_flights=num_flights_override,
-                commit=False,
-            )
-            relay_result = None
-            integration = None
-            build_diff = None
-            if flights is not None:
-                # Phase 4: relay BEFORE spillover so Chokerman Run 2 closes.
-                relay_result = integrate_proam_relay_into_final_flight(
-                    tournament, commit=False,
-                )
-                integration = integrate_college_spillover_into_flights(
-                    tournament, saturday_college_event_ids, commit=False,
-                )
-                post_snap = _snapshot_flights(tournament_id)
-                build_diff = {
-                    'before_flight_count': len(pre_snap),
-                    'after_flight_count': len(post_snap),
-                    'total_heats': sum(post_snap.values()),
-                }
-            assign_saw_blocks(tournament, commit=False)
-            db.session.commit()
-        except Exception as exc:
-            db.session.rollback()
-            _discard_success_flashes_since(flash_checkpoint)
-            flash(f'Heat/flight generation failed and was rolled back: {exc}', 'error')
-        else:
-            try:
-                if flights is not None:
-                    flash(f'Built {flights} pro flight(s).', 'success')
-                    if relay_result.get('placed'):
-                        flash('Pro-Am Relay placed in the final flight.', 'success')
-                    flash_spillover_result(integration)
-                    session[f'build_diff_{tournament_id}'] = build_diff
-                    session.modified = True
-                invalidate_tournament_caches(tournament_id)
-            except Exception as exc:
-                flash(
-                    f'Schedule was saved, but follow-up housekeeping failed: {exc}',
-                    'warning',
-                )
-
-    elif action == 'rebuild_flights':
+    if action == 'rebuild_flights':
         flash_checkpoint = len(session.get('_flashes', []))
         try:
             pre_snap = _snapshot_flights(tournament_id)
@@ -282,7 +270,6 @@ def _handle_event_list_post(tournament, saturday_college_event_ids, generate_eve
 def event_list(tournament_id):
     """Unified Events & Schedule page — heat status, schedule options, generation actions."""
     from services.flight_builder import build_pro_flights, integrate_college_spillover_into_flights
-    from services.heat_generator import generate_event_heats
 
     tournament = db.get_or_404(Tournament, tournament_id)
     if request.method == 'POST':
@@ -300,9 +287,6 @@ def event_list(tournament_id):
         saturday_college_event_ids = [int(i) for i in saved.get('saturday_college_event_ids', [])]
         _handle_event_list_post(
             tournament, saturday_college_event_ids,
-            lambda event: generate_event_heats(
-                event, allow_flight_replacement=True,
-            ),
             build_pro_flights,
             integrate_college_spillover_into_flights,
         )
@@ -785,7 +769,6 @@ def reset_event_order(tournament_id):
 def _day_schedule_legacy(tournament_id):
     """Legacy day-schedule logic — kept for reference, no longer routed."""
     from services.flight_builder import build_pro_flights, integrate_college_spillover_into_flights
-    from services.heat_generator import generate_event_heats
     from services.schedule_builder import COLLEGE_SATURDAY_PRIORITY, build_day_schedule
 
     tournament = db.get_or_404(Tournament, tournament_id)
@@ -833,22 +816,14 @@ def _day_schedule_legacy(tournament_id):
                     'success'
                 )
         elif action == 'generate_all':
-            _generate_all_heats(
-                tournament,
-                lambda event: generate_event_heats(
-                    event, allow_flight_replacement=True,
-                ),
-            )
-            flights = _build_pro_flights_if_possible(tournament, build_pro_flights)
-            if flights is not None:
-                flash(f'Built {flights} pro flight(s).', 'success')
-                integration = integrate_college_spillover_into_flights(tournament, saved['saturday_college_event_ids'])
-                if integration['integrated_heats'] > 0:
-                    db.session.commit()
-                    flash(
-                        f"Integrated {integration['integrated_heats']} college spillover heat(s) into Saturday flights.",
-                        'success'
-                    )
+            try:
+                summary = generate_tournament_schedule_artifacts(tournament.id)
+            except ScheduleBuildError as exc:
+                flash(str(exc), 'error')
+            else:
+                for message in schedule_operator_messages(summary):
+                    flash(message['message'], message['category'])
+                flash_spillover_result(summary.get('spillover'))
         elif action == 'rebuild_flights':
             flights = _build_pro_flights_if_possible(tournament, build_pro_flights)
             if flights is not None:

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -18,8 +18,34 @@ from services.flight_builder import (
     serialize_sqlite_schedule_writer,
 )
 from services.partner_resolver import _resolve_partner_name_local, lookup_partner_cid
+from services.schedule_generation import (
+    FLIGHT_COUNT_MAX,
+    FLIGHT_COUNT_MIN,
+    FLIGHT_SIZING_DEFAULTS,
+    FLIGHT_SIZING_MODE_COUNT,
+    FLIGHT_SIZING_MODE_MINUTES,
+    MINUTES_PER_FLIGHT_MAX,
+    MINUTES_PER_FLIGHT_MIN,
+    MINUTES_PER_HEAT_MAX,
+    MINUTES_PER_HEAT_MIN,
+    VALID_FLIGHT_SIZING_MODES,
+    ScheduleBuildError,
+    ScheduleReadinessError,
+    generate_tournament_schedule_artifacts,
+    persist_flight_sizing_config,
+    schedule_operator_messages,
+)
+from services.schedule_generation import (
+    compute_num_flights_from_duration as _compute_num_flights_from_duration,
+)
+from services.schedule_generation import (
+    read_flight_sizing_config as _read_flight_sizing_config,
+)
+from services.schedule_generation import (
+    resolve_num_flights as _resolve_num_flights_from_persisted_config,
+)
 
-from . import _build_pro_flights_if_possible, _generate_all_heats, scheduling_bp
+from . import _build_pro_flights_if_possible, scheduling_bp
 from .spillover_feedback import flash_spillover_result, spillover_result_payload
 
 
@@ -48,62 +74,17 @@ def one_click_generate(tournament_id):
     the builder's 8-heats-per-flight default. Without this, ~615 pro heats produced 77
     flights regardless of what the operator picked.
     """
-    from services.flight_builder import (
-        FlightRebuildSafetyError,
-        build_pro_flights,
-        integrate_college_spillover_into_flights,
-        integrate_proam_relay_into_final_flight,
-    )
-    from services.heat_generator import generate_event_heats
-    from services.saw_block_assignment import assign_saw_blocks
-
-    tournament = db.get_or_404(Tournament, tournament_id)
-    tournament = lock_tournament_schedule(tournament)
-
-    db_config = tournament.get_schedule_config() or {}
-    saturday_college_event_ids = [int(i) for i in db_config.get('saturday_college_event_ids', [])]
+    db.get_or_404(Tournament, tournament_id)
 
     flash_checkpoint = len(session.get('_flashes', []))
     try:
-        _generate_all_heats(
-            tournament,
-            lambda event: generate_event_heats(
-                event, allow_flight_replacement=True,
-            ),
-        )
-        # Minutes-mode sizing depends on generated heat count. Resolve after
-        # fresh heat generation so first-use one-click honors persisted config.
-        num_flights_override = _resolve_num_flights_from_persisted_config(tournament)
-        flights_built = _build_pro_flights_if_possible(
-            tournament,
-            build_pro_flights,
-            num_flights=num_flights_override,
-            commit=False,
-        )
-        if flights_built is not None:
-            # Phase 4: Relay BEFORE spillover so Chokerman Run 2 still closes.
-            relay_result = integrate_proam_relay_into_final_flight(
-                tournament, commit=False,
-            )
-            integration = integrate_college_spillover_into_flights(
-                tournament, saturday_college_event_ids, commit=False,
-            )
-            assign_saw_blocks(tournament, commit=False)
-            db.session.commit()
-            flash(f'Built {flights_built} pro flight(s).', 'success')
-            if relay_result.get('placed'):
-                flash('Pro-Am Relay placed in the final flight.', 'success')
-            flash_spillover_result(integration)
-        else:
-            assign_saw_blocks(tournament, commit=False)
-            db.session.commit()
-        log_action('one_click_generate', 'tournament', tournament_id, {
-            'flights_built': flights_built,
-        })
-    except FlightRebuildSafetyError as exc:
-        db.session.rollback()
+        summary = generate_tournament_schedule_artifacts(tournament_id)
+    except ScheduleReadinessError as exc:
         _discard_success_flashes_since(flash_checkpoint)
-        flash(str(exc), 'warning')
+        flash(str(exc), 'error')
+    except ScheduleBuildError as exc:
+        _discard_success_flashes_since(flash_checkpoint)
+        flash(str(exc), 'error')
     except Exception:
         db.session.rollback()
         _discard_success_flashes_since(flash_checkpoint)
@@ -111,7 +92,20 @@ def one_click_generate(tournament_id):
         current_app.logger.exception(
             'One-click generate failed for tournament %s', tournament_id,
         )
-        flash('One-click generate failed and was rolled back. See application logs.', 'error')
+        flash(
+            'One-click generation failed and was rolled back. Open Preflight '
+            'to review the show, then run Generate again.',
+            'error',
+        )
+    else:
+        for message in schedule_operator_messages(summary):
+            flash(message['message'], message['category'])
+        flash_spillover_result(summary.get('spillover'))
+        log_action('one_click_generate', 'tournament', tournament_id, {
+            'flights_built': summary.get('flights'),
+            'generated': summary.get('generated'),
+            'protected': len(summary.get('protected') or []),
+        })
 
     return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
 
@@ -183,109 +177,14 @@ def flight_list(tournament_id):
 # Missoula Pro Am's 60-min flight cadence and 5.5-min avg heat duration.
 # ---------------------------------------------------------------------------
 
-FLIGHT_SIZING_MODE_MINUTES = 'minutes'
-FLIGHT_SIZING_MODE_COUNT = 'count'
-VALID_FLIGHT_SIZING_MODES = {FLIGHT_SIZING_MODE_MINUTES, FLIGHT_SIZING_MODE_COUNT}
-
-FLIGHT_SIZING_DEFAULTS = {
-    'mode': FLIGHT_SIZING_MODE_MINUTES,
-    'target_minutes_per_flight': 60,
-    'minutes_per_heat': 5.5,
-    'num_flights': 4,
-}
-
-FLIGHT_COUNT_MIN = 2
-FLIGHT_COUNT_MAX = 10
-MINUTES_PER_FLIGHT_MIN = 30
-MINUTES_PER_FLIGHT_MAX = 180
-MINUTES_PER_HEAT_MIN = 1.0
-MINUTES_PER_HEAT_MAX = 15.0
-
-
-def _read_flight_sizing_config(tournament):
-    """Return saved flight-sizing config merged over defaults."""
-    cfg = tournament.get_schedule_config() or {}
-    mode = cfg.get('flight_sizing_mode', FLIGHT_SIZING_DEFAULTS['mode'])
-    if mode not in VALID_FLIGHT_SIZING_MODES:
-        mode = FLIGHT_SIZING_DEFAULTS['mode']
-    try:
-        target_minutes = int(cfg.get('target_minutes_per_flight',
-                                     FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']))
-    except (TypeError, ValueError):
-        target_minutes = FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']
-    try:
-        minutes_per_heat = float(cfg.get('minutes_per_heat',
-                                         FLIGHT_SIZING_DEFAULTS['minutes_per_heat']))
-    except (TypeError, ValueError):
-        minutes_per_heat = FLIGHT_SIZING_DEFAULTS['minutes_per_heat']
-    try:
-        saved_num_flights = int(cfg.get('num_flights', FLIGHT_SIZING_DEFAULTS['num_flights']))
-    except (TypeError, ValueError):
-        saved_num_flights = FLIGHT_SIZING_DEFAULTS['num_flights']
-    return {
-        'mode': mode,
-        'target_minutes_per_flight': max(
-            MINUTES_PER_FLIGHT_MIN, min(MINUTES_PER_FLIGHT_MAX, target_minutes),
-        ),
-        'minutes_per_heat': max(
-            MINUTES_PER_HEAT_MIN, min(MINUTES_PER_HEAT_MAX, minutes_per_heat),
-        ),
-        'num_flights': max(FLIGHT_COUNT_MIN, min(FLIGHT_COUNT_MAX, saved_num_flights)),
-    }
-
-
 def _persist_flight_sizing_config(tournament, mode, target_minutes, minutes_per_heat, num_flights):
     """Persist operator's flight sizing choices to schedule_config."""
-    cfg = tournament.get_schedule_config() or {}
-    cfg['flight_sizing_mode'] = mode
-    cfg['target_minutes_per_flight'] = int(target_minutes)
-    cfg['minutes_per_heat'] = float(minutes_per_heat)
-    cfg['num_flights'] = int(num_flights)
-    tournament.set_schedule_config(cfg)
-
-
-def _compute_num_flights_from_duration(total_heats, minutes_per_heat, target_minutes_per_flight):
-    """Derive num_flights from target flight duration.
-
-    Returns a clamped value in [FLIGHT_COUNT_MIN, FLIGHT_COUNT_MAX]. A
-    ``clamped`` flag indicates the ideal calculation exceeded the range so
-    the caller can surface a warning.
-    """
-    import math as _math
-    if total_heats <= 0 or minutes_per_heat <= 0 or target_minutes_per_flight <= 0:
-        return FLIGHT_COUNT_MIN, False
-    ideal = _math.ceil((total_heats * minutes_per_heat) / target_minutes_per_flight)
-    clamped_value = max(FLIGHT_COUNT_MIN, min(FLIGHT_COUNT_MAX, ideal))
-    return clamped_value, clamped_value != ideal
-
-
-def _resolve_num_flights_from_persisted_config(tournament) -> int | None:
-    """Return num_flights from saved schedule_config, honouring the saved mode.
-
-    Mirrors the resolver used by /flights/build POST and the Run Show form, but
-    reads from persisted Tournament.schedule_config instead of request.form. Used
-    by buttons (one-click generate) that don't host the sizing form themselves —
-    without this, the builder's 8-heats-per-flight default produces a flight per
-    8 heats no matter what the operator chose.
-
-    Returns None when there are no pro heats yet or when the saved config can't
-    be resolved, letting the builder fall back to its own default.
-    """
-    sizing = _read_flight_sizing_config(tournament)
-    if sizing['mode'] == FLIGHT_SIZING_MODE_MINUTES:
-        pro_heats = Heat.query.join(Event).filter(
-            Event.tournament_id == tournament.id,
-            Event.event_type == 'pro',
-            Event.name != 'Partnered Axe Throw',
-            Heat.run_number == 1,
-        ).count()
-        if pro_heats <= 0:
-            return None
-        computed, _ = _compute_num_flights_from_duration(
-            pro_heats, sizing['minutes_per_heat'], sizing['target_minutes_per_flight'],
-        )
-        return computed if computed >= 1 else None
-    return sizing['num_flights'] if sizing['num_flights'] >= 1 else None
+    persist_flight_sizing_config(tournament, {
+        'mode': mode,
+        'target_minutes_per_flight': target_minutes,
+        'minutes_per_heat': minutes_per_heat,
+        'num_flights': num_flights,
+    })
 
 
 @scheduling_bp.route('/<int:tournament_id>/flights/build', methods=['GET', 'POST'])

--- a/routes/scheduling/preflight.py
+++ b/routes/scheduling/preflight.py
@@ -116,11 +116,17 @@ def preflight_json(tournament_id):
     saved = tournament.get_schedule_config() or session.get(session_key, {})
     saturday_ids = [int(eid) for eid in saved.get('saturday_college_event_ids', [])]
     report = build_preflight_report(tournament, saturday_ids)
+    pre_generation_blocking = report.get('pre_generation_blocking') or []
+    post_generation_blocking = report.get('post_generation_blocking') or []
     return jsonify({
         'issue_count': report['issue_count'],
         'severity': report['severity'],
         'has_blockers': report.get('has_blockers', False),
         'blocking_count': len(report.get('blocking') or []),
+        'pre_generation_has_blockers': bool(pre_generation_blocking),
+        'pre_generation_blocking_count': len(pre_generation_blocking),
+        'post_generation_has_blockers': bool(post_generation_blocking),
+        'post_generation_blocking_count': len(post_generation_blocking),
         'issues': [
             {
                 'severity': i['severity'],
@@ -156,9 +162,25 @@ def generation_job_status(tournament_id, job_id):
     job = get_job(job_id)
     if not job or int((job.get('metadata') or {}).get('tournament_id', -1)) != tournament_id:
         return json.dumps({'error': 'Job not found.'}), 404, {'Content-Type': 'application/json'}
+    status = job['status']
+    result = job['result']
+    error = job['error']
+    # Defensive compatibility for a queued job from an older process that
+    # returned ``ok: false`` instead of raising. New full-show jobs raise a
+    # ScheduleBuildError and are persisted as failed by background_jobs.
+    if (
+        status == 'completed'
+        and isinstance(result, dict)
+        and result.get('ok') is False
+    ):
+        status = 'failed'
+        error = (
+            result.get('message')
+            or 'Schedule generation failed. Open Preflight and run Generate again.'
+        )
     return json.dumps({
         'job_id': job['id'],
-        'status': job['status'],
-        'result': job['result'],
-        'error': job['error'],
+        'status': status,
+        'result': result,
+        'error': error,
     }), 200, {'Content-Type': 'application/json'}

--- a/services/heat_generator.py
+++ b/services/heat_generator.py
@@ -4,6 +4,7 @@ Adapted from STRATHEX tournament_ui.py patterns.
 """
 import logging
 import math
+from collections import Counter
 from functools import wraps
 
 import config
@@ -12,7 +13,15 @@ from config import event_rank_category as _rank_category_for_event
 from database import db
 from models import Event, EventResult, Heat, HeatAssignment
 from models.competitor import CollegeCompetitor, ProCompetitor
-from services.gear_sharing import competitors_share_gear_for_event
+from services.gear_sharing import (
+    competitors_share_gear_for_event,
+    event_matches_gear_key,
+    get_family_events,
+    infer_equipment_categories,
+    normalize_event_text,
+    normalize_person_name,
+    strip_using_prefix,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,25 +33,20 @@ logger = logging.getLogger(__name__)
 LH_SPRINGBOARD_STAND = 4
 # LIST_ONLY_EVENT_NAMES and _rank_category_for_event imported from config above.
 
-# Per-event gear-sharing violation log populated by the snake-draft fallbacks.
-# Routes call get_last_gear_violations(event.id) after generate_event_heats() to
-# surface a warning flash to the judge (gear audit fix G2/G3 — 2026-04-07).
+# Compatibility cache for routes that still ask about the old warning-only
+# fallback. Successful generation now guarantees this cache remains empty.
 _last_gear_violations: dict[int, list[dict]] = {}
 
-# Per-event left-handed springboard overflow log, populated by
-# _generate_springboard_heats() when LH cutter count exceeds heat count.
-# Separate from gear violations because the remediation is different
-# (reconfigure field sizes vs. rebuild gear pairs).
+# Compatibility cache for the old left-handed overflow warning. Springboard
+# generation now expands to one left-handed cutter per heat instead.
 _last_lh_overflow_warnings: dict[int, list[dict]] = {}
 
 # Per-event unpaired-partnered-competitor log, populated by
 # _build_partner_units() when a partnered-event entrant cannot be paired
 # (partner_name blank, unresolved against the event pool, self-reference, or
 # nonreciprocal).
-# When skip_unpaired=True (default) these competitors are HELD BACK from heat
-# generation rather than placed solo on a stand. Routes call
-# get_last_unpaired_partnered() after generate_event_heats() to surface a
-# warning flash + Preflight resolution prompt.
+# Generation records these details and raises HeatGenerationSafetyError before
+# replacing the existing layout.
 _last_unpaired_partnered: dict[int, list[dict]] = {}
 
 # Per-event log of entrants dropped by the gendered-event filter in
@@ -131,16 +135,12 @@ def assert_heat_regeneration_safe(
 
 
 def get_last_gear_violations(event_id: int) -> list[dict]:
-    """Return the gear-sharing violations recorded by the most recent
-    generate_event_heats(event) call for this event_id, or an empty list."""
+    """Return legacy warning details; safe successful generation leaves none."""
     return list(_last_gear_violations.get(event_id, []))
 
 
 def get_last_lh_overflow_warnings(event_id: int) -> list[dict]:
-    """Return the left-handed springboard overflow warnings recorded by the
-    most recent generate_event_heats(event) call for this event_id, or an
-    empty list.  Each entry is a dict with keys type, heat_index,
-    overflow_count, overflow_names."""
+    """Return legacy LH warnings; safe generation expands instead."""
     return list(_last_lh_overflow_warnings.get(event_id, []))
 
 
@@ -200,6 +200,327 @@ def _sort_by_ability(competitors: list, event: Event) -> list:
     )
 
 
+def _effective_heat_capacity(
+    event: Event,
+    configured_capacity: int,
+    stand_numbers: list[int],
+) -> int:
+    """Return the number of stand units that can physically run in one heat."""
+    capacity = configured_capacity
+    if stand_numbers:
+        capacity = min(capacity, len(stand_numbers))
+    if getattr(event, 'stand_type', None) == 'saw_hand':
+        capacity = min(capacity, 4)
+    return capacity
+
+
+def _format_candidate_names(entries: list[dict], *, limit: int = 5) -> str:
+    names = [str(entry.get('name') or entry.get('comp_name') or '').strip()
+             for entry in entries]
+    names = [name for name in names if name]
+    summary = ', '.join(names[:limit])
+    if len(names) > limit:
+        summary += f' (+{len(names) - limit} more)'
+    return summary or 'the affected entrants'
+
+
+def _event_and_gear_family(event: Event) -> list[Event]:
+    all_events = _get_tournament_events(event)
+    return [event, *get_family_events(event, all_events)]
+
+
+def _unmapped_key_targets_event(raw_key: str, relevant_events: list[Event]) -> bool:
+    """Recognize a mistyped current-event key without gating unrelated keys."""
+    normalized_key = normalize_event_text(raw_key)
+    if (
+        not normalized_key
+        or normalized_key.isdigit()
+        or len(normalized_key) < 4
+    ):
+        return False
+    for candidate in relevant_events:
+        for label in (candidate.name, candidate.display_name):
+            normalized_label = normalize_event_text(label)
+            if (
+                len(normalized_label) >= 4
+                and (
+                    normalized_label in normalized_key
+                    or normalized_key in normalized_label
+                )
+            ):
+                return True
+    return False
+
+
+def _free_text_targets_event(details: str, relevant_events: list[Event]) -> bool:
+    normalized_details = normalize_event_text(details)
+    for candidate in relevant_events:
+        labels = {
+            normalize_event_text(candidate.name),
+            normalize_event_text(candidate.display_name),
+        }
+        if any(label and len(label) >= 4 and label in normalized_details for label in labels):
+            return True
+    return any(
+        event_matches_gear_key(candidate, f'category:{category}')
+        for category in infer_equipment_categories(details)
+        for candidate in relevant_events
+    )
+
+
+def _validate_event_gear_declarations(
+    event: Event,
+    competitors: list[dict],
+) -> None:
+    """Reject incomplete declarations that could hide a current-event conflict."""
+    relevant_events = _event_and_gear_family(event)
+    model = CollegeCompetitor if event.event_type == 'college' else ProCompetitor
+    known_names = {
+        normalize_person_name(comp.name)
+        for comp in model.query.filter_by(
+            tournament_id=event.tournament_id,
+            status='active',
+        ).all()
+    }
+    invalid = []
+
+    for competitor in competitors:
+        sharing = competitor.get('gear_sharing') or {}
+        details = str(competitor.get('gear_sharing_details') or '').strip()
+        if details and not sharing and _free_text_targets_event(details, relevant_events):
+            invalid.append(competitor)
+            continue
+
+        self_name = normalize_person_name(
+            competitor.get('base_name') or competitor.get('name') or ''
+        )
+        for key, raw_partner in sharing.items():
+            key_matches = any(
+                event_matches_gear_key(candidate, key)
+                for candidate in relevant_events
+            )
+            if not key_matches:
+                if _unmapped_key_targets_event(key, relevant_events):
+                    invalid.append(competitor)
+                    break
+                continue
+
+            partner_text = str(raw_partner or '').strip()
+            if partner_text.lower().startswith('group:'):
+                continue
+            partner_name = strip_using_prefix(partner_text)
+            partner_norm = normalize_person_name(partner_name)
+            if (
+                not partner_norm
+                or partner_norm == self_name
+                or partner_norm not in known_names
+            ):
+                invalid.append(competitor)
+                break
+
+    if invalid:
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: a gear declaration '
+            f'is incomplete or does not map to this event '
+            f'({_format_candidate_names(invalid)}). Resolve it in Preflight; the '
+            'previous heat layout was preserved.'
+        )
+
+
+def _validate_candidate_layout(
+    event: Event,
+    competitors: list[dict],
+    heats: list[list[dict]],
+    max_units_per_heat: int,
+    stand_numbers: list[int],
+    *,
+    unpaired_log: list[dict] | None = None,
+) -> None:
+    """Reject any candidate that cannot safely represent the event roster."""
+    unpaired = list(unpaired_log or [])
+    if unpaired:
+        _last_unpaired_partnered[event.id] = unpaired
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: partnered '
+            f'entrants are not represented ({_format_candidate_names(unpaired)}). '
+            'Resolve partner declarations in Preflight before regenerating.'
+        )
+
+    gender_excluded = list(_last_gender_excluded.get(event.id, []))
+    if gender_excluded:
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: entered '
+            f'competitors do not match the event gender '
+            f'({_format_candidate_names(gender_excluded)}). Correct the entries '
+            'before regenerating.'
+        )
+
+    if not heats or any(not heat for heat in heats):
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: the candidate '
+            'contains an empty or missing heat. Correct the roster before regenerating.'
+        )
+
+    expected = Counter(comp.get('id') for comp in competitors)
+    represented = Counter(comp.get('id') for heat in heats for comp in heat)
+    missing_ids = sorted(comp_id for comp_id in expected if represented[comp_id] == 0)
+    duplicate_ids = sorted(comp_id for comp_id, count in represented.items() if count != 1)
+    unexpected_ids = sorted(comp_id for comp_id in represented if comp_id not in expected)
+    if missing_ids or duplicate_ids or unexpected_ids or represented != expected:
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: every eligible '
+            'entrant must appear exactly once in run 1. The previous heat layout '
+            'was preserved.'
+        )
+
+    is_partnered = bool(getattr(event, 'is_partnered', False))
+    for heat_index, heat in enumerate(heats):
+        units = _rebuild_pair_units(heat, event)
+        if len(units) > max_units_per_heat:
+            raise HeatGenerationSafetyError(
+                f'Heat generation blocked for {event.display_name}: candidate '
+                f'heat {heat_index + 1} exceeds its physical stand capacity.'
+            )
+        if is_partnered and any(len(unit) != 2 for unit in units):
+            raise HeatGenerationSafetyError(
+                f'Heat generation blocked for {event.display_name}: candidate '
+                f'heat {heat_index + 1} contains an incomplete partner unit.'
+            )
+        partner_gender = getattr(event, 'partner_gender_requirement', None)
+        if is_partnered and partner_gender in {'mixed', 'same'}:
+            invalid_gender_unit = any(
+                (partner_gender == 'mixed' and unit[0].get('gender') == unit[1].get('gender'))
+                or (partner_gender == 'same' and unit[0].get('gender') != unit[1].get('gender'))
+                for unit in units
+            )
+            if invalid_gender_unit:
+                requirement = (
+                    'mixed-gender' if partner_gender == 'mixed' else 'same-gender'
+                )
+                raise HeatGenerationSafetyError(
+                    f'Heat generation blocked for {event.display_name}: candidate '
+                    f'heat {heat_index + 1} violates the {requirement} partner '
+                    'rule. The previous heat layout was preserved.'
+                )
+
+        for left_index, left_unit in enumerate(units):
+            for right_unit in units[left_index + 1:]:
+                conflict = any(
+                    _competitors_share_gear_for_event(left, right, event)
+                    for left in left_unit
+                    for right in right_unit
+                )
+                if conflict:
+                    raise HeatGenerationSafetyError(
+                        f'Heat generation blocked for {event.display_name}: '
+                        f'candidate heat {heat_index + 1} contains a gear-sharing '
+                        'conflict. The previous heat layout was preserved.'
+                    )
+
+        if getattr(event, 'stand_type', None) == 'springboard':
+            left_handed = [comp for comp in heat if comp.get('is_left_handed')]
+            if len(left_handed) > 1:
+                raise HeatGenerationSafetyError(
+                    f'Heat generation blocked for {event.display_name}: candidate '
+                    f'heat {heat_index + 1} requires the left-handed dummy more '
+                    'than once.'
+                )
+
+    if (
+        getattr(event, 'stand_type', None) == 'springboard'
+        and any(comp.get('is_left_handed') for comp in competitors)
+        and LH_SPRINGBOARD_STAND not in stand_numbers
+    ):
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: stand '
+            f'{LH_SPRINGBOARD_STAND}, the left-handed dummy, is not configured '
+            'for this event.'
+        )
+
+
+def _run_one_stands(
+    event: Event,
+    heat_competitors: list[dict],
+    stand_numbers: list[int],
+) -> dict[int, int]:
+    """Build validated run-one stand assignments for one candidate heat."""
+    if getattr(event, 'is_partnered', False):
+        stands = {}
+        for stand_idx, unit in enumerate(_rebuild_pair_units(heat_competitors, event)):
+            stand_num = stand_numbers[stand_idx]
+            for comp in unit:
+                stands[comp['id']] = stand_num
+        return stands
+
+    if getattr(event, 'stand_type', None) == 'springboard':
+        left_handed = next(
+            (comp for comp in heat_competitors if comp.get('is_left_handed')),
+            None,
+        )
+        if left_handed is not None:
+            stands = {left_handed['id']: LH_SPRINGBOARD_STAND}
+            right_handed_stands = [
+                stand for stand in stand_numbers
+                if stand != LH_SPRINGBOARD_STAND
+            ]
+            right_handed = [
+                comp for comp in heat_competitors
+                if comp['id'] != left_handed['id']
+            ]
+            stands.update({
+                comp['id']: right_handed_stands[index]
+                for index, comp in enumerate(right_handed)
+            })
+            return stands
+
+    return {
+        comp['id']: stand_numbers[index]
+        for index, comp in enumerate(heat_competitors)
+    }
+
+
+def _build_candidate_heat_rows(
+    event: Event,
+    heats: list[list[dict]],
+    stand_numbers: list[int],
+) -> list[Heat]:
+    """Build every Heat and HeatAssignment row before replacing stored heats."""
+    candidate_rows = []
+    for heat_num, heat_competitors in enumerate(heats, start=1):
+        heat = Heat(event_id=event.id, heat_number=heat_num, run_number=1)
+        competitor_ids = [comp['id'] for comp in heat_competitors]
+        heat.set_roster(
+            event.event_type,
+            competitor_ids,
+            _run_one_stands(event, heat_competitors, stand_numbers),
+        )
+        candidate_rows.append(heat)
+
+    if not event.requires_dual_runs:
+        return candidate_rows
+
+    for heat_num, heat_competitors in enumerate(heats, start=1):
+        heat = Heat(event_id=event.id, heat_number=heat_num, run_number=2)
+        competitor_ids = [comp['id'] for comp in heat_competitors]
+        stands = {}
+        if getattr(event, 'is_partnered', False):
+            units = _rebuild_pair_units(heat_competitors, event)
+            reversed_stands = list(reversed(stand_numbers))
+            for unit_index, unit in enumerate(units):
+                for comp in unit:
+                    stands[comp['id']] = reversed_stands[unit_index]
+        else:
+            reversed_stands = list(reversed(stand_numbers))
+            stands = {
+                comp['id']: reversed_stands[index]
+                for index, comp in enumerate(heat_competitors)
+            }
+        heat.set_roster(event.event_type, competitor_ids, stands)
+        candidate_rows.append(heat)
+
+    return candidate_rows
+
+
 @_serialize_schedule_heat_generation
 def generate_event_heats(
     event: Event,
@@ -236,7 +557,19 @@ def generate_event_heats(
         raise HeatGenerationSafetyError(
             f'{event.display_name} is completed. Heat regeneration is blocked.'
         )
-    if EventResult.query.filter_by(event_id=event.id, status='completed').first() is not None:
+    if getattr(event, 'has_prelims', False):
+        from services.partnered_axe import partnered_axe_history_protection_reason
+
+        partnered_axe_reason = partnered_axe_history_protection_reason(event)
+        if partnered_axe_reason is not None:
+            raise HeatGenerationSafetyError(
+                f'{event.display_name} has {partnered_axe_reason}. '
+                'Heat regeneration is blocked.'
+            )
+    elif EventResult.query.filter_by(
+        event_id=event.id,
+        status='completed',
+    ).first() is not None:
         raise HeatGenerationSafetyError(
             f'{event.display_name} has scored results. Heat regeneration is blocked.'
         )
@@ -259,6 +592,15 @@ def generate_event_heats(
     # Get competitors for this event
     competitors = _get_event_competitors(event)
 
+    gender_excluded = list(_last_gender_excluded.get(event.id, []))
+    if gender_excluded:
+        raise HeatGenerationSafetyError(
+            f'Heat generation blocked for {event.display_name}: entered '
+            f'competitors do not match the event gender '
+            f'({_format_candidate_names(gender_excluded)}). Correct the entries '
+            'before regenerating.'
+        )
+
     if not competitors:
         raise ValueError(f"No competitors entered for {event.display_name}")
 
@@ -279,6 +621,8 @@ def generate_event_heats(
         db.session.flush()
         return 0
 
+    _validate_event_gear_declarations(event, competitors)
+
     # Get stand configuration; event.max_stands is authoritative when set
     stand_config = config.STAND_CONFIGS.get(event.stand_type, {})
     max_per_heat = event.max_stands if event.max_stands is not None else stand_config.get('total', 4)
@@ -288,247 +632,72 @@ def generate_event_heats(
             'Set max_stands to at least 1 before generating heats.'
         )
     max_per_heat = int(max_per_heat)
+    stand_numbers = _stand_numbers_for_event(event, max_per_heat, stand_config)
+    effective_capacity = _effective_heat_capacity(
+        event,
+        max_per_heat,
+        stand_numbers,
+    )
+    if effective_capacity <= 0:
+        raise HeatGenerationSafetyError(
+            f'{event.display_name} has no usable stands configured. Configure '
+            'at least one physical stand before generating heats.'
+        )
 
     # Calculate number of heats needed
-    num_heats = math.ceil(len(competitors) / max_per_heat)
+    num_heats = math.ceil(len(competitors) / effective_capacity)
 
-    # The helpers identify constraints they cannot satisfy without placing two
-    # people who share gear in the same heat.  Do this before deleting an
-    # existing layout, so an unsafe regeneration leaves that layout intact.
+    # Helpers expand locally until a gear-safe candidate exists. Build and
+    # validate that candidate before deleting an existing layout.
     gear_violations: list[dict] = []
     _last_gear_violations.pop(event.id, None)
 
-    # Per-event left-handed springboard overflow warnings recorded by
-    # _generate_springboard_heats when LH count > heat count.
+    # Kept for compatibility with the helper signature and route getter.
     lh_warnings: list[dict] = []
     _last_lh_overflow_warnings.pop(event.id, None)
 
     # Per-event unpaired-partnered-competitor list. Populated when a partnered
     # event entrant has a blank, unresolved, self-referential, or nonreciprocal
     # partner_name.
-    # Held-back competitors are excluded from heats so a partnered event never
-    # has a solo person on a stand. Surfaced via flash + Preflight.
+    # The final candidate validator treats any entry here as a hard blocker.
     unpaired_log: list[dict] = []
     _last_unpaired_partnered.pop(event.id, None)
 
     # Apply special constraints
     if event.stand_type == 'springboard':
-        heats = _generate_springboard_heats(competitors, num_heats, max_per_heat, stand_config, event=event,
+        heats = _generate_springboard_heats(competitors, num_heats, effective_capacity, stand_config, event=event,
                                             gear_violations=gear_violations,
                                             lh_warnings=lh_warnings)
     elif event.stand_type in ['saw_hand']:
-        heats = _generate_saw_heats(competitors, num_heats, max_per_heat, stand_config, event=event,
+        heats = _generate_saw_heats(competitors, num_heats, effective_capacity, stand_config, event=event,
                                     gear_violations=gear_violations,
                                     unpaired_log=unpaired_log)
     else:
-        heats = _generate_standard_heats(competitors, num_heats, max_per_heat, event=event,
+        heats = _generate_standard_heats(competitors, num_heats, effective_capacity, event=event,
                                          gear_violations=gear_violations,
                                          unpaired_log=unpaired_log)
 
-    forced_conflicts: list[dict] = []
-    if gear_violations:
-        forced_conflicts = [v for v in gear_violations if not v.get('reason')]
-        unplaced = [v for v in gear_violations if v.get('reason')]
-        if unplaced:
-            names = ', '.join(v.get('comp_name', '') for v in unplaced[:5])
-            extra = f' (+{len(unplaced) - 5} more)' if len(unplaced) > 5 else ''
-            raise HeatGenerationSafetyError(
-                f'Heat generation blocked for {event.display_name}: no safe '
-                f'springboard capacity for {names}{extra}. Resolve the roster '
-                'before regenerating.'
-            )
+    _validate_candidate_layout(
+        event,
+        competitors,
+        heats,
+        effective_capacity,
+        stand_numbers,
+        unpaired_log=unpaired_log,
+    )
+    # Build every HeatAssignment row while the stored layout still exists. Any
+    # invalid identity or stand mapping therefore fails before replacement.
+    candidate_heats = _build_candidate_heat_rows(event, heats, stand_numbers)
 
     # No safety blocker remains, so replacing the current layout is safe.
     _delete_event_heats(event.id)
 
     # Use actual heat count returned by the generator (saw events recalculate internally).
     actual_heat_count = len(heats)
-
-    # Validate: every competitor must appear in exactly one heat — UNLESS they
-    # were intentionally held back as an unpaired partnered-event entrant.
-    # Held-back IDs are tracked in unpaired_log so the warning below only fires
-    # for genuine snake-draft / gear-conflict misplacements.
-    placed_ids = {c['id'] for heat_comps in heats for c in heat_comps}
-    held_back_ids = {entry['comp_id'] for entry in unpaired_log}
-    expected_ids = {c['id'] for c in competitors}
-    missing = (expected_ids - placed_ids) - held_back_ids
-    if missing:
-        logger.warning(
-            'heat_generator: %d competitor(s) not placed in any heat for event %r: %s',
-            len(missing), event.display_name, sorted(missing),
-        )
-
-    # Create Heat objects
-    stand_numbers = _stand_numbers_for_event(event, max_per_heat, stand_config)
-    is_partnered = bool(getattr(event, 'is_partnered', False))
-    created_heats = []
-
-    # 'pro' or 'college'.  Hoisted above the build loop because each heat now
-    # writes its roster once, here, instead of writing JSON here and having a
-    # second pass copy it into the rows after the flush.
-    comp_type = event.event_type
-    for heat_num, heat_competitors in enumerate(heats, start=1):
-        heat = Heat(
-            event_id=event.id,
-            heat_number=heat_num,
-            run_number=1
-        )
-        heat_comp_ids = [c['id'] for c in heat_competitors]
-
-        # Stands accumulate in a plain dict and are written once, with the
-        # roster, at the bottom of this block.  They used to be pushed into the
-        # heat one at a time.  That was free while `set_stand_assignment` only
-        # edited a JSON blob, and stops being free the moment a roster write
-        # touches the `heat_assignments` rows: a six-competitor heat would tear
-        # its roster down and rebuild it seven times, once per stand, and
-        # resolve every competitor's uid again on each pass.  Nothing here needs
-        # the intermediate states, so nothing here should be paying for them.
-        stands = {}
-
-        # Assign stands.  For partnered events each PAIR shares one stand —
-        # both partners receive the same stand number.  Non-partnered events
-        # are one competitor per stand as before.
-        if is_partnered:
-            pair_units = _rebuild_pair_units(heat_competitors, event)
-            stand_idx = 0
-            for unit in pair_units:
-                stand_num = stand_numbers[stand_idx] if stand_idx < len(stand_numbers) else stand_idx + 1
-                for comp in unit:
-                    stands[comp['id']] = stand_num
-                stand_idx += 1
-        elif event.stand_type == 'springboard':
-            # Phase 5 rule: Dummy 4 is the LH-configured physical dummy. If any
-            # competitor in this springboard heat is left-handed, they get
-            # stand_number=4; the rest fill the remaining configured stands in
-            # competitor-list order. If no LH cutter is in the heat, fall
-            # through to the default per-index assignment so stand 4 still gets
-            # used.
-            #
-            # The right-handed stands are derived from the event's own stand
-            # list, not hardcoded. The original wrote them as a literal
-            # [1, 2, 3], which is only correct when the event runs exactly four
-            # stands. Measured on a copy of production: event 31, Pro 1-Board,
-            # is configured for five, and generating it with one LH cutter put
-            # competitors 12 and 45 both on stand 4 while stand 5 was never
-            # emitted. Two people to one springboard, and a block sized for five
-            # running four.
-            #
-            # Latent as the data ships, because no pro currently carries the
-            # flag. It arms from a single checkbox on the pro detail form, and
-            # nothing downstream checks for a doubled stand.
-            lh_comp = next((c for c in heat_competitors if c.get('is_left_handed')), None)
-            if lh_comp is not None and LH_SPRINGBOARD_STAND not in stand_numbers:
-                # The venue's left-hand dummy is stand 4. If this event is not
-                # configured to use stand 4 at all (a specific_stands override,
-                # or fewer than four stands), there is no LH dummy to assign and
-                # pinning anyone to it would send them to a stand the event is
-                # not running. Say so and fall through to the plain assignment
-                # rather than silently placing them somewhere wrong.
-                if lh_warnings is not None:
-                    lh_warnings.append({
-                        'type': 'lh_stand_not_in_event_stands',
-                        'heat_index': heat_num - 1,
-                        'lh_names': [lh_comp.get('name', '')],
-                        'event_stands': list(stand_numbers),
-                    })
-                lh_comp = None
-            if lh_comp is not None:
-                # Surface a heat-level warning if the heat has more than one LH
-                # cutter (overflow scenario) — only the first gets stand 4, the
-                # rest fall back to list-order assignment and will physically
-                # collide. This is rare but possible if LH_count > heat_count.
-                lh_comps_in_heat = [c for c in heat_competitors if c.get('is_left_handed')]
-                if len(lh_comps_in_heat) > 1 and lh_warnings is not None:
-                    lh_warnings.append({
-                        'type': 'multiple_lh_same_heat',
-                        'heat_index': heat_num - 1,
-                        'lh_count': len(lh_comps_in_heat),
-                        'lh_names': [c.get('name', '') for c in lh_comps_in_heat],
-                    })
-                # LH cutter goes on the left-hand dummy.
-                stands[lh_comp['id']] = LH_SPRINGBOARD_STAND
-                # Everyone else fills the event's other stands in order. Order
-                # is preserved rather than sorted so the assignment stays the
-                # same as it was for four-stand events, which is the case the
-                # crew has run before.
-                rh_stands = [s for s in stand_numbers if s != LH_SPRINGBOARD_STAND]
-                rh_stand_idx = 0
-                overflow_base = (max(stand_numbers) if stand_numbers
-                                 else LH_SPRINGBOARD_STAND)
-                for comp in heat_competitors:
-                    if comp['id'] == lh_comp['id']:
-                        continue
-                    if rh_stand_idx < len(rh_stands):
-                        stand_num = rh_stands[rh_stand_idx]
-                    else:
-                        # More cutters than the event has stands. The heat is
-                        # already over capacity and the admin has a separate
-                        # problem, but the numbers still have to be distinct:
-                        # the old else-arm here returned the loop index plus
-                        # one, which walks straight back over stands the loop
-                        # had already handed out.
-                        stand_num = (
-                            overflow_base + 1 + (rh_stand_idx - len(rh_stands)))
-                    stands[comp['id']] = stand_num
-                    rh_stand_idx += 1
-            else:
-                # No LH cutter — plain per-index assignment (stand 4 may still
-                # be used by whoever lands in index 3 of heat_competitors).
-                for i, comp in enumerate(heat_competitors):
-                    stand_num = stand_numbers[i] if i < len(stand_numbers) else i + 1
-                    stands[comp['id']] = stand_num
-        else:
-            for i, comp in enumerate(heat_competitors):
-                stand_num = stand_numbers[i] if i < len(stand_numbers) else i + 1
-                stands[comp['id']] = stand_num
-
-        heat.set_roster(comp_type, heat_comp_ids, stands)
-        db.session.add(heat)
-        created_heats.append(heat)
-
-    # For dual-run events, create second run heats
-    if event.requires_dual_runs:
-        for heat_num, heat_competitors in enumerate(heats, start=1):
-            heat = Heat(
-                event_id=event.id,
-                heat_number=heat_num,
-                run_number=2
-            )
-            heat_comp_ids = [c['id'] for c in heat_competitors]
-            stands = {}
-
-            # Swap stand assignments for run 2 (e.g., Course 1 <-> Course 2).
-            # Reverse only the stands actually used by THIS heat, not the full list.
-            if is_partnered:
-                pair_units = _rebuild_pair_units(heat_competitors, event)
-                stands_needed = len(pair_units)
-                run2_stands = list(reversed(stand_numbers[:stands_needed]))
-                for unit_idx, unit in enumerate(pair_units):
-                    s = run2_stands[unit_idx] if unit_idx < len(run2_stands) else unit_idx + 1
-                    for comp in unit:
-                        stands[comp['id']] = s
-                heat.set_roster(comp_type, heat_comp_ids, stands)
-                db.session.add(heat)
-                created_heats.append(heat)
-                continue
-            heat_size = len(heat_competitors)
-            run2_stands = list(reversed(stand_numbers[:heat_size]))
-            for i, comp in enumerate(heat_competitors):
-                stands[comp['id']] = run2_stands[i]
-
-            heat.set_roster(comp_type, heat_comp_ids, stands)
-            db.session.add(heat)
-            created_heats.append(heat)
+    db.session.add_all(candidate_heats)
 
     event.status = 'in_progress'
     db.session.flush()
-
-    # The `for heat in created_heats: heat.sync_assignments(comp_type)` pass
-    # that used to sit here is gone.  Every heat above already wrote its rows
-    # through `set_roster` before it was added to the session, so this loop had
-    # nothing left to copy: it re-read the JSON each heat had just been rendered
-    # from and handed it straight back, for one uid-resolution query per heat.
-    # The flush above is what puts the rows in the table, and it is still here.
 
     # Stock Saw: alternate solo-heat stands across 7 and 8 so consecutive
     # solos don't pile onto the same physical stand. Must run after the flush
@@ -542,9 +711,9 @@ def generate_event_heats(
             idx = w.get('heat_index')
             heat_id = None
             heat_number = None
-            if isinstance(idx, int) and 0 <= idx < len(created_heats):
-                heat_id = created_heats[idx].id
-                heat_number = created_heats[idx].heat_number
+            if isinstance(idx, int) and 0 <= idx < len(candidate_heats):
+                heat_id = candidate_heats[idx].id
+                heat_number = candidate_heats[idx].heat_number
             resolved_lh.append({
                 'type': w.get('type'),
                 'heat_id': heat_id,
@@ -557,30 +726,6 @@ def generate_event_heats(
                 w.get('overflow_count', 0), heat_id,
             )
         _last_lh_overflow_warnings[event.id] = resolved_lh
-
-    # Promote unpaired-partnered competitors so the route can flash + Preflight
-    # can offer a resolution UI. These competitors were intentionally HELD BACK
-    # from heat generation rather than placed solo on a stand. Each entry has:
-    # comp_id, comp_name, partner_name (raw), reason ('blank'|'unresolved'|
-    # 'self_reference'|'nonreciprocal').
-    if unpaired_log:
-        _last_unpaired_partnered[event.id] = list(unpaired_log)
-        for u in unpaired_log:
-            logger.warning(
-                'UNPAIRED PARTNERED ENTRANT: %s (event=%r, partner=%r, reason=%s) '
-                '— held back from heats, resolve in Preflight',
-                u.get('comp_name', ''), event.display_name,
-                u.get('partner_name', ''), u.get('reason', ''),
-            )
-
-    if forced_conflicts:
-        _last_gear_violations[event.id] = list(forced_conflicts)
-        names = ', '.join(v.get('comp_name', '') for v in forced_conflicts[:5])
-        extra = f' (+{len(forced_conflicts) - 5} more)' if len(forced_conflicts) > 5 else ''
-        logger.warning(
-            'FORCED GEAR-SHARING CONFLICT: %s%s (event=%r)',
-            names, extra, event.display_name,
-        )
 
     # Flush but do NOT commit — the calling route owns the transaction boundary and
     # will commit (or roll back) after all scheduling actions are complete.  This
@@ -681,6 +826,7 @@ def _get_event_competitors(event: Event) -> list:
             'gender': comp.gender,
             'is_left_handed': getattr(comp, 'is_left_handed_springboard', False),
             'gear_sharing': comp.get_gear_sharing() if hasattr(comp, 'get_gear_sharing') else {},
+            'gear_sharing_details': getattr(comp, 'gear_sharing_details', ''),
             'partner_name': _get_partner_name_for_event(comp, event)
         }
         if event.event_type == 'pro':
@@ -717,9 +863,8 @@ def _move_partial_heats_to_end(heats: list, sizes: list, max_per_heat: int) -> t
 
     Returns `(reordered_heats, old_to_new)` where `old_to_new[i]` is the new
     index of what used to be heat `i`. Identity mapping when no reorder runs
-    (single heat, all heats the same size, or any heat over capacity — the
-    last case being intentional springboard LH overflow that must stay pinned
-    to the final heat).
+    (single heat, all heats the same size, or any heat over capacity; the final
+    validator reports over-capacity candidates without reordering them first).
 
     Callers MUST use `old_to_new` to remap any side-channel data that carries
     pre-reorder heat indices (gear_violations, lh_warnings) — otherwise those
@@ -751,6 +896,56 @@ def _remap_violation_heat_indices(violations: list | None, old_to_new: dict[int,
             v['heat_index'] = old_to_new[idx]
 
 
+def _try_place_units(
+    units: list[list[dict]],
+    num_heats: int,
+    max_units_per_heat: int,
+    event: Event,
+) -> tuple[list[list[dict]], list[int]] | None:
+    """Try one deterministic snake pass without relaxing gear constraints."""
+    heats = [[] for _ in range(num_heats)]
+    units_used = [0] * num_heats
+    direction = 1
+    heat_idx = 0
+
+    for unit in units:
+        placed = False
+        examined = set()
+        while len(examined) < num_heats:
+            if heat_idx in examined:
+                heat_idx, direction = _advance_snake_index(
+                    heat_idx,
+                    direction,
+                    num_heats,
+                )
+                continue
+            examined.add(heat_idx)
+            has_conflict = any(
+                _has_gear_sharing_conflict(comp, heats[heat_idx], event)
+                for comp in unit
+            )
+            if units_used[heat_idx] < max_units_per_heat and not has_conflict:
+                heats[heat_idx].extend(unit)
+                units_used[heat_idx] += 1
+                placed = True
+                break
+            heat_idx, direction = _advance_snake_index(
+                heat_idx,
+                direction,
+                num_heats,
+            )
+
+        if not placed:
+            return None
+        heat_idx, direction = _advance_snake_index(
+            heat_idx,
+            direction,
+            num_heats,
+        )
+
+    return heats, units_used
+
+
 def _generate_standard_heats(competitors: list, num_heats: int, max_per_heat: int, event: Event = None,
                               gear_violations: list | None = None,
                               unpaired_log: list | None = None) -> list:
@@ -775,85 +970,34 @@ def _generate_standard_heats(competitors: list, num_heats: int, max_per_heat: in
 
     is_partnered = bool(event and getattr(event, 'is_partnered', False))
 
-    # For partnered events, num_heats must be recomputed from unit count:
-    # each pair takes 1 stand (not 2 competitor slots).  For solo events, the
-    # unit count equals the competitor count so this is a no-op.
-    if is_partnered:
-        num_heats = max(1, math.ceil(len(units) / max_per_heat))
+    minimum_heats = max(1, math.ceil(len(units) / max_per_heat))
+    if not is_partnered:
+        minimum_heats = max(minimum_heats, num_heats)
 
-    heats = [[] for _ in range(num_heats)]
-    stands_used = [0] * num_heats  # count of stands (units) per heat
+    # One unit per heat is always safe because gear is checked between units,
+    # never within a legitimate partner pair. Expand only as far as required.
+    for candidate_count in range(minimum_heats, max(minimum_heats, len(units)) + 1):
+        candidate = _try_place_units(
+            units,
+            candidate_count,
+            max_per_heat,
+            event,
+        )
+        if candidate is None:
+            continue
+        heats, stands_used = candidate
+        heats, old_to_new = _move_partial_heats_to_end(
+            heats,
+            stands_used,
+            max_per_heat,
+        )
+        _remap_violation_heat_indices(gear_violations, old_to_new)
+        return heats
 
-    # Snake draft distribution
-    direction = 1
-    heat_idx = 0
-
-    for unit in units:
-        placed = False
-
-        # First pass: look for a heat with capacity and no gear-sharing conflict.
-        #
-        # Both passes are bounded by heats EXAMINED, not by steps taken.
-        # _advance_snake_index BOUNCES at both boundaries: given (num_heats-1,
-        # +1) it returns (num_heats-1, -1), the same index. That bounce is what
-        # makes a snake draft a snake draft (0,1,2,2,1,0,0,...) and must stay,
-        # but it means a loop bounded by num_heats STEPS spends steps without
-        # examining a new heat, so it can run out while a heat still has a free
-        # stand. When the fallback ran out that way the unit was dropped with no
-        # heat, no gear violation, and nothing the operator could see.
-        examined = set()
-        while len(examined) < num_heats:
-            if heat_idx in examined:
-                heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-                continue
-            examined.add(heat_idx)
-            if (
-                (stands_used[heat_idx] + 1) <= max_per_heat and
-                not any(_has_gear_sharing_conflict(comp, heats[heat_idx], event) for comp in unit)
-            ):
-                heats[heat_idx].extend(unit)
-                stands_used[heat_idx] += 1
-                placed = True
-                break
-            heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-
-        # Fallback: place despite conflict if every heat conflicts/full.
-        # Record any gear-sharing conflict introduced here so the caller can
-        # surface a warning to the judge (gear audit fix G2 — 2026-04-07).
-        # Its own `examined` set: this pass must be able to revisit the heats
-        # the conflict-avoiding pass already rejected, since rejecting them is
-        # the whole reason it is running.
-        if not placed:
-            examined = set()
-            while len(examined) < num_heats:
-                if heat_idx in examined:
-                    heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-                    continue
-                examined.add(heat_idx)
-                if (stands_used[heat_idx] + 1) <= max_per_heat:
-                    if gear_violations is not None:
-                        for comp in unit:
-                            if _has_gear_sharing_conflict(comp, heats[heat_idx], event):
-                                gear_violations.append({
-                                    'comp_id': comp.get('id'),
-                                    'comp_name': comp.get('name', ''),
-                                    'heat_index': heat_idx,
-                                })
-                    heats[heat_idx].extend(unit)
-                    stands_used[heat_idx] += 1
-                    placed = True
-                    break
-                heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-
-        heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-
-    # Re-order so any partial heat closes the event instead of opening it.
-    # Remap gear_violations heat indices in-place so the judge's flash points
-    # at the heat the competitor actually landed in after the reorder.
-    heats, old_to_new = _move_partial_heats_to_end(heats, stands_used, max_per_heat)
-    _remap_violation_heat_indices(gear_violations, old_to_new)
-
-    return heats
+    raise HeatGenerationSafetyError(
+        f'Heat generation blocked for {getattr(event, "display_name", "event")}: '
+        'no gear-safe heat layout represents every entrant.'
+    )
 
 
 def _first_token(value: str) -> str:
@@ -1083,171 +1227,120 @@ def _generate_springboard_heats(competitors: list, num_heats: int,
     """
     Generate springboard heats with left-handed cutter spreading.
 
-    Only one physical left-handed springboard dummy exists on site, so at most
-    ONE left-handed cutter can be in a single heat at a time.  Spread LH cutters
-    one per heat across heats 0..N-1.  If more LH cutters than heats exist,
-    overflow into the FINAL heat (per user rule, 2026-04-20) and log a warning
-    via lh_warnings so the admin knows there is dummy contention.
-
-    Slow-heat cutters still cluster starting at the final heat (unchanged).
+    Only one physical left-handed springboard dummy exists on site, so each
+    left-handed cutter needs a separate heat. Slow cutters remain clustered in
+    the closing heat block. If either gear or dummy capacity prevents a safe
+    placement, the event gains one heat and the deterministic pass is retried.
     """
-    heats = [[] for _ in range(num_heats)]
+    if not competitors:
+        return []
 
-    # Dedicated springboard buckets:
-    # - LH cutters: one per heat (spread), overflow to final heat with warning.
-    # - Slow-heat cutters: cluster into the dedicated slow heat.
-    left_handed = [c for c in competitors if c.get('is_left_handed', False)]
-    slow_heat = [c for c in competitors if c.get('is_slow_springboard', False)]
-
-    # Sort LH cutters by ability rank (1 = fastest). When LH_count > num_heats
-    # the tail of this list overflows into the final heat — we want the
-    # SLOWEST LH cutters to overflow (alongside any slow-heat-flagged cutters
-    # already clustering there), not whoever happens to be alphabetically
-    # last in registration order. Name-order overflow placement was the
-    # original V2.5.0 behaviour; tying the split point to ProEventRank means
-    # the fast LH cutters each get their own heat + LH dummy time-slot, and
-    # the slow LH cutters share the dedicated slow-heat block.
-    # Falls back gracefully to input order when no ranks exist for this
-    # tournament + category (that's _sort_by_ability's documented behaviour).
-    if left_handed:
-        left_handed = _sort_by_ability(left_handed, event)
-
-    slow_heat_idx = (num_heats - 1) if slow_heat else None
-
-    assigned_ids = set()
-
-    # --- LH spread ---
-    # One LH cutter per heat, heats 0..N-1.  Overflow spills into the final
-    # heat (heats[num_heats-1]), mixed with RH cutters there.  If the final
-    # heat also hits max_per_heat, any further LH cutters are unplaceable —
-    # surface them via gear_violations as a hard warning so the admin reacts.
-    if left_handed and num_heats > 0:
-        spread = left_handed[:num_heats]
-        overflow = left_handed[num_heats:]
-
-        for i, lh in enumerate(spread):
-            if len(heats[i]) < max_per_heat:
-                heats[i].append(lh)
-                assigned_ids.add(lh['id'])
-
-        if overflow:
-            final_idx = num_heats - 1
-            placed_overflow: list[str] = []
-            unplaced_overflow: list[str] = []
-            for lh in overflow:
-                if lh['id'] in assigned_ids:
-                    continue
-                if len(heats[final_idx]) < max_per_heat:
-                    heats[final_idx].append(lh)
-                    assigned_ids.add(lh['id'])
-                    placed_overflow.append(lh.get('name', ''))
-                else:
-                    unplaced_overflow.append(lh.get('name', ''))
-
-            if placed_overflow and lh_warnings is not None:
-                lh_warnings.append({
-                    'type': 'lh_overflow',
-                    'heat_index': final_idx,
-                    'overflow_count': len(placed_overflow),
-                    'overflow_names': placed_overflow,
-                })
-            if unplaced_overflow and gear_violations is not None:
-                for name in unplaced_overflow:
-                    gear_violations.append({
-                        'comp_id': None,
-                        'comp_name': name,
-                        'heat_index': final_idx,
-                        'reason': 'LH cutter unplaced — all heats at capacity',
-                    })
-
-    # --- Slow-heat cluster (unchanged behavior) ---
-    def _place_group(group: list, preferred_idx: int | None):
-        if not group:
-            return
-        remaining = [g for g in group if g['id'] not in assigned_ids]
-        if not remaining:
-            return
-
-        # Prefer one dedicated heat; overflow stays grouped into adjacent heats.
-        idx = preferred_idx if preferred_idx is not None else 0
-        while remaining:
-            candidate = None
-            for probe in list(range(idx, num_heats)) + list(range(0, idx)):
-                if len(heats[probe]) < max_per_heat:
-                    candidate = probe
-                    break
-            if candidate is None:
-                break
-            idx = candidate
-            capacity = max_per_heat - len(heats[idx])
-            take = remaining[:max(0, capacity)]
-            heats[idx].extend(take)
-            for comp in take:
-                assigned_ids.add(comp['id'])
-            remaining = remaining[len(take):]
-            idx += 1
-
-    _place_group(slow_heat, slow_heat_idx)
-
-    # Fill the remaining cutters with snake draft while respecting capacity.
-    # Sort by ability rank before the snake draft so each heat gets a skill mix.
-    remaining = _sort_by_ability(
-        [c for c in competitors if c['id'] not in assigned_ids], event
+    left_handed = _sort_by_ability(
+        [comp for comp in competitors if comp.get('is_left_handed')],
+        event,
     )
-    if not remaining:
-        return heats
+    slow_cutters = _sort_by_ability(
+        [comp for comp in competitors if comp.get('is_slow_springboard')],
+        event,
+    )
+    slow_ids = {comp['id'] for comp in slow_cutters}
+    regular_lh = [comp for comp in left_handed if comp['id'] not in slow_ids]
+    slow_lh = [comp for comp in left_handed if comp['id'] in slow_ids]
 
-    heat_idx = 0
-    direction = 1
-    for comp in remaining:
-        # First pass: find a heat with capacity AND no gear-sharing conflict.
-        # Springboards are the highest-stakes shared-equipment event, so this
-        # check matches the standard heat generator (gear audit fix G3).
-        placed = False
-        for _ in range(num_heats):
-            if (
-                len(heats[heat_idx]) < max_per_heat and
-                not _has_gear_sharing_conflict(comp, heats[heat_idx], event)
-            ):
-                heats[heat_idx].append(comp)
-                placed = True
-                break
-            heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
+    minimum_heats = max(
+        num_heats,
+        math.ceil(len(competitors) / max_per_heat),
+        len(left_handed),
+    )
 
-        # Fallback: place despite conflict if every heat conflicts/full.
-        # Record any gear-sharing conflict introduced here so the caller can
-        # surface a warning to the judge (gear audit fix G3 — 2026-04-07).
-        if not placed:
-            for _ in range(num_heats):
-                if len(heats[heat_idx]) < max_per_heat:
-                    if gear_violations is not None and _has_gear_sharing_conflict(comp, heats[heat_idx], event):
-                        gear_violations.append({
-                            'comp_id': comp.get('id'),
-                            'comp_name': comp.get('name', ''),
-                            'heat_index': heat_idx,
-                        })
+    for candidate_count in range(minimum_heats, len(competitors) + 1):
+        heats = [[] for _ in range(candidate_count)]
+        assigned_ids = set()
+
+        # Fast/non-slow LH cutters retain the established front-to-back ability
+        # order. Slow LH cutters use the closing slots without sharing a dummy.
+        for index, comp in enumerate(regular_lh):
+            heats[index].append(comp)
+            assigned_ids.add(comp['id'])
+        for offset, comp in enumerate(reversed(slow_lh), start=1):
+            heats[-offset].append(comp)
+            assigned_ids.add(comp['id'])
+
+        failed = False
+        for comp in slow_cutters:
+            if comp['id'] in assigned_ids:
+                continue
+            placed = False
+            for heat_idx in range(candidate_count - 1, -1, -1):
+                if (
+                    len(heats[heat_idx]) < max_per_heat
+                    and not _has_gear_sharing_conflict(comp, heats[heat_idx], event)
+                ):
                     heats[heat_idx].append(comp)
+                    assigned_ids.add(comp['id'])
                     placed = True
                     break
-                heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
+            if not placed:
+                failed = True
+                break
+        if failed:
+            continue
 
-        if not placed:
-            break
-        heat_idx, direction = _advance_snake_index(heat_idx, direction, num_heats)
-
-    # Re-order so any partial heat closes the event instead of opening it.
-    # Springboard isn't partnered, so competitor count == capacity-relevant size.
-    # The helper no-ops when any heat is over capacity (LH overflow stays put).
-    # Skip the reorder entirely when slow-heat cutters were placed — the slow
-    # cluster is intentionally pinned to the final heat and must not migrate.
-    # Remap gear_violations heat indices in-place after the reorder.
-    if not slow_heat:
-        heats, old_to_new = _move_partial_heats_to_end(
-            heats, [len(h) for h in heats], max_per_heat,
+        remaining = _sort_by_ability(
+            [comp for comp in competitors if comp['id'] not in assigned_ids],
+            event,
         )
-        _remap_violation_heat_indices(gear_violations, old_to_new)
+        direction = 1
+        heat_idx = 0
+        for comp in remaining:
+            placed = False
+            examined = set()
+            while len(examined) < candidate_count:
+                if heat_idx in examined:
+                    heat_idx, direction = _advance_snake_index(
+                        heat_idx,
+                        direction,
+                        candidate_count,
+                    )
+                    continue
+                examined.add(heat_idx)
+                if (
+                    len(heats[heat_idx]) < max_per_heat
+                    and not _has_gear_sharing_conflict(comp, heats[heat_idx], event)
+                ):
+                    heats[heat_idx].append(comp)
+                    assigned_ids.add(comp['id'])
+                    placed = True
+                    break
+                heat_idx, direction = _advance_snake_index(
+                    heat_idx,
+                    direction,
+                    candidate_count,
+                )
+            if not placed:
+                failed = True
+                break
+            heat_idx, direction = _advance_snake_index(
+                heat_idx,
+                direction,
+                candidate_count,
+            )
+        if failed or any(not heat for heat in heats):
+            continue
 
-    return heats
+        if not slow_cutters:
+            heats, old_to_new = _move_partial_heats_to_end(
+                heats,
+                [len(heat) for heat in heats],
+                max_per_heat,
+            )
+            _remap_violation_heat_indices(gear_violations, old_to_new)
+        return heats
+
+    raise HeatGenerationSafetyError(
+        f'Heat generation blocked for {getattr(event, "display_name", "springboard")}: '
+        'no gear-safe springboard layout represents every cutter.'
+    )
 
 
 def _generate_saw_heats(competitors: list, num_heats: int,
@@ -1458,13 +1551,33 @@ def _competitors_share_gear_for_event(comp1: dict, comp2: dict, event: Event) ->
     Passes all tournament events to enable cascade checking across gear
     families (e.g. sharing an axe for Springboard also conflicts in Underhand).
     """
+    all_events = _get_tournament_events(event)
+    events_to_check = [event, *get_family_events(event, all_events)]
+
+    # Group entries intentionally name the shared equipment, not another
+    # competitor. Compare the raw group token because person-name
+    # normalization removes the ``group:`` marker used by the generic helper.
+    def group_tokens(comp: dict) -> set[str]:
+        tokens = set()
+        sharing = comp.get('gear_sharing', {}) or {}
+        for key, value in sharing.items():
+            token = str(value or '').strip().lower()
+            if not token.startswith('group:'):
+                continue
+            if any(event_matches_gear_key(candidate, key) for candidate in events_to_check):
+                tokens.add(token)
+        return tokens
+
+    if group_tokens(comp1) & group_tokens(comp2):
+        return True
+
     return competitors_share_gear_for_event(
-        str(comp1.get('name', '')).strip(),
+        str(comp1.get('base_name') or comp1.get('name', '')).strip(),
         comp1.get('gear_sharing', {}) or {},
-        str(comp2.get('name', '')).strip(),
+        str(comp2.get('base_name') or comp2.get('name', '')).strip(),
         comp2.get('gear_sharing', {}) or {},
         event,
-        all_events=_get_tournament_events(event),
+        all_events=all_events,
     )
 
 

--- a/services/partnered_axe.py
+++ b/services/partnered_axe.py
@@ -17,6 +17,32 @@ from models import Event, EventResult, Heat, HeatAssignment
 from models.competitor import ProCompetitor
 
 
+def partnered_axe_history_protection_reason(event: Event) -> str | None:
+    """Return why a Partnered Axe final card is immutable, if finals started."""
+    raw = event.event_state or event.payouts
+    if not raw:
+        return None
+    try:
+        state = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        completed_result = EventResult.query.filter_by(
+            event_id=event.id,
+            status='completed',
+        ).first()
+        return 'unreadable scored Partnered Axe state' if completed_result else None
+    if not isinstance(state, dict):
+        return 'unreadable scored Partnered Axe state'
+    if state.get('stage') == 'completed':
+        return 'completed Partnered Axe finals'
+    finalists = state.get('finalists')
+    if isinstance(finalists, list) and any(
+        isinstance(pair, dict) and pair.get('final_score') is not None
+        for pair in finalists
+    ):
+        return 'scored finals'
+    return None
+
+
 class PartneredAxeThrow:
     """Manages the Partnered Axe Throw prelims/finals flow."""
 

--- a/services/preflight.py
+++ b/services/preflight.py
@@ -9,6 +9,8 @@ click-path fix rather than as advisory warnings.
 """
 from __future__ import annotations
 
+import json
+
 from config import DAY_SPLIT_EVENT_NAMES
 from models import Event, EventResult, Flight, Heat, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
@@ -20,14 +22,25 @@ from services.gear_sharing import (
 )
 from services.mark_assignment import is_mark_assignment_eligible
 
-# Issue codes that hard-block heat / flight generation. Anything not listed
-# here is advisory — generation can still run, the warning informs the
-# operator of a quality concern.
-BLOCKING_CODES = frozenset({
+# Input defects must be repaired before heat generation mutates the schedule.
+PRE_GENERATION_BLOCKING_CODES = frozenset({
+    'missing_partner_name',
     'unresolved_partner_name',
     'self_reference_partner',
     'non_reciprocal_partnership',
     'invalid_partner_gender',
+    'gear_details_not_parsed',
+    'gear_unmapped_event_keys',
+    'gear_unknown_partner_names',
+    'gear_self_reference',
+    'gear_partner_mismatch',
+    'partnered_axe_pair_state_invalid',
+    'partnered_axe_prelims_incomplete',
+    'partnered_axe_finals_not_advanced',
+})
+
+# These invariants can only be evaluated against the generated show layout.
+POST_GENERATION_BLOCKING_CODES = frozenset({
     'invalid_flight_position',
     'duplicate_flight_position',
     'duplicate_flight_number',
@@ -36,6 +49,12 @@ BLOCKING_CODES = frozenset({
     'chokerman_run2_partially_in_flights',
     'chokerman_run2_invalid_closer',
 })
+
+# Public aggregate retained for the Preflight page and existing callers that
+# need to answer the broad question "is any scheduling blocker present?".
+BLOCKING_CODES = (
+    PRE_GENERATION_BLOCKING_CODES | POST_GENERATION_BLOCKING_CODES
+)
 
 
 def get_blocking_issues(report: dict) -> list[dict]:
@@ -47,6 +66,24 @@ def get_blocking_issues(report: dict) -> list[dict]:
     """
     issues = report.get('issues') or []
     return [i for i in issues if i.get('code') in BLOCKING_CODES]
+
+
+def get_pre_generation_blocking_issues(report: dict) -> list[dict]:
+    """Return current input blockers that must be fixed before generation."""
+    issues = report.get('issues') or []
+    return [
+        issue for issue in issues
+        if issue.get('code') in PRE_GENERATION_BLOCKING_CODES
+    ]
+
+
+def get_post_generation_blocking_issues(report: dict) -> list[dict]:
+    """Return blockers evaluated against generated schedule artifacts."""
+    issues = report.get('issues') or []
+    return [
+        issue for issue in issues
+        if issue.get('code') in POST_GENERATION_BLOCKING_CODES
+    ]
 
 
 def _signed_up_pro_count(event: Event) -> int:
@@ -158,12 +195,19 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
             'unreviewed_marks': unreviewed_marks,
         })
 
-    # 2) Partner completeness for ALL partnered events (college + pro).
+    # 2) Partner completeness for ordinary partnered events (college + pro).
     # Previously pro-only — Jack & Jill / Double Buck / Pulp Toss / Peavey on
     # the college side had no odd-pool check, so a missing partner silently
     # placed the lone entrant solo on a stand at race time. Now both sides
     # are scanned.
-    partnered_events = tournament.events.filter_by(is_partnered=True).all()
+    all_partnered_events = tournament.events.filter_by(is_partnered=True).all()
+    partnered_events = [event for event in all_partnered_events if not event.has_prelims]
+    partnered_axe_events = [
+        event for event in all_partnered_events
+        if event.has_prelims
+        and not event.is_finalized
+        and event.status != 'completed'
+    ]
     for event in partnered_events:
         entered = _signed_up_count_for_event(event)
         if entered <= 1:
@@ -177,6 +221,101 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
                 'autofix': True,
             })
 
+    # Partnered Axe owns its pair declarations in Event.event_state. Requiring
+    # duplicate competitor.partner fields creates false blockers; ignoring the
+    # state document would let missing pairs or unfinished prelims reach the
+    # show builder. Validate the authoritative document instead.
+    for event in partnered_axe_events:
+        pool = _signed_up_competitors_for_event(event)
+        if not pool:
+            continue
+        pool_ids = {comp.id for comp in pool}
+        raw_state = event.event_state or event.payouts
+        try:
+            state = json.loads(raw_state or '{}')
+        except (json.JSONDecodeError, TypeError):
+            state = None
+
+        pairs = state.get('pairs') if isinstance(state, dict) else None
+        stage = state.get('stage') if isinstance(state, dict) else None
+        represented_ids: list[int] = []
+        structurally_valid = isinstance(pairs, list) and stage in {
+            'prelims', 'finals', 'completed',
+        }
+        if structurally_valid:
+            for pair in pairs:
+                if not isinstance(pair, dict):
+                    structurally_valid = False
+                    break
+                member_ids = []
+                for key in ('competitor1', 'competitor2'):
+                    member = pair.get(key)
+                    member_id = member.get('id') if isinstance(member, dict) else None
+                    if not isinstance(member_id, int) or isinstance(member_id, bool):
+                        structurally_valid = False
+                        break
+                    member_ids.append(member_id)
+                if not structurally_valid or len(set(member_ids)) != 2:
+                    structurally_valid = False
+                    break
+                represented_ids.extend(member_ids)
+
+        pair_state_valid = (
+            structurally_valid
+            and len(represented_ids) == len(set(represented_ids))
+            and set(represented_ids) == pool_ids
+        )
+        if not pair_state_valid:
+            missing_names = [
+                comp.display_name for comp in pool if comp.id not in represented_ids
+            ]
+            names = ', '.join(missing_names[:5]) or 'review the registered pairs'
+            if len(missing_names) > 5:
+                names += f' (+{len(missing_names) - 5} more)'
+            issues.append({
+                'severity': 'high',
+                'code': 'partnered_axe_pair_state_invalid',
+                'title': 'Partnered Axe pair registration is incomplete',
+                'detail': (
+                    f'{event.display_name} pair registration does not represent '
+                    'every entered competitor exactly once. Complete pair '
+                    f'registration before building the show: {names}.'
+                ),
+                'autofix': False,
+                'event_ids': [event.id],
+            })
+            continue
+
+        unscored_pairs = [
+            pair for pair in pairs if pair.get('prelim_score') is None
+        ]
+        if unscored_pairs:
+            issues.append({
+                'severity': 'high',
+                'code': 'partnered_axe_prelims_incomplete',
+                'title': 'Partnered Axe prelims are incomplete',
+                'detail': (
+                    f'{event.display_name} has {len(unscored_pairs)} registered '
+                    'pair(s) without a preliminary score. Record every prelim '
+                    'before building the finals card.'
+                ),
+                'autofix': False,
+                'event_ids': [event.id],
+            })
+        elif stage == 'prelims':
+            issues.append({
+                'severity': 'high',
+                'code': 'partnered_axe_finals_not_advanced',
+                'title': 'Partnered Axe finalists are not confirmed',
+                'detail': (
+                    f'{event.display_name} prelims are scored, but the top four '
+                    'have not been advanced to finals. Confirm the finalists '
+                    'before building the show.'
+                ),
+                'autofix': False,
+                'event_ids': [event.id],
+            })
+
     # 2a) Unresolved partner names + non-reciprocal partnerships.
     # For every partnered-event entrant, attempt the same three-tier match the
     # heat generator runs (exact → first-name → Levenshtein ≤ 2). Flag any
@@ -188,13 +327,10 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
     non_reciprocal: list[dict] = []
     self_ref_partner: list[dict] = []
     invalid_partner_gender: list[dict] = []
+    missing_partner: list[dict] = []
     for event in partnered_events:
         pool = _signed_up_competitors_for_event(event)
-        if len(pool) <= 1:
-            continue
         # Build lookup by competitor id and by normalized name for fast checks.
-        by_id = {c.id: c for c in pool}
-        norm_to_comp = {normalize_alphanum(c.name): c for c in pool}
         for comp in pool:
             partners = comp.get_partners() if hasattr(comp, 'get_partners') else {}
             partner_name = ''
@@ -207,8 +343,12 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
                         partner_name = str(raw).strip()
                         break
             if not partner_name:
-                # Blank partner — already counted by the odd-pool check via the
-                # pool-size parity, so don't double-emit. Continue.
+                missing_partner.append({
+                    'competitor_id': comp.id,
+                    'competitor_name': comp.display_name,
+                    'event_id': event.id,
+                    'event_name': event.display_name,
+                })
                 continue
             # Self-reference check.
             if normalize_alphanum(partner_name) == normalize_alphanum(comp.name):
@@ -292,6 +432,28 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
                     'matched_partner_name': matched.display_name,
                     'partner_says': their_partner_name,
                 })
+    if missing_partner:
+        names = ', '.join(
+            f"{row['competitor_name']} ({row['event_name']})"
+            for row in missing_partner[:5]
+        )
+        suffix = (
+            f' (+{len(missing_partner) - 5} more)'
+            if len(missing_partner) > 5 else ''
+        )
+        issues.append({
+            'severity': 'high',
+            'code': 'missing_partner_name',
+            'title': 'Partner declaration is blank',
+            'detail': (
+                f'{len(missing_partner)} partnered-event entrant(s) have no '
+                f'partner declaration. Add reciprocal partners in registration '
+                f'before generating heats: {names}{suffix}.'
+            ),
+            'autofix': False,
+            'event_ids': sorted({row['event_id'] for row in missing_partner}),
+            'missing': missing_partner,
+        })
     if unresolved_pairs:
         names = ', '.join(
             f"{p['competitor_name']} → \"{p['partner_name']}\" ({p['event_name']})"
@@ -1146,7 +1308,15 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
     for item in issues:
         by_severity[item.get('severity', 'low')] = by_severity.get(item.get('severity', 'low'), 0) + 1
 
-    blocking = [i for i in issues if i.get('code') in BLOCKING_CODES]
+    pre_generation_blocking = [
+        issue for issue in issues
+        if issue.get('code') in PRE_GENERATION_BLOCKING_CODES
+    ]
+    post_generation_blocking = [
+        issue for issue in issues
+        if issue.get('code') in POST_GENERATION_BLOCKING_CODES
+    ]
+    blocking = pre_generation_blocking + post_generation_blocking
     return {
         'issue_count': len(issues),
         'issues': issues,
@@ -1154,4 +1324,6 @@ def build_preflight_report(tournament: Tournament, saturday_college_event_ids: l
         'has_autofixable': any(i.get('autofix') for i in issues),
         'blocking': blocking,
         'has_blockers': bool(blocking),
+        'pre_generation_blocking': pre_generation_blocking,
+        'post_generation_blocking': post_generation_blocking,
     }

--- a/services/schedule_generation.py
+++ b/services/schedule_generation.py
@@ -1,18 +1,274 @@
-"""Application services for schedule autofix and bulk generation workflows."""
+"""Application services for preflight repair and full-show generation."""
 from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Mapping
 
 from sqlalchemy.orm.exc import NoResultFound
 
 from database import db
-from models import Event, Tournament
+from models import Event, EventResult, Flight, Heat, Tournament
 from services.flight_builder import (
     lock_tournament_schedule,
     serialize_sqlite_schedule_writer,
 )
 
+logger = logging.getLogger(__name__)
+
+
+FLIGHT_SIZING_MODE_MINUTES = 'minutes'
+FLIGHT_SIZING_MODE_COUNT = 'count'
+VALID_FLIGHT_SIZING_MODES = {
+    FLIGHT_SIZING_MODE_MINUTES,
+    FLIGHT_SIZING_MODE_COUNT,
+}
+FLIGHT_SIZING_DEFAULTS = {
+    'mode': FLIGHT_SIZING_MODE_MINUTES,
+    'target_minutes_per_flight': 60,
+    'minutes_per_heat': 5.5,
+    'num_flights': 4,
+}
+FLIGHT_COUNT_MIN = 2
+FLIGHT_COUNT_MAX = 10
+MINUTES_PER_FLIGHT_MIN = 30
+MINUTES_PER_FLIGHT_MAX = 180
+MINUTES_PER_HEAT_MIN = 1.0
+MINUTES_PER_HEAT_MAX = 15.0
+
+
+class ScheduleBuildError(RuntimeError):
+    """Operator-safe full-show failure with a stable machine-readable code."""
+
+    def __init__(
+        self,
+        code: str,
+        phase: str,
+        message: str,
+        *,
+        details: list[dict] | tuple[dict, ...] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.phase = phase
+        self.details = tuple(details or ())
+
+    def to_summary(self) -> dict:
+        return {
+            'ok': False,
+            'code': self.code,
+            'phase': self.phase,
+            'message': str(self),
+            'details': list(self.details),
+        }
+
+
+class ScheduleReadinessError(ScheduleBuildError):
+    """Readiness gate failure carrying issue codes and repair details."""
+
+    def __init__(self, phase: str, issues: list[dict]) -> None:
+        issue_codes = tuple(dict.fromkeys(
+            str(issue.get('code') or 'unknown_readiness_issue')
+            for issue in issues
+        ))
+        timing = 'before generation' if phase == 'pre_generation' else 'after generation'
+        shown = []
+        for issue in issues[:3]:
+            code = str(issue.get('code') or 'unknown_readiness_issue')
+            detail = ' '.join(str(
+                issue.get('detail') or issue.get('title') or 'Repair required.'
+            ).split())
+            shown.append(f'{code}: {detail[:240]}')
+        suffix = f' (+{len(issues) - 3} more)' if len(issues) > 3 else ''
+        message = (
+            f'Schedule build blocked {timing} by Preflight issue(s): '
+            f'{"; ".join(shown)}{suffix} Open Preflight, repair the listed '
+            f'people or events, then run Generate again.'
+        )
+        super().__init__(
+            'schedule_readiness_blocked',
+            phase,
+            message,
+            details=[_readiness_issue_detail(issue) for issue in issues],
+        )
+        self.issues = tuple(issues)
+        self.issue_codes = issue_codes
+
+    def to_summary(self) -> dict:
+        summary = super().to_summary()
+        summary['issue_codes'] = list(self.issue_codes)
+        return summary
+
+
+def _readiness_issue_detail(issue: dict) -> dict:
+    return {
+        'code': str(issue.get('code') or 'unknown_readiness_issue'),
+        'title': str(issue.get('title') or 'Schedule readiness issue'),
+        'detail': str(issue.get('detail') or ''),
+        'event_id': issue.get('event_id'),
+        'event_ids': list(issue.get('event_ids') or []),
+    }
+
+
+def read_flight_sizing_config(tournament: Tournament) -> dict:
+    """Return saved flight-sizing config merged over operator-safe defaults."""
+    cfg = tournament.get_schedule_config() or {}
+    mode = cfg.get('flight_sizing_mode', FLIGHT_SIZING_DEFAULTS['mode'])
+    if mode not in VALID_FLIGHT_SIZING_MODES:
+        mode = FLIGHT_SIZING_DEFAULTS['mode']
+    try:
+        target_minutes = int(cfg.get(
+            'target_minutes_per_flight',
+            FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight'],
+        ))
+    except (TypeError, ValueError):
+        target_minutes = FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']
+    try:
+        minutes_per_heat = float(cfg.get(
+            'minutes_per_heat',
+            FLIGHT_SIZING_DEFAULTS['minutes_per_heat'],
+        ))
+    except (TypeError, ValueError):
+        minutes_per_heat = FLIGHT_SIZING_DEFAULTS['minutes_per_heat']
+    try:
+        saved_num_flights = int(cfg.get(
+            'num_flights', FLIGHT_SIZING_DEFAULTS['num_flights'],
+        ))
+    except (TypeError, ValueError):
+        saved_num_flights = FLIGHT_SIZING_DEFAULTS['num_flights']
+    return {
+        'mode': mode,
+        'target_minutes_per_flight': max(
+            MINUTES_PER_FLIGHT_MIN,
+            min(MINUTES_PER_FLIGHT_MAX, target_minutes),
+        ),
+        'minutes_per_heat': max(
+            MINUTES_PER_HEAT_MIN,
+            min(MINUTES_PER_HEAT_MAX, minutes_per_heat),
+        ),
+        'num_flights': max(
+            FLIGHT_COUNT_MIN,
+            min(FLIGHT_COUNT_MAX, saved_num_flights),
+        ),
+    }
+
+
+def normalize_flight_sizing_input(values: Mapping) -> dict | None:
+    """Validate Run Show sizing fields without mutating schedule state."""
+    raw_mode = str(values.get('flight_sizing_mode') or '').strip().lower()
+    if not raw_mode:
+        return None
+    if raw_mode not in VALID_FLIGHT_SIZING_MODES:
+        raw_mode = FLIGHT_SIZING_DEFAULTS['mode']
+    try:
+        target_minutes = int(values.get(
+            'target_minutes_per_flight',
+            FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight'],
+        ))
+    except (TypeError, ValueError):
+        target_minutes = FLIGHT_SIZING_DEFAULTS['target_minutes_per_flight']
+    target_minutes = max(
+        MINUTES_PER_FLIGHT_MIN,
+        min(MINUTES_PER_FLIGHT_MAX, target_minutes),
+    )
+    try:
+        minutes_per_heat = float(values.get(
+            'minutes_per_heat', FLIGHT_SIZING_DEFAULTS['minutes_per_heat'],
+        ))
+    except (TypeError, ValueError):
+        minutes_per_heat = FLIGHT_SIZING_DEFAULTS['minutes_per_heat']
+    minutes_per_heat = max(
+        MINUTES_PER_HEAT_MIN,
+        min(MINUTES_PER_HEAT_MAX, minutes_per_heat),
+    )
+    try:
+        requested_num_flights = int(values.get('num_flights', 0))
+    except (TypeError, ValueError):
+        requested_num_flights = 0
+    has_requested_count = requested_num_flights >= 1
+    normalized_num_flights = (
+        max(
+            FLIGHT_COUNT_MIN,
+            min(FLIGHT_COUNT_MAX, requested_num_flights),
+        )
+        if has_requested_count
+        else FLIGHT_SIZING_DEFAULTS['num_flights']
+    )
+    return {
+        'mode': raw_mode,
+        'target_minutes_per_flight': target_minutes,
+        'minutes_per_heat': minutes_per_heat,
+        'num_flights': normalized_num_flights,
+        'requested_num_flights': (
+            normalized_num_flights if has_requested_count else None
+        ),
+    }
+
+
+def persist_flight_sizing_config(tournament: Tournament, sizing: Mapping) -> None:
+    """Persist validated operator sizing inside the caller's transaction."""
+    cfg = tournament.get_schedule_config() or {}
+    cfg['flight_sizing_mode'] = sizing['mode']
+    cfg['target_minutes_per_flight'] = int(
+        sizing['target_minutes_per_flight']
+    )
+    cfg['minutes_per_heat'] = float(sizing['minutes_per_heat'])
+    cfg['num_flights'] = int(sizing['num_flights'])
+    tournament.set_schedule_config(cfg)
+
+
+def compute_num_flights_from_duration(
+    total_heats: int,
+    minutes_per_heat: float,
+    target_minutes_per_flight: int,
+) -> tuple[int, bool]:
+    """Derive and clamp a duration-based flight count."""
+    if (
+        total_heats <= 0
+        or minutes_per_heat <= 0
+        or target_minutes_per_flight <= 0
+    ):
+        return FLIGHT_COUNT_MIN, False
+    ideal = math.ceil(
+        (total_heats * minutes_per_heat) / target_minutes_per_flight
+    )
+    clamped = max(FLIGHT_COUNT_MIN, min(FLIGHT_COUNT_MAX, ideal))
+    return clamped, clamped != ideal
+
+
+def resolve_num_flights(
+    tournament: Tournament,
+    sizing: Mapping | None = None,
+) -> int | None:
+    """Resolve persisted or just-submitted sizing after heats are generated."""
+    effective = dict(sizing or read_flight_sizing_config(tournament))
+    if effective['mode'] == FLIGHT_SIZING_MODE_MINUTES:
+        pro_heats = Heat.query.join(Event).filter(
+            Event.tournament_id == tournament.id,
+            Event.event_type == 'pro',
+            Event.name != 'Partnered Axe Throw',
+            Heat.run_number == 1,
+        ).count()
+        if pro_heats <= 0:
+            return None
+        computed, _ = compute_num_flights_from_duration(
+            pro_heats,
+            float(effective['minutes_per_heat']),
+            int(effective['target_minutes_per_flight']),
+        )
+        return computed if computed >= 1 else None
+    requested = effective.get('requested_num_flights')
+    if requested is not None:
+        return int(requested) if int(requested) >= 1 else None
+    saved = int(effective['num_flights'])
+    return saved if saved >= 1 else None
+
 
 @serialize_sqlite_schedule_writer
-def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None = None) -> dict:
+def run_preflight_autofix(
+    tournament: Tournament,
+    saturday_ids: list[int] | None = None,
+) -> dict:
     """Apply the one-click preflight autofix workflow and return a summary."""
     from services.flight_builder import (
         integrate_college_spillover_into_flights,
@@ -22,27 +278,15 @@ def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None
     from services.partner_matching import auto_assign_partners
 
     lock_tournament_schedule(tournament)
-
-    # D12-C commit F2: the heat-sync sweep is gone, and with it the
-    # `heats_fixed` / `heats_checked` counters this function used to return.
-    # It walked every heat calling `sync_assignments`, which rebuilt the
-    # `heat_assignments` rows from the `heats.competitors` JSON. That was a
-    # repair for a divergence that can no longer happen: commit E made the
-    # rows the only place a roster is written, so there is nothing to sync
-    # them FROM and nothing they can drift AGAINST. Sweeping anyway would
-    # rewrite every roster in the tournament from a column no writer touches.
-
     gear_parse_result = parse_all_gear_details(tournament)
     pairs_result = complete_one_sided_pairs(tournament)
     partner_summary = auto_assign_partners(tournament)
-    # Phase 4: relay BEFORE spillover so Chokerman Run 2 still closes the show.
     relay_result = integrate_proam_relay_into_final_flight(
         tournament, commit=False,
     )
     integration = integrate_college_spillover_into_flights(
         tournament, saturday_ids or [], commit=False,
     )
-
     return {
         'gear_parsed': gear_parse_result,
         'gear_pairs_completed': pairs_result['completed'],
@@ -52,19 +296,176 @@ def run_preflight_autofix(tournament: Tournament, saturday_ids: list[int] | None
     }
 
 
+def _protected_event_reason(event: Event) -> str | None:
+    if event.is_finalized:
+        return 'finalized'
+    if event.status == 'completed':
+        return 'completed'
+    if event.has_prelims:
+        from services.partnered_axe import partnered_axe_history_protection_reason
+
+        reason = partnered_axe_history_protection_reason(event)
+        if reason is not None:
+            return reason
+        if Heat.query.filter_by(
+            event_id=event.id, status='completed',
+        ).first() is not None:
+            return 'completed heat history'
+        return None
+    if EventResult.query.filter_by(
+        event_id=event.id, status='completed',
+    ).first() is not None:
+        return 'scored'
+    if Heat.query.filter_by(
+        event_id=event.id, status='completed',
+    ).first() is not None:
+        return 'completed heat history'
+    return None
+
+
+def _event_schedule_snapshot(event_id: int) -> tuple:
+    """Return immutable heat, roster, stand, and flight state for one event."""
+    heats = Heat.query.filter_by(event_id=event_id).order_by(
+        Heat.run_number, Heat.heat_number, Heat.id,
+    ).all()
+    return tuple(
+        (
+            heat.id,
+            heat.heat_number,
+            heat.run_number,
+            heat.status,
+            heat.flight_id,
+            heat.flight_position,
+            tuple(heat.get_competitors()),
+            tuple(sorted(heat.get_stand_assignments().items())),
+        )
+        for heat in heats
+    )
+
+
+def _saturday_event_ids(tournament: Tournament) -> list[int]:
+    config = tournament.get_schedule_config() or {}
+    ids = []
+    for raw_id in config.get('saturday_college_event_ids', []):
+        try:
+            ids.append(int(raw_id))
+        except (TypeError, ValueError):
+            logger.warning(
+                'Ignoring invalid saturday_college_event_id %r for tournament %s',
+                raw_id,
+                tournament.id,
+            )
+    return ids
+
+
+def _flight_snapshot(tournament_id: int) -> dict:
+    flights = Flight.query.filter_by(tournament_id=tournament_id).all()
+    return {
+        'flight_count': len(flights),
+        'total_heats': sum(len(flight.get_heats_ordered()) for flight in flights),
+    }
+
+
+def _ensure_sqlite_write_transaction() -> None:
+    """Make per-event savepoints subordinate to the full SQLite transaction.
+
+    Python's sqlite driver can defer the physical BEGIN past SELECTs. Without
+    an explicit BEGIN, the first ``begin_nested()`` savepoint may become the
+    effective top-level transaction and RELEASE would make that event durable
+    before post-build validation. PostgreSQL does not need this workaround.
+    """
+    connection = db.session.connection()
+    if connection.dialect.name != 'sqlite':
+        return
+    proxied = connection.connection
+    driver_connection = getattr(proxied, 'driver_connection', proxied)
+    if not getattr(driver_connection, 'in_transaction', True):
+        connection.exec_driver_sql('BEGIN IMMEDIATE')
+
+
+def _phase_failure(phase: str, *, event: Event | None = None) -> ScheduleBuildError:
+    labels = {
+        'heat_generation': 'generating event heats',
+        'flight_generation': 'building pro flights',
+        'relay': 'placing the Pro-Am Relay',
+        'spillover': 'integrating Saturday spillover',
+        'saw_blocks': 'assigning saw blocks',
+        'post_generation': 'validating the generated show',
+        'commit': 'saving the generated show',
+    }
+    action = labels.get(phase, 'building the show schedule')
+    affected = f' for {event.display_name}' if event is not None else ''
+    return ScheduleBuildError(
+        f'{phase}_failed',
+        phase,
+        f'Schedule build failed while {action}{affected} and was rolled back. '
+        'Open Preflight to review the affected event, then run Generate again.',
+        details=[{
+            'event_id': event.id,
+            'event_name': event.display_name,
+        }] if event is not None else [],
+    )
+
+
+def schedule_operator_messages(summary: Mapping) -> list[dict]:
+    """Build route/job-ready messages from a successful structured summary."""
+    messages = []
+    generated = int(summary.get('generated') or 0)
+    if generated:
+        messages.append({
+            'category': 'success',
+            'message': f'Heats generated for {generated} event(s).',
+        })
+    skipped = list(summary.get('skipped_events') or [])
+    if skipped:
+        names = ', '.join(item['event_name'] for item in skipped[:8])
+        suffix = f' (+{len(skipped) - 8} more)' if len(skipped) > 8 else ''
+        messages.append({
+            'category': 'warning',
+            'message': (
+                f'{len(skipped)} event(s) had no entrants and were skipped: '
+                f'{names}{suffix}. Add entries in Registration, then Generate again.'
+            ),
+        })
+    protected = list(summary.get('protected') or [])
+    if protected:
+        names = ', '.join(
+            f"{item['event_name']} ({item['reason']})"
+            for item in protected[:8]
+        )
+        suffix = f' (+{len(protected) - 8} more)' if len(protected) > 8 else ''
+        messages.append({
+            'category': 'warning',
+            'message': (
+                f'{len(protected)} scored or finalized event(s) were left '
+                f'unchanged: {names}{suffix}.'
+            ),
+        })
+    flights = summary.get('flights')
+    if flights is not None:
+        messages.append({
+            'category': 'success',
+            'message': f'Built {flights} pro flight(s).',
+        })
+    relay = summary.get('relay') or {}
+    if relay.get('placed'):
+        messages.append({
+            'category': 'success',
+            'message': 'Pro-Am Relay placed in the final flight.',
+        })
+    return messages
+
+
 @serialize_sqlite_schedule_writer
-def generate_tournament_schedule_artifacts(tournament_id: int) -> dict:
-    """Generate heats for every event, then build pro flights when possible.
+def generate_tournament_schedule_artifacts(
+    tournament_id: int,
+    *,
+    flight_sizing: Mapping | None = None,
+) -> dict:
+    """Build all show artifacts under one lock and one transaction.
 
-    Matches the synchronous Run Show "Generate All Heats + Build Flights"
-    pipeline: generate heats → build flights → place Pro-Am Relay pseudo-heat
-    in the final flight → integrate Saturday college spillover (Chokerman Run 2
-    etc.). Without the last two steps the async generate path would produce an
-    incomplete schedule — relay unassigned, Chokerman Run 2 with flight_id=NULL.
-
-    Flight build + relay + spillover run with commit=False and commit once at
-    the end so the chain is atomic. Mirrors ``_build_flights_async`` in
-    ``routes/scheduling/flights.py``.
+    Order is fixed: pre-generation readiness, heats, pro flights, relay,
+    spillover, saw blocks, post-generation readiness, then one commit.
     """
     from services.flight_builder import (
         build_pro_flights,
@@ -72,97 +473,179 @@ def generate_tournament_schedule_artifacts(tournament_id: int) -> dict:
         integrate_proam_relay_into_final_flight,
     )
     from services.heat_generator import generate_event_heats
+    from services.preflight import (
+        build_preflight_report,
+        get_post_generation_blocking_issues,
+        get_pre_generation_blocking_issues,
+    )
+    from services.saw_block_assignment import assign_saw_blocks
 
     try:
         tournament = lock_tournament_schedule(tournament_id)
-    except NoResultFound:
-        return {'ok': False, 'error': f'Tournament {tournament_id} not found.'}
+    except NoResultFound as exc:
+        raise ScheduleBuildError(
+            'tournament_not_found',
+            'lock',
+            f'Tournament {tournament_id} was not found; no schedule was changed.',
+        ) from exc
 
-    generated = 0
-    skipped = 0
-    errors = []
-    for event in tournament.events.order_by(Event.event_type, Event.name, Event.gender).all():
-        try:
-            with db.session.begin_nested():
-                generate_event_heats(
-                    event, allow_flight_replacement=True,
-                )
-            generated += 1
-        except Exception as exc:
-            if 'No competitors entered' in str(exc):
-                skipped += 1
-            else:
-                errors.append(str(exc))
+    phase = 'pre_generation'
+    event_in_progress = None
+    try:
+        _ensure_sqlite_write_transaction()
+        saturday_ids = _saturday_event_ids(tournament)
+        preflight_report = build_preflight_report(tournament, saturday_ids)
+        blockers = get_pre_generation_blocking_issues(preflight_report)
+        if blockers:
+            raise ScheduleReadinessError('pre_generation', blockers)
 
-    if errors:
-        db.session.rollback()
-        return {
-            'ok': False,
-            'generated': 0,
-            'skipped': skipped,
-            'errors': errors,
-            'flights': None,
-            'relay_placed': False,
-            'spillover_integrated': 0,
-            'spillover': {},
+        normalized_sizing = (
+            normalize_flight_sizing_input(flight_sizing)
+            if flight_sizing is not None
+            and 'requested_num_flights' not in flight_sizing
+            else dict(flight_sizing) if flight_sizing is not None else None
+        )
+        if normalized_sizing is not None:
+            persist_flight_sizing_config(tournament, normalized_sizing)
+            db.session.flush()
+
+        before = _flight_snapshot(tournament.id)
+        generated = 0
+        skipped_events = []
+        protected_events = []
+        protected_snapshots = {}
+        phase = 'heat_generation'
+        events = tournament.events.order_by(
+            Event.event_type, Event.name, Event.gender,
+        ).all()
+        for event in events:
+            reason = _protected_event_reason(event)
+            if reason is not None:
+                protected_events.append({
+                    'event_id': event.id,
+                    'event_name': event.display_name,
+                    'reason': reason,
+                })
+                protected_snapshots[event.id] = _event_schedule_snapshot(event.id)
+                continue
+            event_in_progress = event
+            try:
+                with db.session.begin_nested():
+                    generate_event_heats(
+                        event, allow_flight_replacement=True,
+                    )
+                generated += 1
+            except Exception as exc:
+                if 'No competitors entered' in str(exc):
+                    skipped_events.append({
+                        'event_id': event.id,
+                        'event_name': event.display_name,
+                        'event_type': event.event_type,
+                    })
+                    continue
+                raise
+        event_in_progress = None
+
+        pro_heat_count = Heat.query.join(Event).filter(
+            Event.tournament_id == tournament.id,
+            Event.event_type == 'pro',
+            Heat.run_number == 1,
+        ).count()
+        flights_built = None
+        relay_result = {'placed': False, 'reason': 'no_pro_heats'}
+        spillover_result = {
+            'integrated_heats': 0,
+            'reason': 'no_pro_heats',
         }
-
-    pro_heats = sum(
-        1
-        for event in tournament.events.filter_by(event_type='pro').all()
-        for heat in event.heats.all()
-        if heat.run_number == 1
-    )
-    flights = None
-    relay_placed = False
-    spillover_integrated = 0
-    spillover_result = {}
-    if pro_heats:
-        from routes.scheduling.flights import _resolve_num_flights_from_persisted_config
-        num_flights = _resolve_num_flights_from_persisted_config(tournament)
-        saturday_college_event_ids = [
-            int(i) for i in
-            (tournament.get_schedule_config() or {}).get('saturday_college_event_ids', [])
-        ]
-        try:
-            flights = build_pro_flights(
-                tournament, num_flights=num_flights, commit=False,
+        if pro_heat_count:
+            phase = 'flight_generation'
+            num_flights = resolve_num_flights(tournament, normalized_sizing)
+            flights_built = build_pro_flights(
+                tournament,
+                num_flights=num_flights,
+                commit=False,
             )
-            # Relay BEFORE spillover so Chokerman Run 2 lands AFTER the relay
-            # (FlightLogic.md §4.1 show-climax rule).
+            phase = 'relay'
             relay_result = integrate_proam_relay_into_final_flight(
                 tournament, commit=False,
             )
-            relay_placed = bool(relay_result.get('placed'))
-            integration = integrate_college_spillover_into_flights(
+            phase = 'spillover'
+            spillover_result = integrate_college_spillover_into_flights(
                 tournament,
-                college_event_ids=saturday_college_event_ids,
+                college_event_ids=saturday_ids,
                 commit=False,
             )
-            spillover_result = dict(integration)
-            spillover_integrated = integration.get('integrated_heats', 0)
-        except Exception as exc:
-            db.session.rollback()
-            return {
-                'ok': False,
-                'generated': 0,
-                'skipped': skipped,
-                'errors': [f'flight build chain failed: {exc}'],
-                'flights': None,
-                'relay_placed': False,
-                'spillover_integrated': 0,
-                'spillover': {},
-            }
 
-    db.session.commit()
+        phase = 'saw_blocks'
+        saw_block_result = assign_saw_blocks(tournament, commit=False)
 
-    return {
+        phase = 'post_generation'
+        changed_protected = [
+            item for item in protected_events
+            if _event_schedule_snapshot(item['event_id'])
+            != protected_snapshots[item['event_id']]
+        ]
+        if changed_protected:
+            names = ', '.join(
+                item['event_name'] for item in changed_protected[:5]
+            )
+            suffix = (
+                f' (+{len(changed_protected) - 5} more)'
+                if len(changed_protected) > 5 else ''
+            )
+            raise ScheduleBuildError(
+                'protected_history_changed',
+                'post_generation',
+                'Schedule build attempted to change scored or finalized event '
+                f'history and was rolled back: {names}{suffix}. Open Preflight '
+                'and use an unscored tournament schedule for regeneration.',
+                details=changed_protected,
+            )
+        postflight_report = build_preflight_report(tournament, saturday_ids)
+        blockers = get_post_generation_blocking_issues(postflight_report)
+        if blockers:
+            raise ScheduleReadinessError('post_generation', blockers)
+
+        after = _flight_snapshot(tournament.id)
+        phase = 'commit'
+        db.session.commit()
+    except ScheduleBuildError:
+        db.session.rollback()
+        raise
+    except Exception as exc:
+        db.session.rollback()
+        logger.exception(
+            'Full-show generation failed tournament_id=%s phase=%s',
+            tournament_id,
+            phase,
+        )
+        raise _phase_failure(phase, event=event_in_progress) from exc
+
+    summary = {
         'ok': True,
+        'tournament_id': tournament.id,
         'generated': generated,
-        'skipped': skipped,
-        'errors': errors,
-        'flights': flights,
-        'relay_placed': relay_placed,
-        'spillover_integrated': spillover_integrated,
-        'spillover': spillover_result,
+        'skipped': len(skipped_events),
+        'skipped_events': skipped_events,
+        'protected': protected_events,
+        'errors': [],
+        'flights': flights_built,
+        'relay': dict(relay_result or {}),
+        'relay_placed': bool((relay_result or {}).get('placed')),
+        'spillover': dict(spillover_result or {}),
+        'spillover_integrated': int(
+            (spillover_result or {}).get('integrated_heats', 0)
+        ),
+        'saw_blocks': dict(saw_block_result or {}),
+        'build_diff': {
+            'before_flight_count': before['flight_count'],
+            'after_flight_count': after['flight_count'],
+            'total_heats': after['total_heats'],
+        },
+        'readiness': {
+            'pre_generation_blockers': 0,
+            'post_generation_blockers': 0,
+        },
     }
+    summary['operator_messages'] = schedule_operator_messages(summary)
+    return summary

--- a/templates/scheduling/events.html
+++ b/templates/scheduling/events.html
@@ -107,10 +107,18 @@
     .sched-wizard-step:nth-child(2n) .sched-wizard-control { border-right: 0; }
     .sched-wizard-step:nth-last-child(-n + 2) .sched-wizard-control { border-bottom: 0; }
     .ops-tabs {
-        flex-wrap: nowrap;
-        overflow-x: auto;
+        display: grid !important;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        width: 100%;
     }
-    .ops-tabs .nav-link { min-height: 44px; padding-inline: 0.9rem; }
+    .ops-tabs .nav-item { min-width: 0; }
+    .ops-tabs .nav-item:first-child { grid-column: 1 / -1; }
+    .ops-tabs .nav-link {
+        width: 100%;
+        min-height: 44px;
+        padding-inline: 0.65rem;
+        white-space: normal;
+    }
     .schedule-warning-row {
         flex-direction: column;
     }
@@ -221,11 +229,11 @@
         {% set wizard_steps = [
             ('1', 'Configure Events', url_for('scheduling.setup_events', tournament_id=tournament.id), 'bi-gear'),
             ('2', 'Fri/Sat Options', url_for('scheduling.friday_feature', tournament_id=tournament.id), 'bi-calendar2-week'),
-            ('3', 'Generate & Build', '', 'bi-lightning-charge'),
-            ('4', 'Preflight & Print', url_for('scheduling.preflight_check', tournament_id=tournament.id), 'bi-printer'),
+            ('3', 'Preflight Check', url_for('scheduling.preflight_check', tournament_id=tournament.id), 'bi-shield-check'),
+            ('4', 'Generate & Print', '', 'bi-lightning-charge'),
         ] %}
         {% for num, label, href, icon in wizard_steps %}
-        {% set is_active = (num == '3') %}
+        {% set is_active = (num == '4') %}
         {% set is_done = (num in ('1', '2')) %}
         <li class="sched-wizard-step">
             {% if href and not is_active %}
@@ -454,11 +462,11 @@
                 <i class="bi bi-check-circle-fill text-success" style="font-size:1.3rem; flex-shrink:0;"></i>
                 <div class="flex-grow-1">
                     <div class="fw-bold text-success">Heats and flights are ready</div>
-                    <div class="small text-muted">Run a Preflight Check to verify, then print heat sheets for game day.</div>
+                    <div class="small text-muted">The full build passed its readiness checks. Print heat sheets for game day or inspect the current report.</div>
                 </div>
                 <div class="d-flex gap-2 flex-shrink-0">
                     <a href="{{ url_for('scheduling.preflight_check', tournament_id=tournament.id) }}"
-                       class="btn btn-outline-success btn-sm">Preflight Check</a>
+                       class="btn btn-outline-success btn-sm">Readiness Report</a>
                     <a href="{{ url_for('scheduling.heat_sheets', tournament_id=tournament.id) }}"
                        class="btn btn-success btn-sm" target="_blank">
                         <i class="bi bi-printer me-1"></i>Print Heat Sheets
@@ -541,7 +549,8 @@
                             {# Primary action — flight sizing form is the same one as on the
                                Build Flights page; values are stored in schedule_config so the
                                two pages stay in sync. #}
-                            <form method="POST" action="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}" data-loading>
+                            <form method="POST" action="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}"
+                                  data-loading data-full-build-form>
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
                                 {% if flight_sizing %}
@@ -591,7 +600,8 @@
 
                                 <div class="d-grid mb-2">
                                     <button type="submit" name="action" value="generate_all" class="btn btn-primary"
-                                            data-confirm="Generate heats for all events and build pro flights? Existing heats will be regenerated.">
+                                            data-full-build-submit
+                                            data-confirm="Run the required preflight, regenerate all heats, and build the complete show? Existing heats will be replaced only if the full build succeeds.">
                                         <i class="bi bi-lightning-charge me-1"></i>Generate All Heats + Build Flights
                                     </button>
                                 </div>
@@ -1296,15 +1306,32 @@ function loadPreflight() {
     const url = "{{ url_for('scheduling.preflight_json', tournament_id=tournament.id) }}";
     const panel = document.getElementById('preflight-panel');
     const body = document.getElementById('preflight-body');
+    const buildSubmit = document.querySelector('[data-full-build-submit]');
+    function setFullBuildBlocked(blocked) {
+        if (!buildSubmit) return;
+        buildSubmit.disabled = blocked;
+        buildSubmit.setAttribute('aria-disabled', blocked ? 'true' : 'false');
+        buildSubmit.title = blocked
+            ? 'Resolve hard blockers before generating the show.'
+            : '';
+    }
     panel.style.display = '';
     body.innerHTML = '<span class="text-muted">Loading...</span>';
     fetch(url)
         .then(function(r) { return r.json(); })
         .then(function(data) {
+            setFullBuildBlocked(data.pre_generation_has_blockers);
             if (data.issue_count === 0) {
                 body.innerHTML = '<span class="text-success"><i class="bi bi-check-circle-fill me-1"></i>No preflight issues — ready to generate.</span>';
             } else {
-                var html = '<div class="d-flex gap-3 mb-2">';
+                var html = '';
+                if (data.pre_generation_has_blockers) {
+                    html += '<div class="alert alert-danger py-2 mb-2"><strong>Build blocked:</strong> Resolve ' +
+                        data.pre_generation_blocking_count + ' input blocker(s) before generating the show.</div>';
+                } else {
+                    html += '<div class="text-success fw-semibold mb-2"><i class="bi bi-check-circle-fill me-1"></i>No input blockers. The full build can proceed.</div>';
+                }
+                html += '<div class="d-flex gap-3 mb-2">';
                 if (data.severity.high)   html += '<span class="text-danger fw-bold">' + data.severity.high + ' high</span>';
                 if (data.severity.medium) html += '<span class="text-warning fw-bold">' + data.severity.medium + ' medium</span>';
                 if (data.severity.low)    html += '<span class="text-muted">' + data.severity.low + ' low</span>';
@@ -1320,12 +1347,12 @@ function loadPreflight() {
             }
         })
         .catch(function() {
-            body.innerHTML = '<span class="text-danger">Preflight check failed to load.</span>';
+            setFullBuildBlocked(false);
+            body.innerHTML = '<span class="text-warning">Preflight status could not be loaded here. Generation will still run the required server-side check before changing the schedule.</span>';
         });
 }
 
-// Auto-load preflight when on Build tab and heats/flights already exist
-{% if flights_built or pro_heats_exist %}
+// Load readiness whenever the operator reaches the Build tab.
 document.addEventListener('DOMContentLoaded', function() {
     var buildTabBtn = document.getElementById('tab-btn-build');
     if (buildTabBtn) {
@@ -1339,15 +1366,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 });
-{% endif %}
-
-// Re-load preflight when switching back to build tab
-var buildTabBtn2 = document.getElementById('tab-btn-build');
-if (buildTabBtn2) {
-    buildTabBtn2.addEventListener('shown.bs.tab', function() {
-        loadPreflight();
-    });
-}
 
 // ── Loading overlay for build actions ────────────────────────────────────
 document.addEventListener('DOMContentLoaded', function() {

--- a/templates/scheduling/preflight.html
+++ b/templates/scheduling/preflight.html
@@ -14,17 +14,17 @@
                     <li class="breadcrumb-item active">Preflight Check</li>
                 </ol>
             </nav>
-            <div class="d-flex justify-content-between align-items-center">
+            <div class="d-flex flex-wrap gap-3 justify-content-between align-items-center">
                 <div>
                     <h1 class="mb-0"><i class="bi bi-shield-check text-dark"></i> Preflight Check</h1>
                     <p class="text-muted mb-0">{{ tournament.name }} {{ tournament.year }}</p>
                 </div>
-                <div class="d-flex gap-2">
+                <div class="d-flex flex-wrap gap-2">
                     <a href="{{ url_for('scheduling.event_list', tournament_id=tournament.id) }}" class="btn btn-outline-secondary">
                         <i class="bi bi-arrow-left"></i> Back to Events &amp; Schedule
                     </a>
                     {% if report.has_autofixable %}
-                    <form method="POST" data-confirm="Apply all auto-fixes now? This will sync heat assignments, assign missing partners, and integrate spillover heats.">
+                    <form method="POST" data-confirm="Apply all safe auto-fixes now? This will parse gear details, complete one-sided gear pairs, assign safe partners, and integrate spillover heats.">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <input type="hidden" name="action" value="autofix">
                         <button class="btn btn-warning" type="submit">
@@ -37,14 +37,24 @@
         </div>
     </div>
 
-    {% if report.has_blockers %}
+    {% if report.pre_generation_blocking %}
     <div class="alert alert-danger d-flex align-items-start" role="alert">
         <i class="bi bi-shield-exclamation me-2 fs-4"></i>
         <div class="flex-grow-1">
-            <strong>{{ report.blocking|length }} hard blocker(s) — heat generation will hold these competitors back.</strong>
-            Resolve the items below before generating heats. Per DOMAIN_CONTRACT,
-            unresolved partners, self-references, non-reciprocal pairs, and heat sync
-            mismatches are not allowed to slip into the schedule.
+            <strong>The full show build is blocked by {{ report.pre_generation_blocking|length }} input blocker(s).</strong>
+            Resolve the items below before generating the show. No schedule changes will be committed
+            while unresolved partners, invalid pairings, or unsafe gear-sharing declarations remain.
+        </div>
+    </div>
+    {% endif %}
+
+    {% if report.post_generation_blocking %}
+    <div class="alert alert-warning d-flex align-items-start" role="alert">
+        <i class="bi bi-exclamation-triangle me-2 fs-4"></i>
+        <div class="flex-grow-1">
+            <strong>The current generated show has {{ report.post_generation_blocking|length }} schedule blocker(s).</strong>
+            These findings do not prevent a fresh full build. The new schedule will be committed only
+            if its relay, spillover, flight positions, closing order, and saw blocks pass validation.
         </div>
     </div>
     {% endif %}

--- a/tests/test_day_of_operations.py
+++ b/tests/test_day_of_operations.py
@@ -790,7 +790,7 @@ class TestFinalizationGuard:
 
         assert calls == []
 
-    def test_regen_gear_conflict_rebuilds_with_operator_warning(
+    def test_regen_gear_conflict_expands_to_safe_heats(
         self, db_session, auth_client
     ):
         t = _make_tournament(db_session)
@@ -813,13 +813,16 @@ class TestFinalizationGuard:
         )
 
         assert resp.status_code == 200
-        assert b"gear-sharing conflict" in resp.data.lower()
+        assert b"gear-sharing conflict" not in resp.data.lower()
         from models.heat import Heat
 
         _db.session.expire_all()
-        heats = Heat.query.filter_by(event_id=e.id).all()
-        assert len(heats) == 1
-        assert sorted(heats[0].get_competitors()) == sorted([first.id, second.id])
+        heats = Heat.query.filter_by(event_id=e.id).order_by(Heat.heat_number).all()
+        assert len(heats) == 2
+        assert {tuple(heat.get_competitors()) for heat in heats} == {
+            (first.id,),
+            (second.id,),
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_event_build_atomicity.py
+++ b/tests/test_event_build_atomicity.py
@@ -134,7 +134,6 @@ def _run_action(
             _handle_event_list_post(
                 tournament,
                 [],
-                generate_event_heats,
                 build_pro_flights,
                 integrate_spillover,
             )
@@ -148,7 +147,7 @@ def _run_action(
     return calls, commit.call_count, flashes, heat, flights
 
 
-@pytest.mark.parametrize('action', ['generate_all', 'rebuild_flights'])
+@pytest.mark.parametrize('action', ['rebuild_flights'])
 def test_active_event_build_chain_commits_once_after_all_steps(
         app, scheduling_state, action):
     calls, commit_count, flashes, heat, flights = _run_action(
@@ -166,7 +165,7 @@ def test_active_event_build_chain_commits_once_after_all_steps(
     assert any(category == 'success' for category, _message in flashes)
 
 
-@pytest.mark.parametrize('action', ['generate_all', 'rebuild_flights'])
+@pytest.mark.parametrize('action', ['rebuild_flights'])
 def test_active_event_build_chain_rolls_back_forced_spillover_failure(
         app, scheduling_state, action):
     calls, commit_count, flashes, heat, flights = _run_action(
@@ -191,7 +190,7 @@ def test_active_event_build_chain_rolls_back_forced_spillover_failure(
     )
 
 
-@pytest.mark.parametrize('action', ['generate_all', 'rebuild_flights'])
+@pytest.mark.parametrize('action', ['rebuild_flights'])
 def test_saw_assignment_failure_rolls_back_generated_schedule(
         app, scheduling_state, action):
     _calls, commit_count, flashes, heat, flights = _run_action(
@@ -255,7 +254,6 @@ def test_standalone_spillover_chain_commits_once_after_relay(app, scheduling_sta
             _handle_event_list_post(
                 tournament,
                 [],
-                lambda _event: 0,
                 lambda _tournament, **_kwargs: 0,
                 integrate_spillover,
             )
@@ -302,7 +300,6 @@ def test_standalone_spillover_rolls_back_relay_and_success_flash(
             _handle_event_list_post(
                 tournament,
                 [],
-                lambda _event: 0,
                 lambda _tournament, **_kwargs: 0,
                 integrate_spillover,
             )

--- a/tests/test_flight_route_atomicity.py
+++ b/tests/test_flight_route_atomicity.py
@@ -174,79 +174,73 @@ def _assert_snapshot_and_flashes(app, client, tournament_id):
 
 
 def test_one_click_build_chain_rolls_back_as_one_unit(app, auth_client):
+    from services.schedule_generation import ScheduleBuildError
+
     tournament_id = _make_tournament(app)
 
     with patch(
-        'routes.scheduling.flights._generate_all_heats',
-        side_effect=_flash_heat_generation_success,
-    ), patch(
-        'routes.scheduling.flights._build_pro_flights_if_possible',
-        side_effect=_mutating_build,
-    ) as build, patch(
-        'services.flight_builder.integrate_proam_relay_into_final_flight',
-        return_value={'placed': True},
-    ) as relay, patch(
-        'services.flight_builder.integrate_college_spillover_into_flights',
-        side_effect=_raise_spillover,
-    ) as spillover:
+        'routes.scheduling.flights.generate_tournament_schedule_artifacts',
+        side_effect=ScheduleBuildError(
+            'spillover_failed',
+            'spillover',
+            'Schedule build failed while integrating Saturday spillover and was rolled back.',
+        ),
+    ) as generate:
         response = auth_client.post(
             f'/scheduling/{tournament_id}/flights/one-click-generate',
             follow_redirects=False,
         )
 
     assert response.status_code in (302, 303)
-    assert build.call_args.kwargs['commit'] is False
-    assert relay.call_args.kwargs['commit'] is False
-    assert spillover.call_args.kwargs['commit'] is False
+    generate.assert_called_once_with(tournament_id)
     _assert_snapshot_and_flashes(app, auth_client, tournament_id)
 
 
 def test_one_click_heat_generation_failure_rolls_back_as_one_unit(
         app, auth_client):
+    from services.schedule_generation import ScheduleBuildError
+
     tournament_id = _make_tournament(app)
 
     with patch(
-        'routes.scheduling.flights._generate_all_heats',
-        side_effect=_raise_after_heat_generation_mutation,
-    ), patch(
-        'services.flight_builder.build_pro_flights',
-    ) as build:
+        'routes.scheduling.flights.generate_tournament_schedule_artifacts',
+        side_effect=ScheduleBuildError(
+            'heat_generation_failed',
+            'heat_generation',
+            'Schedule build failed while generating event heats and was rolled back.',
+        ),
+    ) as generate:
         response = auth_client.post(
             f'/scheduling/{tournament_id}/flights/one-click-generate',
             follow_redirects=False,
         )
 
     assert response.status_code in (302, 303)
-    build.assert_not_called()
+    generate.assert_called_once_with(tournament_id)
     _assert_snapshot_and_flashes(app, auth_client, tournament_id)
 
 
 def test_one_click_saw_assignment_failure_rolls_back_as_one_unit(
         app, auth_client):
+    from services.schedule_generation import ScheduleBuildError
+
     tournament_id = _make_tournament(app)
 
     with patch(
-        'routes.scheduling.flights._generate_all_heats',
-        side_effect=_flash_heat_generation_success,
-    ), patch(
-        'routes.scheduling.flights._build_pro_flights_if_possible',
-        side_effect=_mutating_build,
-    ), patch(
-        'services.flight_builder.integrate_proam_relay_into_final_flight',
-        return_value={'placed': True},
-    ), patch(
-        'services.flight_builder.integrate_college_spillover_into_flights',
-        return_value={'integrated_heats': 0},
-    ), patch(
-        'services.saw_block_assignment.assign_saw_blocks',
-        side_effect=_raise_saw_assignment,
-    ):
+        'routes.scheduling.flights.generate_tournament_schedule_artifacts',
+        side_effect=ScheduleBuildError(
+            'saw_blocks_failed',
+            'saw_blocks',
+            'Schedule build failed while assigning saw blocks and was rolled back.',
+        ),
+    ) as generate:
         response = auth_client.post(
             f'/scheduling/{tournament_id}/flights/one-click-generate',
             follow_redirects=False,
         )
 
     assert response.status_code in (302, 303)
+    generate.assert_called_once_with(tournament_id)
     _assert_snapshot_and_flashes(app, auth_client, tournament_id)
 
 

--- a/tests/test_heat_gen_integration.py
+++ b/tests/test_heat_gen_integration.py
@@ -241,8 +241,8 @@ class TestGenerateSimpleTimeEvent:
 
         assert ev.status == 'in_progress'
 
-    def test_forced_gear_conflict_rebuilds_and_records_the_warning(self, db_session):
-        """A capacity-feasible conflict is rebuilt and surfaced to the judge."""
+    def test_gear_conflict_expands_heat_count_without_a_warning(self, db_session):
+        """A feasible gear conflict expands instead of producing an unsafe heat."""
         t = _make_tournament(db_session)
         ev = _make_event(db_session, t, name='Underhand', stand_type='underhand',
                          max_stands=2)
@@ -259,9 +259,10 @@ class TestGenerateSimpleTimeEvent:
         generate_event_heats(ev)
 
         heats = _all_heats_for_event(ev.id)
-        assert len(heats) == 1
-        assert sorted(heats[0].get_competitors()) == sorted([first.id, second.id])
-        assert get_last_gear_violations(ev.id)
+        assert len(heats) == 2
+        assert sorted(_all_competitor_ids_from_heats(heats)) == sorted([first.id, second.id])
+        assert all(len(heat.get_competitors()) == 1 for heat in heats)
+        assert get_last_gear_violations(ev.id) == []
 
 
 # ---------------------------------------------------------------------------
@@ -326,6 +327,32 @@ class TestGenerateDualRunEvent:
                 stands_r2 = list(a2.values())
                 assert stands_r1 == list(reversed(stands_r2))
 
+    def test_solo_heat_changes_physical_stand_between_runs(self, db_session):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Speed Climb',
+            stand_type='speed_climb',
+            max_stands=2,
+            requires_dual_runs=True,
+        )
+        climber = _make_pro(
+            db_session,
+            t,
+            'Solo Climber',
+            gender='M',
+            event_ids=[ev.id],
+        )
+
+        from services.heat_generator import generate_event_heats
+        generate_event_heats(ev)
+
+        run1 = _all_heats_for_event(ev.id, run_number=1)[0]
+        run2 = _all_heats_for_event(ev.id, run_number=2)[0]
+        assert run1.get_stand_assignments()[str(climber.id)] == 1
+        assert run2.get_stand_assignments()[str(climber.id)] == 2
+
 
 # ---------------------------------------------------------------------------
 # generate_event_heats — partnered event (Double Buck)
@@ -380,7 +407,7 @@ class TestGenerateSpringboardHeats:
 
     Rule (2026-04-20): only one physical LH springboard dummy on site, so at
     most one LH cutter per heat.  Spread LH cutters one per heat 0..N-1.
-    Overflow (more LH than heats) goes into the final heat with a warning.
+    Expand the event when the original heat count has too few dummy time slots.
     """
 
     def test_left_handed_spread_one_per_heat(self, db_session):
@@ -464,8 +491,147 @@ class TestGearSharingConflictAvoidance:
             assert not (alpha.id in comps and beta.id in comps), \
                 'Gear-sharing partners Alpha and Beta are in the same heat'
 
-    def test_gear_sharing_fallback_when_unavoidable(self, db_session):
-        """Unavoidable shared gear is placed and explicitly recorded."""
+    def test_college_team_suffixes_do_not_hide_named_gear_conflicts(self, db_session):
+        t = _make_tournament(db_session)
+        team = _make_team(db_session, t)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Underhand',
+            event_type='college',
+            gender='M',
+            stand_type='underhand',
+            max_stands=2,
+        )
+        first = _make_college(
+            db_session,
+            t,
+            team,
+            'Alice',
+            event_ids=[ev.id],
+            gear_sharing={str(ev.id): 'Bob'},
+        )
+        second = _make_college(
+            db_session,
+            t,
+            team,
+            'Bob',
+            event_ids=[ev.id],
+            gear_sharing={str(ev.id): 'Alice'},
+        )
+
+        from services.heat_generator import generate_event_heats
+        generate_event_heats(ev)
+
+        rosters = [set(heat.get_competitors()) for heat in _all_heats_for_event(ev.id)]
+        assert len(rosters) == 2
+        assert all(not ({first.id, second.id} <= roster) for roster in rosters)
+
+    @pytest.mark.parametrize(
+        ('gear_sharing', 'details'),
+        [
+            ({'Underhand typo': 'Declaration B'}, ''),
+            ({'__current_event__': 'Missing Person'}, ''),
+            ({}, 'SHARING Underhand axe with Missing Person'),
+        ],
+        ids=[
+            'unmapped-current-event-key',
+            'unknown-current-event-partner',
+            'unparsed-current-event-details',
+        ],
+    )
+    def test_invalid_event_gear_declaration_preserves_existing_layout(
+        self,
+        db_session,
+        gear_sharing,
+        details,
+    ):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Underhand',
+            stand_type='underhand',
+            max_stands=2,
+        )
+        first = _make_pro(
+            db_session,
+            t,
+            'Declaration A',
+            event_ids=[ev.id],
+            gear_sharing=gear_sharing,
+        )
+        second = _make_pro(
+            db_session,
+            t,
+            'Declaration B',
+            event_ids=[ev.id],
+        )
+        if '__current_event__' in gear_sharing:
+            first.gear_sharing = json.dumps({
+                str(ev.id): gear_sharing['__current_event__'],
+            })
+        first.gear_sharing_details = details
+
+        from models import Heat
+        old_heat = Heat(event_id=ev.id, heat_number=8, run_number=1)
+        old_heat.set_roster(
+            'pro',
+            [first.id, second.id],
+            {first.id: 1, second.id: 2},
+        )
+        db_session.add(old_heat)
+        db_session.flush()
+        old_heat_id = old_heat.id
+
+        from services.heat_generator import (
+            HeatGenerationSafetyError,
+            generate_event_heats,
+        )
+        with pytest.raises(HeatGenerationSafetyError, match='gear declaration'):
+            generate_event_heats(ev)
+
+        remaining = _all_heats_for_event(ev.id)
+        assert [heat.id for heat in remaining] == [old_heat_id]
+        assert remaining[0].heat_number == 8
+        assert remaining[0].get_competitors() == [first.id, second.id]
+
+    def test_invalid_gear_declaration_for_another_event_does_not_block(
+        self,
+        db_session,
+    ):
+        t = _make_tournament(db_session)
+        underhand = _make_event(
+            db_session,
+            t,
+            name='Underhand',
+            stand_type='underhand',
+            max_stands=2,
+        )
+        _make_event(
+            db_session,
+            t,
+            name='Hot Saw',
+            stand_type='hot_saw',
+            max_stands=2,
+        )
+        competitor = _make_pro(
+            db_session,
+            t,
+            'Scoped Declaration',
+            event_ids=[underhand.id],
+            gear_sharing={'Hot Saw typo': 'Missing Person'},
+        )
+
+        from services.heat_generator import generate_event_heats
+        generate_event_heats(underhand)
+
+        heats = _all_heats_for_event(underhand.id)
+        assert len(heats) == 1
+        assert heats[0].get_competitors() == [competitor.id]
+
+    def test_minimal_heat_conflict_expands_to_a_safe_layout(self, db_session):
+        """Two sharers on a five-stand event run in separate heats."""
         t = _make_tournament(db_session)
         ev = _make_event(db_session, t, name='Underhand', stand_type='underhand',
                          max_stands=5)
@@ -481,8 +647,226 @@ class TestGearSharingConflictAvoidance:
         from services.heat_generator import generate_event_heats, get_last_gear_violations
         generate_event_heats(ev)
 
-        assert len(_all_heats_for_event(ev.id)) == 1
-        assert get_last_gear_violations(ev.id)
+        heats = _all_heats_for_event(ev.id)
+        assert len(heats) == 2
+        assert all(len(heat.get_competitors()) == 1 for heat in heats)
+        assert get_last_gear_violations(ev.id) == []
+
+    def test_partnered_gear_group_expands_without_splitting_pairs(self, db_session):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Double Buck',
+            stand_type='saw_hand',
+            max_stands=4,
+            is_partnered=True,
+            partner_gender_requirement='same',
+        )
+        pairs = [('Pair A1', 'Pair A2'), ('Pair B1', 'Pair B2')]
+        expected_pairs = []
+        for first_name, second_name in pairs:
+            first = _make_pro(
+                db_session,
+                t,
+                first_name,
+                event_ids=[ev.id],
+                partners={str(ev.id): second_name},
+                gear_sharing={str(ev.id): 'group:shared-saw'},
+            )
+            second = _make_pro(
+                db_session,
+                t,
+                second_name,
+                event_ids=[ev.id],
+                partners={str(ev.id): first_name},
+                gear_sharing={str(ev.id): 'group:shared-saw'},
+            )
+            expected_pairs.append({first.id, second.id})
+
+        from services.heat_generator import generate_event_heats
+        generate_event_heats(ev)
+
+        heat_rosters = [set(heat.get_competitors()) for heat in _all_heats_for_event(ev.id)]
+        assert len(heat_rosters) == 2
+        assert set(map(frozenset, heat_rosters)) == set(map(frozenset, expected_pairs))
+
+    def test_dual_run_expansion_keeps_run_rosters_mirrored(self, db_session):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Speed Climb',
+            stand_type='speed_climb',
+            max_stands=2,
+            requires_dual_runs=True,
+        )
+        first = _make_pro(
+            db_session,
+            t,
+            'Climber A',
+            event_ids=[ev.id],
+            gear_sharing={str(ev.id): 'Climber B'},
+        )
+        second = _make_pro(
+            db_session,
+            t,
+            'Climber B',
+            event_ids=[ev.id],
+            gear_sharing={str(ev.id): 'Climber A'},
+        )
+
+        from services.heat_generator import generate_event_heats
+        generate_event_heats(ev)
+
+        run1 = _all_heats_for_event(ev.id, run_number=1)
+        run2 = _all_heats_for_event(ev.id, run_number=2)
+        assert len(run1) == len(run2) == 2
+        assert [heat.get_competitors() for heat in run1] == [
+            heat.get_competitors() for heat in run2
+        ]
+        assert sorted(_all_competitor_ids_from_heats(run1)) == sorted([first.id, second.id])
+
+    def test_invalid_partner_candidate_preserves_existing_layout(self, db_session):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Double Buck',
+            stand_type='saw_hand',
+            max_stands=4,
+            is_partnered=True,
+            partner_gender_requirement='same',
+        )
+        first = _make_pro(
+            db_session,
+            t,
+            'Valid A',
+            event_ids=[ev.id],
+            partners={str(ev.id): 'Valid B'},
+        )
+        second = _make_pro(
+            db_session,
+            t,
+            'Valid B',
+            event_ids=[ev.id],
+            partners={str(ev.id): 'Valid A'},
+        )
+        _make_pro(db_session, t, 'Unpaired', event_ids=[ev.id])
+
+        from models import Heat
+        old_heat = Heat(event_id=ev.id, heat_number=1, run_number=1)
+        old_heat.set_roster('pro', [first.id, second.id], {first.id: 1, second.id: 1})
+        db_session.add(old_heat)
+        db_session.flush()
+        old_heat_id = old_heat.id
+        old_roster = old_heat.get_competitors()
+
+        from services.heat_generator import HeatGenerationSafetyError, generate_event_heats
+        with pytest.raises(HeatGenerationSafetyError, match='partner'):
+            generate_event_heats(ev)
+
+        remaining = _all_heats_for_event(ev.id)
+        assert [heat.id for heat in remaining] == [old_heat_id]
+        assert remaining[0].get_competitors() == old_roster
+
+    def test_invalid_partner_gender_preserves_existing_layout(self, db_session):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Jack & Jill Sawing',
+            stand_type='saw_hand',
+            max_stands=4,
+            is_partnered=True,
+            partner_gender_requirement='mixed',
+        )
+        first = _make_pro(
+            db_session,
+            t,
+            'Same Gender A',
+            gender='M',
+            event_ids=[ev.id],
+            partners={str(ev.id): 'Same Gender B'},
+        )
+        second = _make_pro(
+            db_session,
+            t,
+            'Same Gender B',
+            gender='M',
+            event_ids=[ev.id],
+            partners={str(ev.id): 'Same Gender A'},
+        )
+
+        from models import Heat
+        old_heat = Heat(event_id=ev.id, heat_number=6, run_number=1)
+        old_heat.set_roster(
+            'pro',
+            [first.id, second.id],
+            {first.id: 1, second.id: 1},
+        )
+        db_session.add(old_heat)
+        db_session.flush()
+        old_heat_id = old_heat.id
+
+        from services.heat_generator import (
+            HeatGenerationSafetyError,
+            generate_event_heats,
+        )
+        with pytest.raises(HeatGenerationSafetyError, match='mixed-gender'):
+            generate_event_heats(ev)
+
+        remaining = _all_heats_for_event(ev.id)
+        assert [heat.id for heat in remaining] == [old_heat_id]
+        assert remaining[0].heat_number == 6
+        assert remaining[0].get_competitors() == [first.id, second.id]
+
+    def test_final_candidate_validation_precedes_heat_deletion(self, db_session, monkeypatch):
+        t = _make_tournament(db_session)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Underhand',
+            stand_type='underhand',
+            max_stands=2,
+        )
+        first = _make_pro(
+            db_session,
+            t,
+            'Unsafe A',
+            event_ids=[ev.id],
+            gear_sharing={str(ev.id): 'Unsafe B'},
+        )
+        second = _make_pro(
+            db_session,
+            t,
+            'Unsafe B',
+            event_ids=[ev.id],
+            gear_sharing={str(ev.id): 'Unsafe A'},
+        )
+
+        from models import Heat
+        old_heat = Heat(event_id=ev.id, heat_number=9, run_number=1)
+        old_heat.set_roster('pro', [first.id], {first.id: 1})
+        db_session.add(old_heat)
+        db_session.flush()
+        old_heat_id = old_heat.id
+
+        def unsafe_candidate(competitors, *_args, **_kwargs):
+            return [competitors]
+
+        monkeypatch.setattr(
+            'services.heat_generator._generate_standard_heats',
+            unsafe_candidate,
+        )
+
+        from services.heat_generator import HeatGenerationSafetyError, generate_event_heats
+        with pytest.raises(HeatGenerationSafetyError, match='gear'):
+            generate_event_heats(ev)
+
+        remaining = _all_heats_for_event(ev.id)
+        assert [heat.id for heat in remaining] == [old_heat_id]
+        assert remaining[0].get_competitors() == [first.id]
 
 
 # ---------------------------------------------------------------------------
@@ -797,9 +1181,8 @@ class TestGenerateCollegeEvent:
             c = _make_college(db_session, t, team, f'M Comp {i}', gender='M',
                               event_ids=['Underhand Speed'])
             comp_ids.append(c.id)
-        # Female competitor should be excluded (gender='M' event)
-        _make_college(db_session, t, team, 'F Comp', gender='F',
-                      event_ids=['Underhand Speed'])
+        # A competitor who is not entered in this event remains out of its heats.
+        _make_college(db_session, t, team, 'F Comp', gender='F')
 
         from services.heat_generator import generate_event_heats
         num = generate_event_heats(ev)
@@ -808,6 +1191,33 @@ class TestGenerateCollegeEvent:
         heats = _all_heats_for_event(ev.id)
         assigned = _all_competitor_ids_from_heats(heats)
         assert sorted(assigned) == sorted(comp_ids)
+
+    def test_wrong_gender_entrant_blocks_instead_of_being_omitted(self, db_session):
+        t = _make_tournament(db_session)
+        team = _make_team(db_session, t)
+        ev = _make_event(
+            db_session,
+            t,
+            name='Underhand Speed',
+            event_type='college',
+            gender='M',
+            stand_type='underhand',
+            max_stands=5,
+        )
+        _make_college(
+            db_session,
+            t,
+            team,
+            'Wrong Division',
+            gender='F',
+            event_ids=['Underhand Speed'],
+        )
+
+        from services.heat_generator import HeatGenerationSafetyError, generate_event_heats
+        with pytest.raises(HeatGenerationSafetyError, match='event gender'):
+            generate_event_heats(ev)
+
+        assert _all_heats_for_event(ev.id) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_heat_generator.py
+++ b/tests/test_heat_generator.py
@@ -393,8 +393,7 @@ class TestGenerateSpringboardHeats:
       - Only one physical LH springboard dummy on site.
       - At most one LH cutter per heat.
       - Spread LH cutters one per heat 0..N-1.
-      - If more LH cutters than heats, overflow goes to the FINAL heat with
-        a warning (emitted via lh_warnings list).
+      - Expand the heat count when the original layout has too few time slots.
       - Slow-heat cutters still cluster into the final heat (unchanged).
     """
 
@@ -455,8 +454,8 @@ class TestGenerateSpringboardHeats:
         ]
         assert lh_per_heat == [1, 1, 1, 1]
 
-    def test_overflow_lh_goes_to_final_heat_with_warning(self):
-        """5 LH cutters across 4 heats: 4 spread, 1 overflows to final heat."""
+    def test_lh_overflow_expands_to_one_cutter_per_heat(self):
+        """A fifth LH cutter creates a fifth dummy time slot."""
         ev = _event(event_type='college', stand_type='springboard')
         comps = [
             _comp(1, name='A', is_left_handed=True),
@@ -472,25 +471,18 @@ class TestGenerateSpringboardHeats:
         heats = _generate_springboard_heats(
             comps, 4, 4, {}, event=ev, lh_warnings=lh_warnings,
         )
-        # Heat 0..2 each have exactly 1 LH; final heat has 2 LH.
+        # Each LH cutter gets the sole left-handed dummy in a separate heat.
         lh_per_heat = [
             sum(1 for c in heat if c['id'] in {1, 2, 3, 4, 5})
             for heat in heats
         ]
-        assert lh_per_heat == [1, 1, 1, 2]
-        # Overflow warning emitted for heat 3.
-        assert len(lh_warnings) == 1
-        assert lh_warnings[0]['type'] == 'lh_overflow'
-        assert lh_warnings[0]['heat_index'] == 3
-        assert lh_warnings[0]['overflow_count'] == 1
+        assert lh_per_heat == [1, 1, 1, 1, 1]
+        assert lh_warnings == []
 
-    def test_overflow_unplaceable_when_final_heat_full(self):
-        """LH overflow exceeds max_per_heat of final heat — gear_violations records it."""
+    def test_lh_capacity_expands_until_every_cutter_is_placed(self):
+        """LH dummy capacity expands even when the original final heat is full."""
         ev = _event(event_type='college', stand_type='springboard')
-        # 3 heats of max 2 cutters each = 6 slots.
-        # 4 LH cutters: 3 spread to heats 0/1/2 (one each), 4th overflow to final
-        # heat 2.  Final heat now has 1 LH from spread + 1 LH overflow = 2/2 capacity.
-        # Add a 5th LH: overflow unplaceable.
+        # The original three-heat request cannot represent five LH cutters.
         comps = [
             _comp(1, name='A', is_left_handed=True),
             _comp(2, name='B', is_left_handed=True),
@@ -500,14 +492,14 @@ class TestGenerateSpringboardHeats:
         ]
         lh_warnings: list = []
         gear_violations: list = []
-        _generate_springboard_heats(
+        heats = _generate_springboard_heats(
             comps, 3, 2, {}, event=ev,
             gear_violations=gear_violations, lh_warnings=lh_warnings,
         )
-        # E (id=5) can't fit anywhere — all heats at max 2 after spread + 1 overflow.
-        unplaceable = [v for v in gear_violations if 'unplaced' in v.get('reason', '').lower()]
-        assert len(unplaceable) == 1
-        assert unplaceable[0]['comp_name'] == 'E'
+        assert len(heats) == 5
+        assert [sum(c['is_left_handed'] for c in heat) for heat in heats] == [1] * 5
+        assert gear_violations == []
+        assert lh_warnings == []
 
     def test_no_left_handers_no_warning_and_no_grouping(self):
         ev = _event(event_type='college', stand_type='springboard')
@@ -539,8 +531,8 @@ class TestGenerateSpringboardHeats:
 
     def test_lh_and_slow_heat_both_land_in_final_heat(self):
         """Interaction: 1 LH cutter alone fits heat 0; 1 slow-heat cutter in final.
-        With only 2 heats, final heat hosts the slow cutter AND (eventually) overflow
-        LH would go there too.  Smoke test that both mechanisms coexist without crash.
+        With only 2 heats, the final heat hosts the slow cutter while the LH
+        cutter retains its own dummy slot. Smoke test that both mechanisms coexist.
         """
         ev = _event(event_type='college', stand_type='springboard')
         comps = [
@@ -679,22 +671,10 @@ class TestPartialHeatGoesLast:
             f'Slow cutter must close the event — heats={[[c["id"] for c in h] for h in heats]}'
         )
 
-    def test_gear_violation_heat_index_follows_reorder(self):
-        """When a fallback gear-conflict places a competitor in the partial
-        heat AND the partial gets reordered to the end, the gear_violations
-        entry's heat_index must point at the NEW position so the judge's
-        flash-warning fingers the correct heat (not the original snake-draft
-        index that no longer exists in the final order)."""
-        ev = _event(event_type='college', stand_type='underhand')
-        # 3 competitors, all sharing axe gear → snake forces heat 0 to take
-        # the leftover via the fallback path. With max_per_heat=1, num_heats=3,
-        # so all heats end up partial — _no_ reorder occurs (all-partial guard).
-        # Use 5 comps with max_per_heat=2 → snake gives sizes [1, 2, 2], a real
-        # reorder. To force a fallback gear violation in the partial heat,
-        # competitors share gear so the snake's first pass conflicts.
-        gear = {'axe': True}
+    def test_gear_conflicts_expand_and_partial_heat_still_closes(self):
+        ev = _event(id=9, event_type='college', stand_type='underhand')
         comps = [
-            _comp(i, name=f'C{i}', gear_sharing=dict(gear))
+            _comp(i, name=f'C{i}', gear_sharing={'9': 'group:one-axe'})
             for i in range(1, 6)
         ]
         gear_violations: list = []
@@ -703,23 +683,9 @@ class TestPartialHeatGoesLast:
         )
         sizes = [len(h) for h in heats]
         assert sum(sizes) == 5
-        # Partial heat (size 1) is at the end after reorder.
-        assert sizes[-1] == 1, f'expected partial last, got {sizes}'
-        # Any logged gear_violation heat_index points at a valid heat in the
-        # post-reorder order (not stale pre-reorder index that would mislead
-        # the judge's flash warning to the wrong heat number).
-        for v in gear_violations:
-            idx = v['heat_index']
-            assert 0 <= idx < len(heats), (
-                f'gear_violation heat_index={idx} out of range — stale after reorder?'
-            )
-            # The named competitor must actually be in the heat the violation
-            # points at — proves the remap is correct, not just in-bounds.
-            comp_id = v['comp_id']
-            assert any(c['id'] == comp_id for c in heats[idx]), (
-                f'gear_violation says comp {comp_id} is in heat {idx} but they are not — '
-                f'heat {idx} contains {[c["id"] for c in heats[idx]]}'
-            )
+        assert len(heats) == 5
+        assert all(size == 1 for size in sizes)
+        assert gear_violations == []
 
     def test_partnered_saw_odd_pairs_partial_at_end(self):
         """Partnered Jack & Jill: 5 mixed pairs (10 competitors) on 2-stand heats

--- a/tests/test_lh_ability_ordering.py
+++ b/tests/test_lh_ability_ordering.py
@@ -115,9 +115,8 @@ def _enroll(competitor, event):
 
 
 class TestLhAbilityOverflow:
-    def test_slowest_lh_cutters_land_in_final_overflow_heat(self, db_session):
-        """With 4 LH cutters + 3 heats, the slowest LH (rank 4) goes in the
-        final-heat overflow; the three fastest get their own heats."""
+    def test_ranked_lh_cutters_expand_in_ability_order(self, db_session):
+        """Four LH cutters receive four dummy time slots in ability order."""
         from models import Heat
         from services.heat_generator import generate_event_heats
 
@@ -152,26 +151,26 @@ class TestLhAbilityOverflow:
             )
             .all()
         )
-        assert len(heats) == 3, f"expected 3 heats, got {len(heats)}"
+        assert len(heats) == 4, f"expected 4 heats, got {len(heats)}"
 
-        # Each of the 3 heats gets exactly 1 LH cutter from the spread,
-        # but with 4 LH + 3 heats, one heat ALSO gets the overflow.
         final_heat = heats[-1]
         final_comp_ids = set(final_heat.get_competitors())
         assert lh_slow.id in final_comp_ids, (
-            f"LH slowest (rank 4) should land in the final-heat overflow, "
+            f"LH slowest (rank 4) should land in the final dummy slot, "
             f"got final heat comps {final_comp_ids}."
         )
 
-        # The three FAST LH cutters (ranks 1, 2, 3) get one per heat via spread.
-        # Fastest goes in heat 0 — the slow cutter overflow into heat 2 means
-        # heat 2 already has the rank-3 spread LH. We verify each fast LH ends
-        # up in SOME heat (not orphaned).
+        ordered_lh = []
         all_placed_lh = set()
         for h in heats:
+            heat_lh = []
             for cid in h.get_competitors():
                 if cid in {lh_fast.id, lh_mid1.id, lh_mid2.id, lh_slow.id}:
                     all_placed_lh.add(cid)
+                    heat_lh.append(cid)
+            assert len(heat_lh) == 1
+            ordered_lh.extend(heat_lh)
+        assert ordered_lh == [lh_fast.id, lh_mid1.id, lh_mid2.id, lh_slow.id]
         assert all_placed_lh == {
             lh_fast.id,
             lh_mid1.id,
@@ -204,7 +203,8 @@ class TestLhAbilityOverflow:
         # the no-ranks case and returns the input list unchanged.
         generate_event_heats(ev)
         heats = Heat.query.filter_by(event_id=ev.id, run_number=1).all()
-        assert len(heats) == 3
+        heats = sorted(heats, key=lambda heat: heat.heat_number)
+        assert len(heats) == 4
 
         # All 4 LH cutters placed somewhere.
         all_placed_lh = set()
@@ -213,6 +213,11 @@ class TestLhAbilityOverflow:
                 if cid in {lh1.id, lh2.id, lh3.id, lh4.id}:
                     all_placed_lh.add(cid)
         assert all_placed_lh == {lh1.id, lh2.id, lh3.id, lh4.id}
+        ordered_lh = [
+            next(cid for cid in heat.get_competitors() if cid in all_placed_lh)
+            for heat in heats
+        ]
+        assert ordered_lh == [lh1.id, lh2.id, lh3.id, lh4.id]
 
     def test_single_lh_with_rank_still_gets_stand_4(self, db_session):
         """Regression guard: ability-sort on a single-LH input list

--- a/tests/test_lh_springboard_stand_4.py
+++ b/tests/test_lh_springboard_stand_4.py
@@ -201,9 +201,8 @@ class TestLhCutterGetsStand4:
 
 
 class TestMultipleLhInSameHeat:
-    def test_two_lh_same_heat_first_gets_stand_4_and_warning_fires(self, db_session):
-        """When 2+ LH cutters land in the same heat, first gets stand 4 +
-        a 'multiple_lh_same_heat' warning is recorded."""
+    def test_multiple_lh_cutters_expand_to_one_dummy_slot_each(self, db_session):
+        """Generation never schedules two cutters on the sole LH dummy together."""
         from services.heat_generator import (
             generate_event_heats,
             get_last_lh_overflow_warnings,
@@ -223,11 +222,17 @@ class TestMultipleLhInSameHeat:
 
         generate_event_heats(ev)
 
+        from models import Heat
+
+        heats = Heat.query.filter_by(event_id=ev.id, run_number=1).order_by(
+            Heat.heat_number
+        ).all()
+        assert len(heats) == 4
+        for heat in heats:
+            assert len(heat.get_competitors()) == 1
+            assert list(heat.get_stand_assignments().values()) == [4]
         warnings = get_last_lh_overflow_warnings(ev.id)
-        types = {w.get("type") for w in warnings}
-        assert (
-            "multiple_lh_same_heat" in types
-        ), f"expected 'multiple_lh_same_heat' warning, got types {types}"
+        assert warnings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_persisted_config_route_reads.py
+++ b/tests/test_persisted_config_route_reads.py
@@ -344,6 +344,9 @@ class TestAsyncGenerateArtifactsChainsRelayAndSpillover:
         ), patch(
             "services.flight_builder.integrate_college_spillover_into_flights",
             side_effect=_spill_spy,
+        ), patch(
+            "services.preflight.build_preflight_report",
+            return_value={"issues": []},
         ):
             result = generate_tournament_schedule_artifacts(tid)
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1129,6 +1129,8 @@ class TestFullyValidTournament:
                                 stand_type='saw_hand', is_partnered=True)
         p1 = _make_pro(db_session, tournament, 'Pro A', event_ids=[partnered.id])
         p2 = _make_pro(db_session, tournament, 'Pro B', event_ids=[partnered.id])
+        p1.partners = json.dumps({str(partnered.id): p2.name})
+        p2.partners = json.dumps({str(partnered.id): p1.name})
         heat2 = _make_heat(db_session, partnered)
         _make_heat_assignment(db_session, heat2.id, p1.id)
         _make_heat_assignment(db_session, heat2.id, p2.id)
@@ -1393,9 +1395,13 @@ class TestBlockingCodes:
         }
         blocking = get_blocking_issues(report)
 
-        assert len(blocking) == 2
+        assert len(blocking) == 3
         codes = {b['code'] for b in blocking}
-        assert codes == {'unresolved_partner_name', 'non_reciprocal_partnership'}
+        assert codes == {
+            'unresolved_partner_name',
+            'non_reciprocal_partnership',
+            'gear_partner_mismatch',
+        }
 
     def test_clean_tournament_has_no_blockers(self, db_session, tournament):
         from services.preflight import build_preflight_report

--- a/tests/test_schedule_generation.py
+++ b/tests/test_schedule_generation.py
@@ -137,12 +137,35 @@ def test_run_preflight_autofix_reports_its_summary_numbers(db_session, monkeypat
 
 
 def test_generate_tournament_schedule_artifacts_returns_error_for_missing_tournament():
-    from services.schedule_generation import generate_tournament_schedule_artifacts
+    from services.schedule_generation import (
+        ScheduleBuildError,
+        generate_tournament_schedule_artifacts,
+    )
 
-    result = generate_tournament_schedule_artifacts(999999)
+    with pytest.raises(ScheduleBuildError) as exc_info:
+        generate_tournament_schedule_artifacts(999999)
 
-    assert result['ok'] is False
-    assert 'not found' in result['error']
+    assert exc_info.value.code == 'tournament_not_found'
+    assert 'not found' in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ('submitted', 'expected'),
+    [('1', 2), ('99', 10)],
+)
+def test_normalize_flight_sizing_input_clamps_submitted_flight_count(
+    submitted,
+    expected,
+):
+    from services.schedule_generation import normalize_flight_sizing_input
+
+    sizing = normalize_flight_sizing_input({
+        'flight_sizing_mode': 'fixed',
+        'num_flights': submitted,
+    })
+
+    assert sizing['num_flights'] == expected
+    assert sizing['requested_num_flights'] == expected
 
 
 def test_generate_tournament_schedule_artifacts_orchestrates_heat_and_flight_generation(
@@ -189,7 +212,10 @@ def test_generate_tournament_schedule_rolls_back_all_events_on_error(
     monkeypatch,
 ):
     from models import Heat
-    from services.schedule_generation import generate_tournament_schedule_artifacts
+    from services.schedule_generation import (
+        ScheduleBuildError,
+        generate_tournament_schedule_artifacts,
+    )
 
     tournament = _make_tournament(db_session)
     success_event = _make_event(
@@ -212,11 +238,11 @@ def test_generate_tournament_schedule_rolls_back_all_events_on_error(
         'services.heat_generator.generate_event_heats', _fake_generate,
     )
 
-    result = generate_tournament_schedule_artifacts(tournament.id)
+    with pytest.raises(ScheduleBuildError) as exc_info:
+        generate_tournament_schedule_artifacts(tournament.id)
 
-    assert result['ok'] is False
-    assert result['generated'] == 0
-    assert result['errors'] == ['kaboom']
+    assert exc_info.value.phase == 'heat_generation'
+    assert 'kaboom' not in str(exc_info.value)
     assert Heat.query.filter_by(event_id=success_event.id).count() == 0
 
 
@@ -226,7 +252,10 @@ def test_generate_tournament_schedule_rolls_back_partial_failed_event(
 ):
     """A failed event must not leak flushed heat rows into the final commit."""
     from models import Heat
-    from services.schedule_generation import generate_tournament_schedule_artifacts
+    from services.schedule_generation import (
+        ScheduleBuildError,
+        generate_tournament_schedule_artifacts,
+    )
 
     tournament = _make_tournament(db_session)
     failed_event = _make_event(db_session, tournament, 'Partial Failure', event_type='pro')
@@ -239,11 +268,11 @@ def test_generate_tournament_schedule_rolls_back_partial_failed_event(
 
     monkeypatch.setattr('services.heat_generator.generate_event_heats', _partial_failure)
 
-    result = generate_tournament_schedule_artifacts(tournament.id)
+    with pytest.raises(ScheduleBuildError) as exc_info:
+        generate_tournament_schedule_artifacts(tournament.id)
 
-    assert result['ok'] is False
-    assert result['generated'] == 0
-    assert result['errors'] == ['forced failure after flush']
+    assert exc_info.value.phase == 'heat_generation'
+    assert 'forced failure after flush' not in str(exc_info.value)
     assert Heat.query.filter_by(event_id=failed_event.id).count() == 0
 
 
@@ -252,7 +281,10 @@ def test_generate_tournament_schedule_rolls_back_heats_when_flight_chain_fails(
     monkeypatch,
 ):
     from models import Heat
-    from services.schedule_generation import generate_tournament_schedule_artifacts
+    from services.schedule_generation import (
+        ScheduleBuildError,
+        generate_tournament_schedule_artifacts,
+    )
 
     tournament = _make_tournament(db_session)
     event = _make_event(db_session, tournament, 'Atomic Background Event')
@@ -280,13 +312,11 @@ def test_generate_tournament_schedule_rolls_back_heats_when_flight_chain_fails(
         ),
     )
 
-    result = generate_tournament_schedule_artifacts(tournament.id)
+    with pytest.raises(ScheduleBuildError) as exc_info:
+        generate_tournament_schedule_artifacts(tournament.id)
 
-    assert result['ok'] is False
-    assert result['generated'] == 0
-    assert result['errors'] == [
-        'flight build chain failed: forced spillover failure',
-    ]
+    assert exc_info.value.phase == 'spillover'
+    assert 'forced spillover failure' not in str(exc_info.value)
     assert Heat.query.filter_by(event_id=event.id).count() == 0
 
 

--- a/tests/test_show_readiness.py
+++ b/tests/test_show_readiness.py
@@ -1,0 +1,765 @@
+"""Fail-closed full-show generation tests.
+
+All database cases use the temporary migrated SQLite fixture from
+``tests.conftest``. No production or private-mirror connection is used.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from database import db
+from tests.conftest import make_event, make_heat, make_pro_competitor, make_tournament
+
+
+def _clear_readiness(monkeypatch, calls: list[str] | None = None) -> None:
+    report_calls = 0
+
+    def _report(_tournament, _saturday_ids):
+        nonlocal report_calls
+        report_calls += 1
+        if calls is not None:
+            calls.append(f'preflight:{report_calls}')
+        return {'issues': []}
+
+    monkeypatch.setattr('services.preflight.build_preflight_report', _report)
+
+
+def test_blocking_codes_are_phase_aware_and_keep_aggregate_contract():
+    from services.preflight import (
+        BLOCKING_CODES,
+        POST_GENERATION_BLOCKING_CODES,
+        PRE_GENERATION_BLOCKING_CODES,
+    )
+
+    assert 'missing_partner_name' in PRE_GENERATION_BLOCKING_CODES
+    assert 'unresolved_partner_name' in PRE_GENERATION_BLOCKING_CODES
+    assert {
+        'gear_details_not_parsed',
+        'gear_unmapped_event_keys',
+        'gear_unknown_partner_names',
+        'gear_self_reference',
+        'gear_partner_mismatch',
+        'partnered_axe_pair_state_invalid',
+        'partnered_axe_prelims_incomplete',
+        'partnered_axe_finals_not_advanced',
+    } <= PRE_GENERATION_BLOCKING_CODES
+    assert 'invalid_flight_position' in POST_GENERATION_BLOCKING_CODES
+    assert PRE_GENERATION_BLOCKING_CODES.isdisjoint(POST_GENERATION_BLOCKING_CODES)
+    assert BLOCKING_CODES == (
+        PRE_GENERATION_BLOCKING_CODES | POST_GENERATION_BLOCKING_CODES
+    )
+
+
+def test_preflight_json_separates_input_blockers_from_generated_show_blockers(
+    db_session, auth_client, monkeypatch
+):
+    tournament = make_tournament(db_session, name='Phase-Aware Preflight JSON')
+    report = {
+        'issue_count': 2,
+        'severity': {'high': 2, 'medium': 0, 'low': 0},
+        'has_blockers': True,
+        'blocking': [
+            {'code': 'missing_partner_name'},
+            {'code': 'invalid_flight_position'},
+        ],
+        'pre_generation_blocking': [{'code': 'missing_partner_name'}],
+        'post_generation_blocking': [{'code': 'invalid_flight_position'}],
+        'issues': [
+            {
+                'severity': 'high',
+                'code': 'missing_partner_name',
+                'title': 'Partner declaration is blank',
+                'detail': 'Repair the pair.',
+                'autofix': False,
+            },
+            {
+                'severity': 'high',
+                'code': 'invalid_flight_position',
+                'title': 'Generated flight position is invalid',
+                'detail': 'Rebuild the generated show.',
+                'autofix': False,
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        'services.preflight.build_preflight_report', lambda *_args: report
+    )
+
+    response = auth_client.get(
+        f'/scheduling/{tournament.id}/preflight-json'
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['has_blockers'] is True
+    assert payload['blocking_count'] == 2
+    assert payload['pre_generation_has_blockers'] is True
+    assert payload['pre_generation_blocking_count'] == 1
+    assert payload['post_generation_has_blockers'] is True
+    assert payload['post_generation_blocking_count'] == 1
+
+
+def test_blank_partner_declarations_block_before_generation(db_session):
+    from services.preflight import (
+        build_preflight_report,
+        get_pre_generation_blocking_issues,
+    )
+
+    tournament = make_tournament(db_session, name='Blank Partner Gate')
+    event = make_event(
+        db_session,
+        tournament,
+        'Jack & Jill Sawing',
+        is_partnered=True,
+    )
+    make_pro_competitor(
+        db_session, tournament, 'Alex Blank', gender='F', events=[event.name]
+    )
+    make_pro_competitor(
+        db_session, tournament, 'Jordan Blank', gender='M', events=[event.name]
+    )
+
+    report = build_preflight_report(tournament)
+    blockers = get_pre_generation_blocking_issues(report)
+
+    missing = [issue for issue in blockers if issue['code'] == 'missing_partner_name']
+    assert len(missing) == 1
+    assert missing[0]['event_ids'] == [event.id]
+    assert {row['competitor_name'] for row in missing[0]['missing']} == {
+        'Alex Blank',
+        'Jordan Blank',
+    }
+
+
+def test_partnered_axe_state_pairs_do_not_require_duplicate_partner_fields(db_session):
+    from services.preflight import build_preflight_report
+
+    tournament = make_tournament(db_session, name='Partnered Axe State Preflight')
+    event = make_event(
+        db_session,
+        tournament,
+        'Partnered Axe Throw',
+        is_partnered=True,
+        has_prelims=True,
+        stand_type='axe_throw',
+        scoring_type='score',
+        scoring_order='highest_wins',
+    )
+    first = make_pro_competitor(
+        db_session, tournament, 'Axe Partner A', events=[event.id]
+    )
+    second = make_pro_competitor(
+        db_session, tournament, 'Axe Partner B', events=[event.id]
+    )
+    pair = {
+        'pair_id': 1,
+        'competitor1': {'id': first.id, 'name': first.name},
+        'competitor2': {'id': second.id, 'name': second.name},
+        'prelim_score': None,
+        'final_score': None,
+        'final_position': None,
+    }
+    event.event_state = json.dumps({
+        'stage': 'prelims',
+        'pairs': [pair],
+        'prelim_results': [],
+        'finalists': [],
+        'final_results': [],
+    })
+    db_session.flush()
+
+    report = build_preflight_report(tournament)
+    codes = {issue['code'] for issue in report['issues']}
+
+    assert 'missing_partner_name' not in codes
+    assert 'unresolved_partner_name' not in codes
+    assert 'non_reciprocal_partnership' not in codes
+    assert 'invalid_partner_gender' not in codes
+    assert 'partnered_axe_prelims_incomplete' in codes
+
+
+def test_partnered_axe_preflight_validates_authoritative_pair_coverage(db_session):
+    from services.preflight import (
+        build_preflight_report,
+        get_pre_generation_blocking_issues,
+    )
+
+    tournament = make_tournament(db_session, name='Partnered Axe Pair Coverage')
+    event = make_event(
+        db_session,
+        tournament,
+        'Partnered Axe Throw',
+        is_partnered=True,
+        has_prelims=True,
+        stand_type='axe_throw',
+        scoring_type='score',
+        scoring_order='highest_wins',
+    )
+    first = make_pro_competitor(
+        db_session, tournament, 'Registered Axe Partner', events=[event.id]
+    )
+    make_pro_competitor(
+        db_session, tournament, 'Unpaired Axe Entrant', events=[event.id]
+    )
+    event.event_state = json.dumps({
+        'stage': 'prelims',
+        'pairs': [{
+            'pair_id': 1,
+            'competitor1': {'id': first.id, 'name': first.name},
+            'competitor2': {'id': first.id, 'name': first.name},
+            'prelim_score': None,
+            'final_score': None,
+            'final_position': None,
+        }],
+        'prelim_results': [],
+        'finalists': [],
+        'final_results': [],
+    })
+    db_session.flush()
+
+    blockers = get_pre_generation_blocking_issues(
+        build_preflight_report(tournament)
+    )
+    assert 'partnered_axe_pair_state_invalid' in {
+        issue['code'] for issue in blockers
+    }
+
+
+def test_partnered_axe_preflight_requires_advancing_scored_prelims(db_session):
+    from services.preflight import (
+        build_preflight_report,
+        get_pre_generation_blocking_issues,
+    )
+
+    tournament = make_tournament(db_session, name='Partnered Axe Advance Gate')
+    event = make_event(
+        db_session,
+        tournament,
+        'Partnered Axe Throw',
+        is_partnered=True,
+        has_prelims=True,
+        stand_type='axe_throw',
+        scoring_type='score',
+        scoring_order='highest_wins',
+    )
+    first = make_pro_competitor(
+        db_session, tournament, 'Scored Axe A', events=[event.id]
+    )
+    second = make_pro_competitor(
+        db_session, tournament, 'Scored Axe B', events=[event.id]
+    )
+    pair = {
+        'pair_id': 1,
+        'competitor1': {'id': first.id, 'name': first.name},
+        'competitor2': {'id': second.id, 'name': second.name},
+        'prelim_score': 12,
+        'final_score': None,
+        'final_position': None,
+    }
+    event.event_state = json.dumps({
+        'stage': 'prelims',
+        'pairs': [pair],
+        'prelim_results': [pair],
+        'finalists': [],
+        'final_results': [],
+    })
+    db_session.flush()
+
+    blockers = get_pre_generation_blocking_issues(
+        build_preflight_report(tournament)
+    )
+    assert 'partnered_axe_finals_not_advanced' in {
+        issue['code'] for issue in blockers
+    }
+
+
+def test_partnered_axe_preflight_does_not_reopen_completed_pair_state(db_session):
+    from services.preflight import (
+        build_preflight_report,
+        get_pre_generation_blocking_issues,
+    )
+
+    tournament = make_tournament(db_session, name='Completed Partnered Axe Gate')
+    event = make_event(
+        db_session,
+        tournament,
+        'Partnered Axe Throw',
+        is_partnered=True,
+        has_prelims=True,
+        stand_type='axe_throw',
+        scoring_type='score',
+        scoring_order='highest_wins',
+        status='completed',
+    )
+    event.is_finalized = True
+    make_pro_competitor(
+        db_session, tournament, 'Historical Axe Entrant', events=[event.id]
+    )
+    event.event_state = json.dumps({
+        'stage': 'completed',
+        'pairs': [],
+        'prelim_results': [],
+        'finalists': [],
+        'final_results': [],
+    })
+    db_session.flush()
+
+    codes = {
+        issue['code']
+        for issue in get_pre_generation_blocking_issues(
+            build_preflight_report(tournament)
+        )
+    }
+    assert 'partnered_axe_pair_state_invalid' not in codes
+    assert 'partnered_axe_prelims_incomplete' not in codes
+    assert 'partnered_axe_finals_not_advanced' not in codes
+
+
+def test_full_show_service_runs_every_phase_in_order(db_session, monkeypatch):
+    from models import Heat
+    from services.schedule_generation import generate_tournament_schedule_artifacts
+
+    tournament = make_tournament(db_session, name='Ordered Full Show')
+    event = make_event(db_session, tournament, 'Underhand')
+    calls: list[str] = []
+    _clear_readiness(monkeypatch, calls)
+
+    def _generate(candidate, *, allow_flight_replacement=False):
+        assert allow_flight_replacement is True
+        calls.append(f'heat:{candidate.id}')
+        db.session.add(Heat(event_id=candidate.id, heat_number=1, run_number=1))
+        db.session.flush()
+        return 1
+
+    monkeypatch.setattr('services.heat_generator.generate_event_heats', _generate)
+    monkeypatch.setattr(
+        'services.flight_builder.build_pro_flights',
+        lambda *_args, **_kwargs: calls.append('flights') or 1,
+    )
+    monkeypatch.setattr(
+        'services.flight_builder.integrate_proam_relay_into_final_flight',
+        lambda *_args, **_kwargs: calls.append('relay') or {'placed': True},
+    )
+    monkeypatch.setattr(
+        'services.flight_builder.integrate_college_spillover_into_flights',
+        lambda *_args, **_kwargs: calls.append('spillover')
+        or {'integrated_heats': 2},
+    )
+    monkeypatch.setattr(
+        'services.saw_block_assignment.assign_saw_blocks',
+        lambda *_args, **_kwargs: calls.append('saw_blocks')
+        or {'heats_updated': 3},
+    )
+
+    result = generate_tournament_schedule_artifacts(tournament.id)
+
+    assert result['ok'] is True
+    assert result['generated'] == 1
+    assert result['flights'] == 1
+    assert result['relay']['placed'] is True
+    assert result['spillover']['integrated_heats'] == 2
+    assert result['saw_blocks']['heats_updated'] == 3
+    assert calls == [
+        'preflight:1',
+        f'heat:{event.id}',
+        'flights',
+        'relay',
+        'spillover',
+        'saw_blocks',
+        'preflight:2',
+    ]
+
+
+def test_pre_generation_blocker_prevents_any_schedule_mutation(
+    db_session, monkeypatch
+):
+    from services.schedule_generation import (
+        ScheduleReadinessError,
+        generate_tournament_schedule_artifacts,
+    )
+
+    tournament = make_tournament(db_session, name='Blocked Full Show')
+    event = make_event(db_session, tournament, 'Partnered Event', is_partnered=True)
+    existing = make_heat(db_session, event, heat_number=7)
+    db_session.commit()
+
+    report = {
+        'issues': [{
+            'code': 'missing_partner_name',
+            'title': 'Partner declaration is blank',
+            'detail': 'Partnered Event: Alex Blank needs a partner.',
+            'event_ids': [event.id],
+        }]
+    }
+    monkeypatch.setattr(
+        'services.preflight.build_preflight_report', lambda *_args: report
+    )
+    monkeypatch.setattr(
+        'services.heat_generator.generate_event_heats',
+        lambda *_args, **_kwargs: pytest.fail('generation ran despite readiness blocker'),
+    )
+
+    with pytest.raises(ScheduleReadinessError) as exc_info:
+        generate_tournament_schedule_artifacts(tournament.id)
+
+    assert exc_info.value.phase == 'pre_generation'
+    assert exc_info.value.issue_codes == ('missing_partner_name',)
+    assert 'Preflight' in str(exc_info.value)
+    assert db.session.get(type(existing), existing.id) is existing
+    assert existing.heat_number == 7
+
+
+def test_full_show_preserves_finalized_and_scored_events(db_session, monkeypatch):
+    from models import EventResult, Heat
+    from services.schedule_generation import generate_tournament_schedule_artifacts
+
+    tournament = make_tournament(db_session, name='Protected History')
+    finalized = make_event(db_session, tournament, 'Finalized', event_type='college')
+    finalized.is_finalized = True
+    scored = make_event(db_session, tournament, 'Scored', event_type='college')
+    pending = make_event(db_session, tournament, 'Pending', event_type='college')
+    finalized_heat = make_heat(db_session, finalized, heat_number=4)
+    scored_heat = make_heat(db_session, scored, heat_number=5)
+    db_session.add(EventResult(
+        event_id=scored.id,
+        competitor_id=123,
+        competitor_type='college',
+        competitor_name='Historical Competitor',
+        status='completed',
+        result_value=10.0,
+    ))
+    db_session.flush()
+    _clear_readiness(monkeypatch)
+    generated_ids: list[int] = []
+
+    def _generate(event, *, allow_flight_replacement=False):
+        generated_ids.append(event.id)
+        db.session.add(Heat(event_id=event.id, heat_number=1, run_number=1))
+        db.session.flush()
+        return 1
+
+    monkeypatch.setattr('services.heat_generator.generate_event_heats', _generate)
+    monkeypatch.setattr(
+        'services.saw_block_assignment.assign_saw_blocks',
+        lambda *_args, **_kwargs: {'heats_updated': 0},
+    )
+
+    result = generate_tournament_schedule_artifacts(tournament.id)
+
+    assert generated_ids == [pending.id]
+    assert {item['event_id'] for item in result['protected']} == {
+        finalized.id,
+        scored.id,
+    }
+    assert db.session.get(Heat, finalized_heat.id).heat_number == 4
+    assert db.session.get(Heat, scored_heat.id).heat_number == 5
+
+
+def test_partnered_axe_prelim_scores_allow_final_card_build_until_finals_start(
+    db_session,
+    monkeypatch,
+):
+    from models import EventResult, Heat
+    from services.flight_builder import _prepare_partnered_axe_show_heats
+    from services.schedule_generation import (
+        _protected_event_reason,
+        generate_tournament_schedule_artifacts,
+    )
+
+    tournament = make_tournament(db_session, name='Partnered Axe Final Card')
+    axe_event = make_event(
+        db_session,
+        tournament,
+        'Partnered Axe Throw',
+        is_partnered=True,
+        has_prelims=True,
+        stand_type='axe_throw',
+        scoring_type='score',
+        scoring_order='highest_wins',
+    )
+    pairs = []
+    for index in range(4):
+        first = make_pro_competitor(
+            db_session,
+            tournament,
+            f'Axe {index}A',
+            events=[axe_event.id],
+        )
+        second = make_pro_competitor(
+            db_session,
+            tournament,
+            f'Axe {index}B',
+            events=[axe_event.id],
+        )
+        pair = {
+            'pair_id': index + 1,
+            'competitor1': {'id': first.id, 'name': first.name},
+            'competitor2': {'id': second.id, 'name': second.name},
+            'prelim_score': 20 - index,
+            'final_score': None,
+            'final_position': None,
+        }
+        pairs.append(pair)
+        for competitor in (first, second):
+            db_session.add(EventResult(
+                event_id=axe_event.id,
+                competitor_id=competitor.id,
+                competitor_type='pro',
+                competitor_name=competitor.name,
+                result_value=pair['prelim_score'],
+                status='completed',
+            ))
+    axe_event.event_state = json.dumps({
+        'stage': 'finals',
+        'pairs': pairs,
+        'prelim_results': pairs,
+        'finalists': pairs,
+        'final_results': [],
+    })
+
+    normal_event = make_event(
+        db_session,
+        tournament,
+        'Underhand',
+        stand_type='underhand',
+        max_stands=2,
+    )
+    make_pro_competitor(
+        db_session,
+        tournament,
+        'Regular Show Cutter',
+        events=[normal_event.id],
+    )
+    db_session.flush()
+    _clear_readiness(monkeypatch)
+
+    assert _protected_event_reason(axe_event) is None
+
+    def _build_flights(*_args, **_kwargs):
+        _prepare_partnered_axe_show_heats(axe_event)
+        return 1
+
+    monkeypatch.setattr('services.flight_builder.build_pro_flights', _build_flights)
+    monkeypatch.setattr(
+        'services.flight_builder.integrate_proam_relay_into_final_flight',
+        lambda *_args, **_kwargs: {'placed': False, 'reason': 'not_configured'},
+    )
+    monkeypatch.setattr(
+        'services.flight_builder.integrate_college_spillover_into_flights',
+        lambda *_args, **_kwargs: {'integrated_heats': 0},
+    )
+    monkeypatch.setattr(
+        'services.saw_block_assignment.assign_saw_blocks',
+        lambda *_args, **_kwargs: {'heats_updated': 0},
+    )
+
+    result = generate_tournament_schedule_artifacts(tournament.id)
+
+    assert axe_event.id not in {item['event_id'] for item in result['protected']}
+    assert Heat.query.filter_by(event_id=axe_event.id, run_number=1).count() == 4
+
+    state = json.loads(axe_event.event_state)
+    state['finalists'][0]['final_score'] = 25
+    axe_event.event_state = json.dumps(state)
+    db_session.flush()
+    assert _protected_event_reason(axe_event) == 'scored finals'
+
+
+def test_post_generation_blocker_rolls_back_the_entire_build(
+    db_session, monkeypatch
+):
+    from models import Heat
+    from services.schedule_generation import (
+        ScheduleReadinessError,
+        generate_tournament_schedule_artifacts,
+    )
+
+    tournament = make_tournament(db_session, name='Post-Build Rollback')
+    event = make_event(db_session, tournament, 'College Underhand', event_type='college')
+    existing = make_heat(db_session, event, heat_number=9)
+    existing_id = existing.id
+    db_session.commit()
+    report_count = 0
+
+    def _report(*_args):
+        nonlocal report_count
+        report_count += 1
+        if report_count == 1:
+            return {'issues': []}
+        return {'issues': [{
+            'code': 'invalid_flight_position',
+            'title': 'Generated flight position is invalid',
+            'detail': 'College Underhand has an invalid generated position.',
+            'event_id': event.id,
+        }]}
+
+    def _replace(candidate, *, allow_flight_replacement=False):
+        current = Heat.query.filter_by(event_id=candidate.id).one()
+        current.heat_number = 1
+        db.session.flush()
+        return 1
+
+    monkeypatch.setattr('services.preflight.build_preflight_report', _report)
+    monkeypatch.setattr('services.heat_generator.generate_event_heats', _replace)
+    monkeypatch.setattr(
+        'services.saw_block_assignment.assign_saw_blocks',
+        lambda *_args, **_kwargs: {'heats_updated': 0},
+    )
+
+    with pytest.raises(ScheduleReadinessError) as exc_info:
+        generate_tournament_schedule_artifacts(tournament.id)
+
+    assert exc_info.value.phase == 'post_generation'
+    restored = db.session.get(Heat, existing_id)
+    assert restored is not None
+    assert restored.heat_number == 9
+
+
+def test_one_click_route_delegates_to_full_show_service(
+    db_session, auth_client, monkeypatch
+):
+    tournament = make_tournament(db_session, name='Delegated One Click')
+    calls: list[int] = []
+
+    def _generate(tournament_id, **_kwargs):
+        calls.append(tournament_id)
+        return {
+            'ok': True,
+            'generated': 0,
+            'skipped': [],
+            'protected': [],
+            'flights': None,
+            'relay': {'placed': False},
+            'spillover': {'integrated_heats': 0},
+            'saw_blocks': {'heats_updated': 0},
+        }
+
+    monkeypatch.setattr(
+        'routes.scheduling.flights.generate_tournament_schedule_artifacts',
+        _generate,
+    )
+
+    response = auth_client.post(
+        f'/scheduling/{tournament.id}/flights/one-click-generate',
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    assert calls == [tournament.id]
+
+
+def test_run_show_route_delegates_to_full_show_service(
+    db_session, auth_client, monkeypatch
+):
+    tournament = make_tournament(db_session, name='Delegated Run Show')
+    calls: list[tuple[int, dict | None]] = []
+
+    def _generate(tournament_id, *, flight_sizing=None):
+        calls.append((tournament_id, flight_sizing))
+        return {
+            'ok': True,
+            'generated': 0,
+            'skipped_events': [],
+            'protected': [],
+            'flights': None,
+            'relay': {'placed': False},
+            'spillover': {'integrated_heats': 0},
+            'build_diff': {
+                'before_flight_count': 0,
+                'after_flight_count': 0,
+                'total_heats': 0,
+            },
+        }
+
+    monkeypatch.setattr(
+        'routes.scheduling.events.generate_tournament_schedule_artifacts',
+        _generate,
+    )
+
+    response = auth_client.post(
+        f'/scheduling/{tournament.id}/events',
+        data={
+            'action': 'generate_all',
+            'flight_sizing_mode': 'count',
+            'num_flights': '3',
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code in (302, 303)
+    assert calls == [(
+        tournament.id,
+        {
+            'mode': 'count',
+            'target_minutes_per_flight': 60,
+            'minutes_per_heat': 5.5,
+            'num_flights': 3,
+            'requested_num_flights': 3,
+        },
+    )]
+
+
+def test_async_route_submits_the_shared_full_show_service(
+    db_session, auth_client, monkeypatch
+):
+    from services.schedule_generation import generate_tournament_schedule_artifacts
+
+    tournament = make_tournament(db_session, name='Delegated Background Show')
+    submitted = {}
+
+    def _submit(label, fn, *args, metadata=None, **kwargs):
+        submitted.update({
+            'label': label,
+            'fn': fn,
+            'args': args,
+            'metadata': metadata,
+            'kwargs': kwargs,
+        })
+        return 'job-123'
+
+    monkeypatch.setattr('routes.scheduling.preflight.submit_job', _submit)
+
+    response = auth_client.post(
+        f'/scheduling/{tournament.id}/events/generate-async'
+    )
+
+    assert response.status_code == 202
+    assert submitted == {
+        'label': f'generate_all:{tournament.id}',
+        'fn': generate_tournament_schedule_artifacts,
+        'args': (tournament.id,),
+        'metadata': {
+            'tournament_id': tournament.id,
+            'kind': 'generate_all',
+        },
+        'kwargs': {},
+    }
+
+
+def test_job_polling_reports_legacy_ok_false_payload_as_failed(
+    db_session, auth_client, monkeypatch
+):
+    tournament = make_tournament(db_session, name='Failed Background Show')
+    monkeypatch.setattr(
+        'services.background_jobs.get',
+        lambda _job_id: {
+            'id': 'job-failed',
+            'status': 'completed',
+            'result': {
+                'ok': False,
+                'message': 'Schedule readiness blocked. Open Preflight.',
+            },
+            'error': None,
+            'metadata': {'tournament_id': tournament.id},
+        },
+    )
+
+    response = auth_client.get(
+        f'/scheduling/{tournament.id}/events/job-status/job-failed'
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()['status'] == 'failed'
+    assert 'Preflight' in response.get_json()['error']

--- a/tests/test_spillover_feedback.py
+++ b/tests/test_spillover_feedback.py
@@ -74,21 +74,20 @@ def test_event_page_integration_flashes_unavoidable_conflict(
 def test_one_click_generation_flashes_unavoidable_conflict(
         db_session, auth_client):
     tournament = _make_tournament(db_session)
+    summary = {
+        'ok': True,
+        'generated': 0,
+        'skipped_events': [],
+        'protected': [],
+        'flights': 2,
+        'relay': {'placed': False},
+        'spillover': _conflict_result(),
+    }
 
-    with patch('routes.scheduling.flights._generate_all_heats'), patch(
-        'routes.scheduling.flights._build_pro_flights_if_possible',
-        return_value=2,
-    ), patch(
-        'services.flight_builder.integrate_proam_relay_into_final_flight',
-        return_value={'placed': False},
-    ), patch(
-        'services.flight_builder.integrate_college_spillover_into_flights',
-        return_value=_conflict_result(),
-    ), patch(
-        'services.saw_block_assignment.trigger_saw_block_recompute',
-    ), patch('routes.scheduling.flights.log_action'), patch(
-        'routes.scheduling.flights.db.session.commit', side_effect=db_session.flush,
-    ):
+    with patch(
+        'routes.scheduling.flights.generate_tournament_schedule_artifacts',
+        return_value=summary,
+    ), patch('routes.scheduling.flights.log_action'):
         response = auth_client.post(
             f'/scheduling/{tournament.id}/flights/one-click-generate',
             follow_redirects=False,

--- a/tests/test_ui_presentation.py
+++ b/tests/test_ui_presentation.py
@@ -34,3 +34,45 @@ def test_templates_do_not_depend_on_public_ui_cdns():
         source = template.read_text(encoding='utf-8')
         for host in forbidden_hosts:
             assert host not in source, f'{template.relative_to(PROJECT_ROOT)} uses {host}'
+
+
+def test_schedule_wizard_requires_preflight_before_generation():
+    source = (PROJECT_ROOT / 'templates/scheduling/events.html').read_text(
+        encoding='utf-8'
+    )
+
+    preflight_step = "('3', 'Preflight Check'"
+    build_step = "('4', 'Generate & Print'"
+    assert preflight_step in source
+    assert build_step in source
+    assert source.index(preflight_step) < source.index(build_step)
+    assert "('3', 'Generate & Build'" not in source
+    assert "('4', 'Preflight & Print'" not in source
+
+
+def test_full_build_surface_exposes_fail_closed_preflight_state():
+    events_source = (PROJECT_ROOT / 'templates/scheduling/events.html').read_text(
+        encoding='utf-8'
+    )
+    preflight_source = (
+        PROJECT_ROOT / 'templates/scheduling/preflight.html'
+    ).read_text(encoding='utf-8')
+
+    assert 'data-full-build-form' in events_source
+    assert 'data-full-build-submit' in events_source
+    assert 'data.pre_generation_has_blockers' in events_source
+    assert 'Resolve hard blockers before generating the show.' in events_source
+    assert 'will hold these competitors back' not in preflight_source
+    assert 'The full show build is blocked' in preflight_source
+    assert 'No schedule changes will be committed' in preflight_source
+    assert 'heat sync mismatches' not in preflight_source
+
+
+def test_mobile_operation_tabs_are_all_visible_without_horizontal_scrolling():
+    source = (PROJECT_ROOT / 'templates/scheduling/events.html').read_text(
+        encoding='utf-8'
+    )
+
+    assert 'grid-template-columns: repeat(2, minmax(0, 1fr));' in source
+    assert '.ops-tabs .nav-item:first-child { grid-column: 1 / -1; }' in source
+    assert 'overflow-x: auto;' not in source


### PR DESCRIPTION
## Summary

- make event heat generation fail closed for gear conflicts, invalid gear declarations, partner rules, and physical stand constraints
- centralize synchronous and background full-show generation behind one locked, atomic service with fresh preflight and postflight readiness gates
- preserve valid Partnered Axe state while protecting scored/completed history from destructive rebuilds
- separate input blockers from generated-schedule blockers in the operator UI and keep all operation tabs visible on mobile
- document the canonical heats -> flights -> relay -> spillover -> saw blocks workflow and its rollback contract

## Validation

- full isolated SQLite test suite: passed at 100%
- focused PostgreSQL generation/readiness/end-to-end lane: passed
- `ruff check .`: passed
- Python 3.10 grammar parse: 352 files passed
- `git diff --check`: passed
- Playwright desktop 1440x1000 and mobile 390x844 QA for Events and Preflight: no overflow, console errors, page errors, or hidden operation tabs

## Boundaries

- no production database or private mirror data was used
- the standard full-suite configuration excludes the dedicated `proam_regression` lane; PostgreSQL-sensitive behavior was exercised separately against disposable local PostgreSQL test databases
