### PR TITLE
Certify race-day recovery workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
   # job, which only proves migrations apply and a handful of routes answer.
   unit-postgres:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     services:
       postgres:

--- a/.github/workflows/daily-backup.yml
+++ b/.github/workflows/daily-backup.yml
@@ -1,35 +1,20 @@
 name: Daily Production DB Backup
 
-# Runs pg_dump against the production Postgres via the Railway public proxy
-# and uploads the compressed SQL as a GitHub Actions artifact (90-day
-# retention). Daily cron at 08:00 UTC (02:00 MDT / 03:00 MST — low traffic).
+# The 2027 event dates are not configured. This workflow keeps only the daily
+# baseline until the owner approves a race-weekend window.
 #
-# Motivated by the 2026-04-08 incident: zero backups existed when the
-# Postgres volume detached. Only reason data loss was zero is that no
-# competitor data had been entered yet.  See
-# docs/solutions/best-practices/railway-postgres-operational-playbook-2026-04-21.md
-# lesson 11.
+# Required repository configuration:
+#   secret RAILWAY_PG_READONLY_DUMP_URL: dedicated production dump role URL
+#   variable BACKUP_AGE_RECIPIENT: approved age public recipient (age1...)
+#   variable BACKUP_AGE_RECIPIENT_SHA256: approved recipient string SHA-256
 #
-# REQUIRED SECRET: RAILWAY_PG_PUBLIC_URL
-#   The full DATABASE_PUBLIC_URL from Railway (Settings → Secrets → Actions).
-#   Get it with: railway variables --service Postgres-HB8_ | grep DATABASE_PUBLIC_URL
-#   Form:        postgres://postgres:<pass>@turntable.proxy.rlwy.net:48640/railway
-#                (the workflow normalizes postgres:// → postgresql:// automatically)
+# The recovery private key is deliberately not available to this workflow.
 
 on:
   schedule:
-    # Daily baseline: 08:00 UTC = 02:00 MDT / 01:00 MST — low-traffic window.
     - cron: '0 8 * * *'
-    # Race-weekend hourly coverage: every hour on April 24-26 (UTC), which
-    # covers Thursday 6 PM MDT through Sunday 5 PM MDT. Caps worst-case data
-    # loss at 1 hour during the event. Update these dates after each annual
-    # Missoula Pro-Am if the race weekend shifts.
-    - cron: '0 * 24-26 4 *'
   workflow_dispatch:
 
-# Serialize runs so the baseline + hourly + manual-dispatch schedules never
-# stampede the public Postgres proxy. Queue, don't cancel — backups mid-flight
-# should complete.
 concurrency:
   group: daily-backup
   cancel-in-progress: false
@@ -40,130 +25,395 @@ permissions:
 jobs:
   backup:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: runner-local-restore-only
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      RESTORE_HOST: 127.0.0.1
+      RESTORE_PORT: '5432'
+      RESTORE_DB: proam_restore_verify
+      RESTORE_USER: postgres
+      EXPECTED_ALEMBIC_HEAD: a6b7c8d9e0f1
+
     steps:
-      - name: Install Postgres 18 client
+      - name: Install PostgreSQL client and age
         run: |
           set -euo pipefail
           curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
             | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg
           sudo sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update
-          sudo apt-get install -y postgresql-client-18
-          # Prepend PG 18's bin dir to PATH so the Debian pg_wrapper doesn't
-          # dispatch to an older pg_dump preinstalled on ubuntu-latest. The
-          # version mismatch error `aborting because of server version mismatch`
-          # comes from a client older than the PG 18.3 server.
+          sudo apt-get install -y postgresql-client-18 age
           echo "/usr/lib/postgresql/18/bin" >> "$GITHUB_PATH"
-          # Verify we're picking up PG 18:
           /usr/lib/postgresql/18/bin/pg_dump --version
+          age --version
 
-      - name: Verify secret is set
+      - name: Verify encryption recipient
         env:
-          RAILWAY_PG_PUBLIC_URL: ${{ secrets.RAILWAY_PG_PUBLIC_URL }}
+          CONFIGURED_RECIPIENT: ${{ vars.BACKUP_AGE_RECIPIENT }}
+          PINNED_RECIPIENT_SHA256: ${{ vars.BACKUP_AGE_RECIPIENT_SHA256 }}
         run: |
-          if [ -z "$RAILWAY_PG_PUBLIC_URL" ]; then
-            echo "::error::RAILWAY_PG_PUBLIC_URL repo secret is not configured."
-            echo "Get the URL with: railway variables --service Postgres-HB8_ | grep DATABASE_PUBLIC_URL"
-            echo "Then add it under Settings → Secrets and variables → Actions → New repository secret."
+          set -euo pipefail
+          RECIPIENT=$(printf '%s' "$CONFIGURED_RECIPIENT" | tr -d '[:space:]')
+          PINNED_RECIPIENT_SHA256=$(printf '%s' "$PINNED_RECIPIENT_SHA256" \
+            | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+          if [ -z "$RECIPIENT" ]; then
+            echo "::error::BACKUP_AGE_RECIPIENT is not configured; no backup will be uploaded."
+            exit 1
+          fi
+          if [[ ! "$RECIPIENT" =~ ^age1[0-9a-z]+$ ]]; then
+            echo "::error::BACKUP_AGE_RECIPIENT is not an age public recipient."
+            exit 1
+          fi
+          if [[ ! "$PINNED_RECIPIENT_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::BACKUP_AGE_RECIPIENT_SHA256 is not a valid SHA-256 fingerprint."
+            exit 1
+          fi
+          ACTUAL_RECIPIENT_SHA256=$(printf '%s' "$RECIPIENT" | sha256sum | awk '{print $1}')
+          if [ "$ACTUAL_RECIPIENT_SHA256" != "$PINNED_RECIPIENT_SHA256" ]; then
+            echo "::error::BACKUP_AGE_RECIPIENT does not match the approved fingerprint."
+            exit 1
+          fi
+          echo "BACKUP_AGE_RECIPIENT=$RECIPIENT" >> "$GITHUB_ENV"
+
+      - name: Verify production dump role
+        env:
+          RAILWAY_PG_READONLY_DUMP_URL: ${{ secrets.RAILWAY_PG_READONLY_DUMP_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RAILWAY_PG_READONLY_DUMP_URL" ]; then
+            echo "::error::RAILWAY_PG_READONLY_DUMP_URL is not configured."
             exit 1
           fi
 
-      - name: Take pg_dump
+          RAW_URL=$(printf '%s' "$RAILWAY_PG_READONLY_DUMP_URL" | tr -d '[:space:]')
+          if [[ "$RAW_URL" =~ ^[A-Z0-9_]+= ]]; then
+            RAW_URL="${RAW_URL#*=}"
+          fi
+          NORMALIZED_URL="${RAW_URL/#postgres:\/\//postgresql://}"
+          if [[ ! "$NORMALIZED_URL" =~ ^postgresql:// ]]; then
+            echo "::error::The production dump URL is not a PostgreSQL URL."
+            exit 1
+          fi
+
+          ROLE_OK=$(psql "$NORMALIZED_URL" --no-psqlrc --quiet --tuples-only \
+            --no-align --set ON_ERROR_STOP=1 --command "
+              SELECT CASE WHEN
+                NOT dump_role.rolsuper
+                AND NOT dump_role.rolcreaterole
+                AND NOT dump_role.rolcreatedb
+                AND NOT dump_role.rolreplication
+                AND NOT dump_role.rolbypassrls
+                AND current_setting('default_transaction_read_only')::boolean
+                AND NOT has_database_privilege(current_user, current_database(), 'CREATE')
+                AND NOT has_schema_privilege(current_user, 'public', 'CREATE')
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM pg_class object
+                  JOIN pg_namespace namespace ON namespace.oid = object.relnamespace
+                  WHERE namespace.nspname NOT IN ('pg_catalog', 'information_schema')
+                    AND (
+                      (
+                        object.relkind IN ('r', 'p', 'v', 'm', 'f')
+                        AND has_table_privilege(
+                          current_user,
+                          object.oid,
+                          'INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+                        )
+                      )
+                      OR (
+                        object.relkind = 'S'
+                        AND has_sequence_privilege(current_user, object.oid, 'UPDATE')
+                      )
+                    )
+                )
+              THEN 'ok' ELSE 'reject' END
+              FROM pg_roles dump_role
+              WHERE dump_role.rolname = current_user;")
+          ROLE_OK=$(printf '%s' "$ROLE_OK" | tr -d '[:space:]')
+          if [ "$ROLE_OK" != "ok" ]; then
+            echo "::error::Production dump credential is not a non-superuser, read-only role."
+            exit 1
+          fi
+          echo "Production dump role passed the least-privilege guard."
+
+      - name: Take read-only pg_dump
         env:
-          RAILWAY_PG_PUBLIC_URL: ${{ secrets.RAILWAY_PG_PUBLIC_URL }}
+          RAILWAY_PG_READONLY_DUMP_URL: ${{ secrets.RAILWAY_PG_READONLY_DUMP_URL }}
         run: |
           set -euo pipefail
-          # Tolerate three common secret-paste mishaps:
-          #   1. trailing whitespace / newline from copy-paste — strip all whitespace
-          #      (URLs cannot contain whitespace, so this is safe)
-          #   2. `KEY=URL` form — raw paste from `railway variables --kv`
-          #   3. `postgres://` (old scheme) instead of `postgresql://` — normalize
-          RAW_URL=$(printf '%s' "$RAILWAY_PG_PUBLIC_URL" | tr -d '[:space:]')
+          RAW_URL=$(printf '%s' "$RAILWAY_PG_READONLY_DUMP_URL" | tr -d '[:space:]')
           if [[ "$RAW_URL" =~ ^[A-Z0-9_]+= ]]; then
             RAW_URL="${RAW_URL#*=}"
           fi
           NORMALIZED_URL="${RAW_URL/#postgres:\/\//postgresql://}"
           TS=$(date -u +%Y%m%d_%H%M%S)
-          OUT="proam_backup_${TS}.sql.gz"
+          OUT="$RUNNER_TEMP/proam_backup_${TS}.dump"
 
-          # pg_dump: --no-owner and --no-acl keep the dump portable between
-          # accounts; --clean+--if-exists make the dump idempotent on restore
-          pg_dump "$NORMALIZED_URL" \
-            --no-owner --no-acl --clean --if-exists \
-            | gzip -9 > "$OUT"
+          pg_dump --dbname "$NORMALIZED_URL" \
+            --format custom --compress 9 --no-owner --no-acl \
+            --clean --if-exists --file "$OUT"
 
           SIZE=$(stat -c %s "$OUT")
-          echo "Backup file: $OUT ($SIZE bytes)"
-
           if [ "$SIZE" -lt 1024 ]; then
-            echo "::error::Backup too small ($SIZE bytes) — likely an error or empty DB. Aborting."
+            echo "::error::Backup is unexpectedly small; restore verification will not run."
             exit 1
           fi
-
+          SHA256=$(sha256sum "$OUT" | awk '{print $1}')
           echo "BACKUP_FILE=$OUT" >> "$GITHUB_ENV"
           echo "BACKUP_SIZE=$SIZE" >> "$GITHUB_ENV"
+          echo "BACKUP_SHA256=$SHA256" >> "$GITHUB_ENV"
+          echo "Read-only dump completed without printing database rows."
 
-      - name: Sanity-check dump content
+      - name: Restore dump into runner-local PostgreSQL
+        env:
+          PGPASSWORD: runner-local-restore-only
         run: |
-          # Deliberately NOT using `set -o pipefail` — `gunzip | head` closes
-          # the pipe early (by design) and would raise SIGPIPE on gunzip,
-          # which pipefail then converts into a fatal step failure.
-          set -eu
-          echo "--- First 20 lines of dump ---"
-          gunzip -c "$BACKUP_FILE" | head -20 || true
-
-          TABLE_COUNT=$(gunzip -c "$BACKUP_FILE" | grep -c "^CREATE TABLE" || true)
-          echo "CREATE TABLE statements: $TABLE_COUNT"
-
-          # App has 16 public tables (tournaments, teams, college_competitors,
-          # pro_competitors, events, heats, heat_assignments, event_results,
-          # flights, wood_configs, school_captains, pro_event_ranks,
-          # payout_templates, users, audit_logs, alembic_version).
-          # Allow some slack for future migrations; fail if we got < 10.
-          if [ "$TABLE_COUNT" -lt 10 ]; then
-            echo "::error::Dump has too few CREATE TABLE statements ($TABLE_COUNT); expected >= 10."
+          set -euo pipefail
+          if [ "$RESTORE_HOST" != "127.0.0.1" ]; then
+            echo "::error::Restore host must be the runner-local PostgreSQL service."
+            exit 1
+          fi
+          if [ "$RESTORE_PORT" != "5432" ]; then
+            echo "::error::Restore port does not match the runner-local service."
+            exit 1
+          fi
+          if [ "$RESTORE_DB" != "proam_restore_verify" ]; then
+            echo "::error::Restore database is not the disposable verification target."
             exit 1
           fi
 
-          ALEMBIC_VERSION=$(gunzip -c "$BACKUP_FILE" \
-            | grep -A1 "COPY public.alembic_version" \
-            | tail -1 \
-            | head -c 50 || true)
-          if [ -n "$ALEMBIC_VERSION" ]; then
-            echo "alembic_version in dump: $ALEMBIC_VERSION"
-          else
-            echo "::warning::No alembic_version row found in dump — schema may be empty."
+          RESTORE_LOG=$(mktemp "$RUNNER_TEMP/proam_pg_restore_XXXXXX.log")
+          chmod 600 "$RESTORE_LOG"
+          secure_delete_restore_log() {
+            local command_status=$?
+            if [ -f "$RESTORE_LOG" ]; then
+              shred --remove=unlink --zero "$RESTORE_LOG" 2>/dev/null \
+                || rm -f -- "$RESTORE_LOG" \
+                || {
+                  echo "::error::Runner-local restore diagnostic cleanup failed."
+                  return 1
+                }
+            fi
+            return "$command_status"
+          }
+          trap secure_delete_restore_log EXIT
+
+          dropdb --host "$RESTORE_HOST" --port "$RESTORE_PORT" \
+            --username "$RESTORE_USER" --if-exists --force "$RESTORE_DB"
+          createdb --host "$RESTORE_HOST" --port "$RESTORE_PORT" \
+            --username "$RESTORE_USER" "$RESTORE_DB"
+          if ! pg_restore --host "$RESTORE_HOST" --port "$RESTORE_PORT" \
+              --username "$RESTORE_USER" --dbname "$RESTORE_DB" \
+              --exit-on-error --single-transaction --no-owner --no-acl \
+              --clean --if-exists "$BACKUP_FILE" \
+              >"$RESTORE_LOG" 2>&1; then
+            echo "::error::Runner-local restore failed; database diagnostics were withheld."
+            exit 1
           fi
 
-      - name: Upload backup artifact
-        uses: actions/upload-artifact@v4
+      - name: Verify restored schema and aggregate invariants
+        env:
+          PGPASSWORD: runner-local-restore-only
+        run: |
+          set -euo pipefail
+          LOCAL_PSQL=(psql --host "$RESTORE_HOST" --port "$RESTORE_PORT" \
+            --username "$RESTORE_USER" --dbname "$RESTORE_DB" --no-psqlrc \
+            --quiet --tuples-only --no-align --set ON_ERROR_STOP=1)
+
+          SCHEMA_OK=$("${LOCAL_PSQL[@]}" --command "
+            SELECT CASE WHEN count(*) = 9 THEN 'ok' ELSE 'reject' END
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name IN (
+                'tournaments', 'users', 'events', 'heats', 'event_results',
+                'background_jobs', 'score_submission_receipts', 'audit_logs',
+                'alembic_version'
+              );")
+          if [ "$(printf '%s' "$SCHEMA_OK" | tr -d '[:space:]')" != "ok" ]; then
+            echo "::error::Restored database is missing required application tables."
+            exit 1
+          fi
+
+          MIGRATION_OK=$("${LOCAL_PSQL[@]}" --command "
+            SELECT CASE WHEN count(*) = 1
+              AND bool_and(version_num = '$EXPECTED_ALEMBIC_HEAD')
+              THEN 'ok' ELSE 'reject' END
+            FROM public.alembic_version;")
+          if [ "$(printf '%s' "$MIGRATION_OK" | tr -d '[:space:]')" != "ok" ]; then
+            echo "::error::Restored migration metadata is missing or ambiguous."
+            exit 1
+          fi
+
+          CRITICAL_SCHEMA_OK=$("${LOCAL_PSQL[@]}" --command "
+            WITH expected(table_name, column_name) AS (
+              VALUES
+                ('background_jobs', 'owner_boot_id'),
+                ('background_jobs', 'owner_heartbeat_at'),
+                ('score_submission_receipts', 'request_id'),
+                ('score_submission_receipts', 'tournament_id'),
+                ('score_submission_receipts', 'heat_id'),
+                ('score_submission_receipts', 'issuing_user_id'),
+                ('score_submission_receipts', 'canonical_payload_sha256'),
+                ('score_submission_receipts', 'accepted_outcome_json'),
+                ('score_submission_receipts', 'created_at')
+            ), receipt_foreign_keys AS (
+              SELECT attribute.attname AS column_name, constraint_row.confdeltype
+              FROM pg_constraint constraint_row
+              JOIN pg_class relation ON relation.oid = constraint_row.conrelid
+              JOIN pg_namespace namespace ON namespace.oid = relation.relnamespace
+              JOIN unnest(constraint_row.conkey) AS key_column(attnum) ON true
+              JOIN pg_attribute attribute
+                ON attribute.attrelid = relation.oid
+                AND attribute.attnum = key_column.attnum
+              WHERE constraint_row.contype = 'f'
+                AND namespace.nspname = 'public'
+                AND relation.relname = 'score_submission_receipts'
+            )
+            SELECT CASE WHEN count(column.column_name) = 9
+              AND to_regclass('public.ix_background_jobs_owner_boot_id') IS NOT NULL
+              AND to_regclass('public.ix_background_jobs_owner_heartbeat_at') IS NOT NULL
+              AND to_regclass('public.ix_score_submission_receipts_binding') IS NOT NULL
+              AND (SELECT count(*) FROM receipt_foreign_keys
+                WHERE column_name = 'tournament_id' AND confdeltype = 'c') = 1
+              AND (SELECT count(*) FROM receipt_foreign_keys
+                WHERE column_name = 'issuing_user_id' AND confdeltype = 'n') = 1
+              AND (SELECT count(*) FROM receipt_foreign_keys
+                WHERE column_name = 'heat_id') = 0
+              THEN 'ok' ELSE 'reject' END
+            FROM expected
+            LEFT JOIN information_schema.columns column
+              ON column.table_schema = 'public'
+              AND column.table_name = expected.table_name
+              AND column.column_name = expected.column_name;")
+          if [ "$(printf '%s' "$CRITICAL_SCHEMA_OK" | tr -d '[:space:]')" != "ok" ]; then
+            echo "::error::Restored database is missing critical current-head columns, indexes, or receipt lifecycle constraints."
+            exit 1
+          fi
+
+          INVARIANTS_OK=$("${LOCAL_PSQL[@]}" --command "
+            SELECT CASE WHEN
+              (SELECT count(*) FROM events event
+                LEFT JOIN tournaments tournament ON tournament.id = event.tournament_id
+                WHERE tournament.id IS NULL) = 0
+              AND (SELECT count(*) FROM heats heat
+                LEFT JOIN events event ON event.id = heat.event_id
+                WHERE event.id IS NULL) = 0
+              AND (SELECT count(*) FROM event_results result
+                LEFT JOIN events event ON event.id = result.event_id
+                WHERE event.id IS NULL) = 0
+              THEN 'ok' ELSE 'reject' END;")
+          if [ "$(printf '%s' "$INVARIANTS_OK" | tr -d '[:space:]')" != "ok" ]; then
+            echo "::error::Restored aggregate relationship checks failed."
+            exit 1
+          fi
+          echo "Runner-local restore, schema, migration, and aggregate checks passed."
+
+      - name: Encrypt verified backup
+        run: |
+          set -euo pipefail
+          CIPHERTEXT_FILE="${BACKUP_FILE}.age"
+          age --recipient "$BACKUP_AGE_RECIPIENT" \
+            --output "$CIPHERTEXT_FILE" "$BACKUP_FILE"
+          if [ ! -s "$CIPHERTEXT_FILE" ]; then
+            echo "::error::Encrypted backup was not created."
+            exit 1
+          fi
+          CIPHERTEXT_SHA256=$(sha256sum "$CIPHERTEXT_FILE" | awk '{print $1}')
+          echo "CIPHERTEXT_FILE=$CIPHERTEXT_FILE" >> "$GITHUB_ENV"
+          echo "CIPHERTEXT_SHA256=$CIPHERTEXT_SHA256" >> "$GITHUB_ENV"
+
+      - name: Drop runner-local plaintext restore
+        if: ${{ always() }}
+        env:
+          PGPASSWORD: runner-local-restore-only
+        run: |
+          set -euo pipefail
+          if [ "$RESTORE_HOST" != "127.0.0.1" ]; then
+            echo "::error::Restore cleanup host must be runner-local."
+            exit 1
+          fi
+          if [ "$RESTORE_PORT" != "5432" ]; then
+            echo "::error::Restore cleanup port must be runner-local."
+            exit 1
+          fi
+          if [ "$RESTORE_DB" != "proam_restore_verify" ]; then
+            echo "::error::Restore cleanup target is not disposable."
+            exit 1
+          fi
+          dropdb --host "$RESTORE_HOST" --port "$RESTORE_PORT" \
+            --username "$RESTORE_USER" --if-exists --force "$RESTORE_DB"
+          echo "Runner-local plaintext restore dropped before artifact upload."
+
+      - name: Delete plaintext backup
+        if: ${{ always() }}
+        run: |
+          set -uo pipefail
+          CLEANUP_FAILED=0
+          if [ -n "${BACKUP_FILE:-}" ] && [ -f "$BACKUP_FILE" ]; then
+            shred --remove=unlink --zero "$BACKUP_FILE" \
+              || rm -f -- "$BACKUP_FILE" \
+              || CLEANUP_FAILED=1
+          fi
+          while IFS= read -r -d '' PLAINTEXT; do
+            shred --remove=unlink --zero "$PLAINTEXT" \
+              || rm -f -- "$PLAINTEXT" \
+              || CLEANUP_FAILED=1
+          done < <(find "$RUNNER_TEMP" -maxdepth 1 -type f \
+            -name 'proam_backup_*.dump' -print0)
+          if find "$RUNNER_TEMP" -maxdepth 1 -type f \
+            -name 'proam_backup_*.dump' -print -quit | grep -q .; then
+            CLEANUP_FAILED=1
+          fi
+          if [ "$CLEANUP_FAILED" -ne 0 ]; then
+            echo "::error::Plaintext cleanup failed; artifact upload is blocked."
+            exit 1
+          fi
+
+      - name: Upload encrypted backup artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: proam-db-backup-${{ github.run_id }}
-          path: ${{ env.BACKUP_FILE }}
+          path: ${{ env.CIPHERTEXT_FILE }}
+          if-no-files-found: error
           retention-days: 90
           compression-level: 0
 
-      - name: Summary
+      - name: Write verification summary
+        if: ${{ success() }}
         run: |
           {
-            echo "## Backup Complete"
+            echo "## Plaintext Backup Restore Verified"
             echo ""
-            echo "- File: \`$BACKUP_FILE\`"
-            echo "- Size: $BACKUP_SIZE bytes"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- Plaintext size: $BACKUP_SIZE bytes"
+            echo "- Plaintext SHA-256: $BACKUP_SHA256"
+            echo "- Ciphertext SHA-256: $CIPHERTEXT_SHA256"
+            echo "- Restore target: runner-local PostgreSQL service"
+            echo "- Artifact: age-encrypted ciphertext only"
+            echo "- Ciphertext decrypt-and-restore: not run by this workflow"
             echo "- Retention: 90 days"
             echo ""
-            echo "Download from the Artifacts section of this workflow run."
-            echo ""
-            echo "### Restore procedure (emergency only)"
-            echo ""
-            echo '```bash'
-            echo "# 1. Download the artifact and unzip"
-            echo "unzip proam-db-backup-*.zip"
-            echo ""
-            echo "# 2. Confirm the target DB is empty (or you have a fresh one)"
-            echo "# 3. Apply the dump via the Railway public proxy"
-            echo 'export DATABASE_URL="postgresql://postgres:<pass>@turntable.proxy.rlwy.net:48640/railway"'
-            echo "gunzip -c proam_backup_*.sql.gz | psql \"\$DATABASE_URL\""
-            echo '```'
+            echo "Recoverability requires the separately held identity rehearsal in docs/ROLLBACK_SOP.md."
+            echo "Production restore is prohibited from this workflow. Follow docs/ROLLBACK_SOP.md."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Delete runner ciphertext copy
+        if: ${{ always() }}
+        run: |
+          if [ -n "${CIPHERTEXT_FILE:-}" ]; then
+            rm -f -- "$CIPHERTEXT_FILE"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,7 +231,10 @@ Teams are organized by school. A school can enter multiple teams (e.g., UM-A, UM
 - **Speed Climb Run 1 placement:** Normal position in the Friday schedule (no special end-of-day requirement).
 - **Saturday placement:** Both Chokerman Run 2 and Speed Climb Run 2 go to Saturday. Chokerman Run 2 is placed at the end of the last flight per the existing rule. Speed Climb Run 2 is placed via the college overflow integration (round-robin across flights, or judge-selected position).
 
-Obstacle Pole is single-run in both college and pro divisions for 2026.
+**Obstacle Pole:** the owner requirement is two runs for College (Pole 1 / Pole
+2, best time) and explicitly one run for Pro. Existing 2026 tournament rows
+retain their persisted configuration; newly configured tournaments use the
+owner-rule distinction above.
 
 **Caber Toss:** Caber Toss has `requires_dual_runs=True` in config.py but does NOT split across days -- both runs occur on Friday. The day-split rule applies only to Chokerman's Race and Speed Climb.
 

--- a/app.py
+++ b/app.py
@@ -28,6 +28,8 @@ import strings as text
 from database import db, init_db
 from services import reference_gate
 from services.background_jobs import configure as configure_jobs
+from services.background_jobs import reconcile_interrupted_jobs
+from services.background_jobs import start_heartbeat as start_job_heartbeat
 from services.logging_setup import (
     configure_error_monitoring,
     configure_logging,
@@ -278,6 +280,16 @@ def _create_app_inner():
 
     # Initialize database
     init_db(app)
+
+    # A SQLite restore is an offline operation. The web process holds a shared
+    # filesystem fence for its full lifetime; the maintenance command requires
+    # the exclusive form, so replacement cannot race open pools or background
+    # worker threads.
+    from services.restore_workflow import configure_sqlite_process_fence
+
+    configure_sqlite_process_fence(app)
+    reconcile_interrupted_jobs(app)
+    start_job_heartbeat(app)
 
     # Refuse writes that introduce a reference to the wrong competitor. Armed
     # on the session, not at the eight places that assign to Event.payouts or

--- a/config.py
+++ b/config.py
@@ -45,6 +45,12 @@ class BaseConfig:
     STRUCTURED_LOGGING = os.environ.get('STRUCTURED_LOGGING', '1') == '1'
     SENTRY_DSN = os.environ.get('SENTRY_DSN', '').strip()
     JOB_MAX_WORKERS = int(os.environ.get('JOB_MAX_WORKERS', '2'))
+    JOB_HEARTBEAT_INTERVAL_SECONDS = int(
+        os.environ.get('JOB_HEARTBEAT_INTERVAL_SECONDS', '5')
+    )
+    JOB_LEASE_TIMEOUT_SECONDS = int(
+        os.environ.get('JOB_LEASE_TIMEOUT_SECONDS', '30')
+    )
     REPORT_CACHE_TTL_SECONDS = int(os.environ.get('REPORT_CACHE_TTL_SECONDS', '60'))
     PUBLIC_CACHE_TTL_SECONDS = int(os.environ.get('PUBLIC_CACHE_TTL_SECONDS', '5'))
     ENABLE_UPLOAD_MALWARE_SCAN = os.environ.get('ENABLE_UPLOAD_MALWARE_SCAN', '0') == '1'
@@ -418,7 +424,8 @@ COLLEGE_CLOSED_EVENTS = [
     {'name': 'Jack & Jill Sawing', 'scoring_type': 'time', 'stand_type': 'saw_hand', 'is_partnered': True, 'partner_gender': 'mixed'},
     {'name': 'Stock Saw', 'scoring_type': 'time', 'stand_type': 'stock_saw', 'is_gendered': True},
     {'name': 'Speed Climb', 'scoring_type': 'time', 'stand_type': 'speed_climb', 'is_gendered': True, 'requires_dual_runs': True},
-    {'name': 'Obstacle Pole', 'scoring_type': 'time', 'stand_type': 'obstacle_pole', 'is_gendered': True},
+    {'name': 'Obstacle Pole', 'scoring_type': 'time', 'stand_type': 'obstacle_pole',
+     'is_gendered': True, 'requires_dual_runs': True},
     {'name': 'Chokerman\'s Race', 'scoring_type': 'time', 'stand_type': 'chokerman', 'is_gendered': True, 'requires_dual_runs': True},
     {'name': 'Birling', 'scoring_type': 'bracket', 'stand_type': 'birling', 'is_gendered': True},
     {'name': '1-Board Springboard', 'scoring_type': 'time', 'stand_type': 'springboard', 'is_gendered': True},

--- a/docs/2027_RACE_DAY_CERTIFICATION.md
+++ b/docs/2027_RACE_DAY_CERTIFICATION.md
@@ -1,0 +1,175 @@
+# 2027 Race-Day Certification Ledger
+
+This ledger is the authoritative map from owner-authored operating rules to
+executable evidence for the 2027 Missoula Pro-Am. A green unit test is evidence
+for its named behavior only. It is not, by itself, proof of PostgreSQL,
+multi-device, offline, deployment, or production readiness.
+
+## Authority Model
+
+`docs/Alex's Docs` contains the event owner's business rules.
+`docs/DOMAIN_CONTRACT.md` is the canonical, reconciled implementation contract.
+`FlightLogic.md` supplies flight detail where the contract is silent. Tests and
+code are evidence, not authority. There is no blanket rule that lets an older
+document or current implementation silently win a conflict: each conflicting
+requirement must name the controlling clause or a dated owner decision, and the
+Domain Contract must then be updated to match.
+
+The handover names four historical authority files that are not present in the
+repository, enclosing project directory, desktop documents, or supplied
+attachments: `CODEX_RECON.md`, `CODEX_WORK_ORDER_05.md`,
+`PROAM_2026_C97_DECISION_BOARD.md`, and
+`PROAM_2026_C98_T4A_SHIPPED_AND_WRONG_TREE.md`. Their absence is an evidence
+gap; this ledger does not invent their contents.
+
+## Evidence States
+
+- **Certified**: the acceptance behavior has current automated and operational
+  evidence in every environment named by the requirement.
+- **Implemented**: code and focused tests exist, but a required environment or
+  rehearsal is still missing.
+- **Partial**: only part of the acceptance behavior is implemented.
+- **Blocked**: a known defect can violate the acceptance behavior.
+- **Owner decision**: the repository cannot supply the required business
+  decision.
+
+## Reliability Requirements
+
+Evidence is intentionally split from evidence still required. This workflow is
+based on `06db7ec`; the release commit is recorded only after the branch is
+published. Static inspection is not a passing test, and local evidence does not
+stand in for hosted CI, a production mirror, or production smoke evidence.
+
+| ID | Requirement | Authority | State | Current evidence | Required certification evidence |
+|---|---|---|---|---|---|
+| R27-001 | Friday/Pro Saturday show order and spillover follow the contract. | Domain Contract 15-30, 123-134; FlightLogic | Partial | Full isolated SQLite suite passed; flight/order tests passed inside it | Approved 2027 event matrix, exact PostgreSQL order lane, and full-show browser digest |
+| R27-003 | Gear sharing fails closed without unsafe same-heat/overlap placement. | GEAR_SHARING_DOMAIN; Domain Contract 69-92 | Partial | Full isolated SQLite suite passed, including generator/readiness coverage | Exact disposable PostgreSQL result and synthetic browser sharing rehearsal |
+| R27-004 | A prepared device can restart during WAN loss and open every scheduled heat page and local asset. | Domain Contract local-first boundary | Implemented | Bound manifest verifies content hashes; browser prepared 14/14 items and cold-reloaded the heat with `navigator.onLine=false` under service-worker control | Physical-device restart rehearsal on the approved 2027 schedule |
+| R27-005 | One request produces at most one committed scoring action across duplicate, lost-response, retry, reconnect, and transfer paths; request tombstones remain with tournament history. | Owner scoring integrity | Implemented | Durable receipts/tombstones, rollback and duplicate tests, eight PostgreSQL races, lifecycle FK tests, and two browser replays with matching UUID/SHA-256 receipts | Hosted exact-head run and production-like multi-device rehearsal |
+| R27-006 | Queues are inspectable and transferable as data, while replay authority remains bound to the issuing user and current role/tournament access; old entries stop automatic mutation. | Local-first and authorization controls | Implemented | Canonical LocalStorage queue; issuer/role/tournament/schedule binding; authenticated 8-30 day renewal; 30-day cutoff; export/import and stale-context tests; browser queue inspection | Physical cross-device transfer rehearsal and approved operator procedure |
+| R27-007 | Compatible concurrent operations survive; conflicting, duplicate, stale, and out-of-order operations receive deterministic outcomes without silent loss. | Owner workflows; Domain Contract | Implemented | Stale-writer fences cover relay, payout, partner, scratch, flight, Birling, scoring, and background completion; eight disposable PostgreSQL races passed; lock-only scoring version race passed in two browser sessions | Hosted PostgreSQL lane plus complete 2027 full-show adversarial rehearsal |
+| R27-008 | Background work reports failed, interrupted, expired, and completed truthfully and is scoped before tournament limits are applied. | Operator recovery integrity | Implemented | Boot ownership, heartbeat, interrupted reconciliation, atomic completion, truthful return-state tests, and tournament-scope tests passed | Hosted restart/reconciliation rehearsal with retained operator evidence |
+| R27-009 | SQLite backup is consistent; restore is quiesced, validated, journaled outside the DB, rollback-capable, and never reported ambiguously. | Existing SQLite recovery surface | Implemented | Process fence, consistent snapshot, restore package v2, schema/FK/index/trigger fingerprint, private permissions, WAL/SHM intent journal, quarantine, rollback, and 31 restore tests passed | Operator rehearsal on release hardware; provenance remains transport/host evidence, not a signature claim |
+| R27-010 | A PostgreSQL artifact is restored only into a runner-local disposable target and passes schema/migration checks before publication. | Production PostgreSQL boundary | Implemented | Workflow enforces a least-privilege dump URL, runner-local target guard, current-head schema checks, encrypted-only upload, and plaintext cleanup; local PostgreSQL drill passed | Hosted workflow run with the approved secrets and retained artifact evidence |
+| R27-011 | Backup cadence and recovery objectives match the approved 2027 event window and owner-approved tolerances. | Release operations | Owner decision | Stale 2026 race-window schedule exists | Approved dates/objectives recorded in release docs and rehearsed against the configured cadence |
+| R27-012 | Operator controls and recovery states work at desktop/phone widths without console errors, hidden actions, overlap, or overflow. | Operator UI requirement | Implemented | Browser QA at 1440x900 and 390x844 found no document overflow or page/console errors; commands remained visible and screenshots were reviewed | Checked-in browser scenario and physical-phone rehearsal on release head |
+| R27-013 | SQLite, disposable PostgreSQL, production mirror, migration, browser, hosted CI, and production smoke evidence are separate. | Release Checklist; isolation rule | Partial | This ledger records SQLite, disposable PostgreSQL, migration, static, and browser evidence separately | Production mirror, hosted CI, deployment, and production smoke receipts remain absent |
+| R27-014 | MNEMEX/STRATHMARK are not live-scoring dependencies and Missoula owns provisional results. | Domain Contract | Partial | Architecture and failure-handling code exists; not rerun here | Explicit network-denial scoring/build browser test |
+| R27-021 | Cache invalidation cannot evict another tournament or resurrect stale standings after commit. | Multi-tournament integrity | Implemented | Delimited cache keys, generation fencing, PostgreSQL process-cache bypass, and controlled race tests passed | Hosted multi-process cache rehearsal |
+| R27-022 | A completed export resolves to an existing checksum-verified artifact; missing/tampered ephemeral files become expired. | Operator recovery integrity | Implemented | Same-handle checksum, retry window, retention, restart/missing/tampered/download/tournament-scope tests passed | Hosted ephemeral-filesystem rehearsal |
+| R27-023 | Backup confidentiality has approved encryption, key custody, least-privilege dump access, retention, deletion, and audit controls; plaintext is never published. | PII and recovery boundary | Partial | Workflow refuses plaintext publication, pins the configured `age` recipient by SHA-256, uses a dedicated dump URL, cleans plaintext/logs, and explicitly does not claim ciphertext recovery verification | Approved separately held recipient key, verified read-only dump role, hosted encrypt run, separate retained-artifact decrypt-and-restore rehearsal, retention/deletion review, and download audit |
+
+## Owner Rule Ledger
+
+Each row must be resolved into `docs/DOMAIN_CONTRACT.md`, configuration, exact
+tests, and an operator step before final certification. `Owner decision` means
+the annual choice or conflict cannot be inferred. `Blocked` means the existing
+owner rule is clear and the implementation must be corrected unless the owner
+changes it.
+
+| ID | Rule family | Controlling clause/current conflict | State | Operator step | Required evidence |
+|---|---|---|---|---|---|
+| REG-TEAM-001 | College teams have no more than eight competitors and at least two men and two women. | ProAM requirements 8-10 | Partial | Import/register team and resolve eligibility warnings | Registration validation and browser setup test |
+| CFG-EVENT-001 | Open/closed event selection, field limits, and the college six-event cap are annual/operator controlled. | ProAM requirements 43-72, 127-159 | Owner decision | Approve matrix, then configure Events | Approved 2027 matrix and configuration enforcement tests |
+| PAIR-VALID-001 | Partner units are reciprocal, active, entered, gender-valid, and atomic. | Domain Contract 33-67 | Partial | Repair Partner Preflight blockers | Partner/preflight tests on both DBs and concurrent claim test |
+| HEAT-ATOMIC-001 | Heat generation uses active entrants, capacity, ability order, partner units, dual-run stand swaps, and authoritative assignments. | Domain Contract 69-92 | Partial | Run Preflight, then Generate Show | Exact focused tests, PostgreSQL lane, full-show digest |
+| OBSTACLE-RUN-001 | College Obstacle Pole runs twice; Pro Obstacle Pole runs once. | ProAM requirements 73-81 and 167 | Implemented | Review both generated College runs and stand/course change | `tests/test_owner_requirements_config.py`, dual-run generator/scoring tests, PostgreSQL and browser evidence |
+| RESOURCE-SPRING-001 | Springboard capacity/left-handed dummy behavior is fail-closed or an explicitly authorized exception. | Domain Contract 81-87 conflicts with 150-154, 183-188 and FlightLogic | Owner decision | Resolve Springboard Preflight blocker | Dated ruling, reconciled text, generator tests |
+| FLIGHT-BUILD-001 | Saturday flights derive from generated heat sequence and protect completed history. | Domain Contract 94-121 | Partial | Build/review Flights after heats | Flight build/rebuild tests and PostgreSQL digest |
+| ORDER-RELAY-001 | Relay closes normal Saturday flights; mandatory Chokerman run 2 closes spillover. | Domain Contract 123-134 | Partial | Review Show Day closing order | Full-show order tests and browser rehearsal |
+| BIRLING-2027-001 | Annual 2027 Pro Birling inclusion/exclusion and, if held, last-event/bracket rules are explicit. | ProAM requirements 165-175; current config excludes it | Owner decision | Approve matrix; seed/run bracket if enabled | Dated decision and bracket/order tests if enabled |
+| RELAY-COMP-001 | Relay composition, exclusions, team count, one-flight behavior, participation guarantee, and $5 fee are reconciled. | ProAmRelay 5-21; ProAM requirements 190-212; implementation docs differ | Owner decision | Configure, validate, draw, and score Relay | Dated ruling plus composition/fee/flight tests |
+| SCORE-POINTS-001 | College points are 10/7/5/3/2/1 with event-specific score direction. | ProAM requirements 27-39 | Partial | Enter, review, and finalize event scores | Scoring calculation tests on both DBs |
+| SCORE-TIE-001 | Tie splitting and two-timer averaging are authorized for 2027. | Historical plan/current code; weak business authority | Owner decision | Approve policy; resolve flagged ties/timers | Dated ruling and retained/revised scoring tests |
+| MARK-REVIEW-001 | Handicap marks require review; reviewed zero is intentional scratch; scored history is immutable. | Domain Contract 190-204 | Partial | Review marks before scoring | Preflight/scoring/history tests on both DBs |
+| REPORT-AWARDS-001 | Top-five team/men/women, Bull/Belle, payouts, settlement, and event results are correct and printable. | ProAM requirements reporting sections | Partial | Finalize, review, print/export, settle | Calculation, export/print, and browser workflow tests |
+| REG-PRO-001 | ALA self-report, first-time status, shirts, annual fees, and related registration data are preserved. | ProAM requirements registration sections | Partial | Import/register and run fee/ALA reports | Import/form/report tests using synthetic data |
+
+## 2026-08-18 Evidence Receipt
+
+All local data in this receipt was synthetic. Tests used isolated temporary
+SQLite databases, a disposable local PostgreSQL database, and
+`instance/browser_certification.db`. No production database or PII was accessed.
+
+- **Complete SQLite suite:** 4,384 collected; 4,342 passed and 42 expected
+  skips in 791.256 seconds. Nine existing SQLAlchemy identity-map warnings in
+  flight-builder tests remain visible; the run had no failure or error.
+- **Scoring/offline/lock regression:** 444 tests passed after adding the
+  lock-independent scoring-state digest. The digest rejects changed scores or
+  heat structure but permits replay after lock-only `Heat.version_id` changes.
+- **Disposable PostgreSQL:** eight race tests passed for request receipts and
+  lifecycle, relay team and payout, partner claim, flight reorder, Birling, and
+  background completion/reconciliation. The rebased release lane also passed
+  the populated shadow-schema round trip and locked-delivery worker test, for
+  ten successful PostgreSQL checks on the combined branch.
+- **Recovery:** 31 restore-workflow tests passed. Restore package v2 verifies
+  complete schema, foreign keys, indexes, and triggers and exercises quiesce,
+  intent journal, quarantine, rollback, and interrupted recovery paths.
+- **Migrations:** 24 migration tests passed with two expected skips. The local
+  PostgreSQL migration template was rebuilt from the complete current chain
+  before the race module ran.
+- **Focused reliability:** 50 receipt-lifecycle/offline/daily-workflow tests and
+  141 Birling-focused tests passed. The broader combined scoring, scratch,
+  offline, restore, and day-of-operations lane passed 144 tests.
+- **Static/runtime:** full Ruff, compileall, Python 3.10 grammar parsing, JS
+  syntax checks, both Node offline suites, and `git diff --check` passed.
+- **Installed STRATHMARK contract:** the exact Git-pinned artifact at
+  `da5c44d07311b226c1e9842104477efaf61253fa` exposed the expected seven-route
+  contract and digest. The migrated synthetic rehearsal proved exact receipt
+  replay and duplicate numeric-outcome handling with no network or production
+  data. The release-readiness and PostgreSQL migration-safety modules passed
+  all 12 checks.
+- **Browser package:** Chrome prepared and byte-verified 14 of 14 manifest
+  items. A forced reload with network disabled retained the authenticated heat
+  page under service-worker control.
+- **Browser replay:** request `0a98cf2b-585d-41b1-840b-b55e91ca345d`
+  replayed 11.00/11.20 to 11.10 and produced a receipt with payload SHA-256
+  `8e88de872c06ffa55b3604704ce4dc74f2843fdbab18d292d668a15fae842469`.
+- **Lock-refresh browser race:** a second authenticated session advanced the
+  lock-only heat version from 5 to 6 while request
+  `09322d30-303e-4277-905c-4f367b6c5d19` remained offline. Replay accepted the
+  unchanged scoring digest, persisted 12.00/12.20 as 12.10, created the matching
+  receipt, and cleared the queue.
+- **Responsive browser QA:** 1440x900 and 390x844 had no document overflow,
+  hidden primary command, page error, or console error. The scoring table used
+  contained horizontal scrolling at phone width.
+- **Not run:** hosted GitHub Actions, a production mirror, deployment, and
+  production smoke. The PostgreSQL backup workflow still requires the approved
+  `RAILWAY_PG_READONLY_DUMP_URL`, `BACKUP_AGE_RECIPIENT`, and a separately held
+  private `age` identity before its hosted evidence can exist.
+
+## Baseline Disposition
+
+The 2026-08-18 baseline blockers were handled as follows:
+
+1. **Resolved:** heat and service-worker queue behavior now converges on one
+   canonical, race-tested LocalStorage queue.
+2. **Resolved:** durable receipts make accepted retries deterministic and retain
+   tournament-scoped history after heat deletion.
+3. **Resolved locally:** prepared manifests contain every scheduled page and
+   asset with byte hashes; cold-offline browser loading passed.
+4. **Resolved locally:** background jobs have boot ownership, heartbeat,
+   interrupted reconciliation, and atomic truthful completion.
+5. **Resolved locally:** SQLite snapshot and restore now have quiesce, intent,
+   validation, quarantine, rollback, and private-permission evidence.
+6. **Resolved in code/local tests:** relay, partner, scratch, flight, Birling,
+   scoring, and payout stale-writer gaps now fail deterministically.
+7. **Resolved in workflow code:** hosted PostgreSQL backup restores into a
+   runner-local target before encrypted publication; its hosted run is pending.
+8. **Resolved locally:** browser storage, offline reconnect, concurrent browser
+   lock refresh, service-worker loading, and responsive presentation were run.
+9. **Open:** several 2027 business rules remain contradictory or unselected;
+   code must not silently choose among them.
+10. **Resolved locally:** cache keys/generations are fenced and completed export
+    files are checksum-verified with explicit expiry behavior.
+
+## Certification Gate
+
+Reliability implementation may ship before annual business choices are made,
+provided the release does not claim certification or silently change those
+rules. Final certification requires every applicable reliability and owner-rule
+row to be **Certified**, every `Owner decision` to be approved and incorporated
+or explicitly signed not applicable, R27-011 to record the actual event window
+and approved recovery objectives, and R27-023 to have an operable key policy.
+Until then the product may be materially improved and deployable, but it must
+not be described as 2027 race-day certified.

--- a/docs/DOMAIN_CONTRACT.md
+++ b/docs/DOMAIN_CONTRACT.md
@@ -83,6 +83,8 @@ Heat generation owns event-level placement only. It must:
   use the `Heat` roster APIs rather than writing a second representation.
 - For dual-run events, assign every entrant to a different physical stand or
   course in run 2, including a one-person heat.
+- College Obstacle Pole is dual-run on Pole 1 / Pole 2 and uses the best time;
+  Pro Obstacle Pole is explicitly single-run.
 
 Generation must prove that every eligible entrant can be placed without a
 same-heat gear conflict before replacing an existing schedule. If event-specific
@@ -215,6 +217,11 @@ Authoritative handicap numbers are deterministic. No LLM provider participates
 in numeric prediction, mark optimization, shadow receipt authority, or official
 scoring. Newer language models may assist engineering or optional reviewed
 narrative work, but they must remain outside these race-day authority paths.
+
+Every accepted score request has a durable request-ID receipt. Score undo
+supersedes but does not delete that receipt. The receipt belongs to tournament
+history, retains the original heat ID even if an undone heat is regenerated,
+and loses replay authority without deletion if its issuing user is removed.
 
 ## Production Parity
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -47,6 +47,12 @@ These are GitHub settings, not repo code:
 - If touching deploy/runtime/config:
   - confirm `railway.toml` changes are intentional
   - confirm env var expectations are documented
+- If touching hosted backup/recovery:
+  - confirm `RAILWAY_PG_READONLY_DUMP_URL` belongs to the dedicated
+    non-superuser, read-only dump role
+  - confirm `BACKUP_AGE_RECIPIENT` is the owner-approved public recipient
+  - confirm the recovery private identity is held separately from GitHub,
+    Railway, the repository, and the application environment
 - If touching scoring/scheduling/reporting:
   - run targeted tests for the affected subsystem
 
@@ -61,6 +67,8 @@ python -m pytest tests/test_postgres_runtime_smoke.py -q
 python -m pytest tests/test_pg_migration_safety.py -q
 python -m pytest tests/test_migration_integrity.py::TestMigrationIntegrity -q
 python -m pytest tests/test_migration_integrity.py::test_shadow_schema_repair_upgrades_an_existing_b7_database -q
+python -m pytest tests/test_infrastructure.py tests/test_reporting_export.py -q
+python -m pytest tests/test_daily_backup_workflow.py -q
 $env:PROAM_UNIT_PG = "1"
 python -m pytest tests/test_migration_integrity.py::test_shadow_schema_repair_round_trip_on_populated_b7_postgresql tests/test_shadow_settlement_workflow.py::test_postgres_workers_skip_a_locked_delivery_instead_of_double_sending -q
 ```
@@ -81,6 +89,33 @@ For a service-worker/offline-scoring change, also verify on a demo database:
 3. a successful, non-redirected heat-entry page is available by its exact URL after the local server is stopped
 4. an uncached heat-entry URL shows the offline fallback rather than a browser network-error page
 5. queued POST evidence stays in the same browser profile and is reconciled through Offline Operations after reconnect
+
+## Hosted Backup Restore Proof
+
+The 2027 race-weekend dates are not yet configured. Do not add a date-specific
+schedule or claim race-weekend coverage until the owner approves the dates.
+
+Before merging a backup workflow change:
+
+1. Static workflow tests pass and confirm that production credentials occur
+   only in the role-verification and dump steps.
+2. A hosted run on the exact branch head verifies the dump role, creates the
+   dump without row output, restores it only to the runner-local PostgreSQL
+   service, suppresses and deletes `pg_restore` diagnostics, and passes
+   required-table, Alembic, and aggregate checks.
+3. The run uploads one `.age` ciphertext artifact and no plaintext dump. A
+   missing recipient, failed encryption, failed runner-local database removal,
+   or failed plaintext cleanup must produce no upload. The runner-local restore
+   must be dropped before the commit-pinned upload action executes.
+4. Evidence records the run URL, exact commit SHA, plaintext and ciphertext
+   SHA-256 digests, local restore result, and cleanup result.
+5. A designated recovery operator separately decrypts an artifact with the
+   approved private identity path and restores it into a disposable PostgreSQL
+   database according to `docs/ROLLBACK_SOP.md`.
+
+Do not mark hosted restore proof complete from static tests alone. Do not mark
+key custody or decryption proof complete until the separately held identity has
+been rehearsed by its owner.
 
 ## Deploy Verification
 
@@ -120,6 +155,9 @@ For a deliberately enabled STRATHMARK shadow deployment, also confirm:
 - [ ] CI green
 - [ ] PostgreSQL smoke green
 - [ ] migration safety green
+- [ ] hosted backup restored in runner-local PostgreSQL on the exact head
+- [ ] encrypted artifact contains ciphertext only
+- [ ] separately held recovery identity rehearsal recorded, or release blocked
 - [ ] rollback path documented
 - [ ] deploy verified in Railway logs
 - [ ] `/health` verified after deploy

--- a/docs/ROLLBACK_SOP.md
+++ b/docs/ROLLBACK_SOP.md
@@ -128,12 +128,152 @@ Response:
    - verify schema revision matches current app
    - document lost operator actions since backup
    - communicate before restore
+   - use the provider recovery path below; the application and backup workflow
+     are not production restore tools
 
-## Production Backup / Restore Notes
+## Recovery Boundaries
 
-- SQLite backup download and restore are app-supported only in SQLite environments
-- Cloud/local backup jobs should be visible through the app workflow and ops dashboard
-- Never restore a DB artifact with unknown schema provenance
+Keep these three operations separate:
+
+1. **Application rollback** reverts application code with a PR and redeploy. It
+   does not reverse committed database rows or automatically downgrade schema.
+2. **Provider recovery** restores a Railway-managed backup, snapshot, or
+   point-in-time recovery target through an owner-approved incident procedure.
+   This is the only production database recovery path documented here.
+3. **Disposable verification** decrypts and restores an exported artifact into
+   a new local or CI PostgreSQL database for proof. It never targets Railway,
+   an externally resolved host, or a database named for production.
+
+The application must not perform an in-place PostgreSQL production restore.
+The daily backup workflow must not receive production restore credentials. It
+may read a dump through the dedicated read-only role, but it restores only into
+the runner-local PostgreSQL service before encrypting the artifact.
+
+SQLite backup and staged restore operations apply only to explicitly supported
+SQLite environments. They are not a substitute for PostgreSQL recovery proof.
+
+### SQLite Offline Restore Contract
+
+The web route may validate and stage a SQLite restore package, but it must not
+replace the live database. Applying a staged package is an offline maintenance
+operation: stop every app process, drain queued/running jobs, and acquire the
+exclusive database activity fence before proceeding.
+
+Restore package version 2 fails closed unless the upload has all of the
+following:
+
+- a clean SQLite integrity and foreign-key check
+- the current Alembic revision
+- the exact current application table set, excluding only SQLite's internal
+  tables, with the same canonical columns, types, nullability, defaults,
+  primary keys, foreign keys, and indexes for every table
+- the same deterministic identity fingerprint for the complete sorted set of
+  tournament `(id, name, year)` rows, not only the selected tournament
+- the staged manifest checksum
+
+The selected tournament and complete tournament-set fingerprint establish
+identity continuity with the current database; the restore still replaces the
+whole SQLite database. A mismatch in any other tournament blocks the restore.
+These checks do **not** prove backup provenance or authenticity. Package v2
+does not consume a backup-issued signed manifest or an owner-held signature.
+Until that external evidence exists, an operator must independently verify the
+source backup and its recorded digest before staging it; do not describe the
+package as cryptographically provenance-verified.
+
+Before replacing the main database file, the maintenance process creates and
+verifies a SQLite online safety snapshot. While the exclusive fence is held, it
+moves any target `-wal` and `-shm` files into the package's
+`sidecar-quarantine` directory before replacing either the live main file or a
+rollback main file. Every sidecar move intent, destination name, and source
+hash is fsynced to the external restore journal and manifest before the move.
+A later invocation reconciles a move that completed before its final manifest
+update, then reconciles the interrupted `applying` package before opening the
+target database. It either validates a fully replaced target or restores the
+safety snapshot. Quarantined sidecars must never be moved back beside a
+restored main file.
+
+The staged database, safety snapshot, external journal, manifest, and
+quarantined sidecars can contain production-equivalent personal data. Protect
+the entire `.restore-staging` tree as backup material. The maintenance tooling
+sets staging and quarantine directories to `0700` and database, journal, and
+manifest files to `0600` on filesystems that support those modes. Platform
+access controls remain mandatory where POSIX modes are unavailable. Remove the
+tree only under the approved evidence-retention procedure.
+
+## Hosted Backup Contract
+
+The scheduled workflow fails closed unless all three are configured:
+
+- `RAILWAY_PG_READONLY_DUMP_URL`, a dedicated dump role URL
+- `BACKUP_AGE_RECIPIENT`, the approved `age` public recipient repository variable
+- `BACKUP_AGE_RECIPIENT_SHA256`, the reviewed SHA-256 of the exact recipient
+  string, stored as a separate repository variable
+
+Before `pg_dump`, automation verifies that the connected role is not a
+superuser, cannot create roles or databases, defaults to read-only transactions,
+and has no detected table or sequence write privileges. The production URL is
+available only to that check and the dump step.
+
+The dump is restored into `127.0.0.1:5432/proam_restore_verify`. Required
+tables, Alembic metadata, and aggregate relationship checks must pass. The
+runner-local database password is scoped only to the trusted restore,
+verification, and database-removal shell steps. `pg_restore` diagnostics are
+captured without being printed and securely deleted on both success and
+failure. The workflow then encrypts the verified dump to the approved
+recipient only after its configured value matches the pinned fingerprint,
+drops the runner-local plaintext database, removes the plaintext
+dump unconditionally, and only then invokes the commit-pinned official upload
+action with the `.age` file. Missing configuration, failed restore, failed
+verification, failed encryption, failed database removal, or failed plaintext
+cleanup produces no artifact upload.
+
+Workflow logs and summaries must not print database rows. Evidence may include
+file sizes, SHA-256 digests, generic pass/fail results, the workflow run URL,
+and the exact Git commit.
+
+## Disposable PostgreSQL Restore Rehearsal
+
+The recovery private key is held separately from GitHub Actions. Do not add it
+to repository secrets or the application environment. A designated recovery
+operator performs the decryption rehearsal on an approved workstation:
+
+1. Record the workflow run URL, commit SHA, ciphertext SHA-256, and operator.
+2. Download the `.dump.age` artifact and verify its ciphertext SHA-256 against
+   the workflow summary.
+3. Set `PROAM_BACKUP_AGE_IDENTITY` to the approved private identity file path.
+   Stop if the path is missing, unapproved, or repository-owned.
+4. Decrypt with `age --decrypt --identity "$PROAM_BACKUP_AGE_IDENTITY"` to a
+   temporary local file. Confirm its SHA-256 matches the plaintext digest in
+   the workflow summary.
+5. Guard the restore target before any destructive command: host must be
+   `127.0.0.1`, database must be a newly created disposable rehearsal database,
+   and neither the host nor database may reference Railway or production.
+6. Restore with `pg_restore --exit-on-error --single-transaction --no-owner
+   --no-acl` and run the same required-table, Alembic, and relationship checks.
+7. Record pass/fail without capturing row output. Delete the decrypted dump and
+   drop the disposable database after evidence is recorded.
+
+Successful hosted encryption and a matching recipient fingerprint are not
+decryption proof. Release evidence must say whether the separately held
+identity rehearsal was actually executed against the retained artifact.
+
+## Provider Production Recovery
+
+Production recovery requires an incident-specific plan reviewed by the release
+owner and database owner. Before any provider restore:
+
+1. Freeze application writes and preserve audit and deployment evidence.
+2. Identify the provider recovery source and a new recovery target. Do not
+   overwrite the active database as the first operation.
+3. Record current and target schema revisions and the operator actions that may
+   be lost. Do not invent an RPO or RTO.
+4. Restore through provider tooling into the reviewed target, validate it, and
+   switch application connectivity only after explicit approval.
+5. Keep the old target available until post-recovery checks and reconciliation
+   complete.
+
+Never restore a database artifact with unknown provenance, an unverified
+checksum, or a schema revision that has not been reviewed.
 
 ## Required Post-Rollback Actions
 

--- a/docs/plans/2026-08-18-race-day-certification-recovery.md
+++ b/docs/plans/2026-08-18-race-day-certification-recovery.md
@@ -1,0 +1,465 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+certification_readiness: blocked-owner-and-operations-decisions
+title: 2027 Race-Day Certification And Recovery
+date: 2026-08-18
+owner: Codex
+---
+
+# 2027 Race-Day Certification And Recovery
+
+## Direction
+
+Make race-day scoring, concurrent operation, backup, and recovery fail closed
+and produce evidence that operators can inspect. Preserve the owner-authored
+event rules and show order. Do not make MNEMEX, STRATHMARK, Railway, or any WAN
+service a live scoring dependency.
+
+## Product Contract
+
+### In Scope
+
+1. One canonical, operator-visible offline score queue.
+2. Prepared-device cold-offline access to every scheduled heat-entry page.
+3. Durable, user-bound scoring request IDs that make retries idempotent.
+4. Expired-session replay through the existing HMAC-authorized endpoint.
+5. Stale-write rejection for confirmed relay, partner, scratch, flight, and
+   Birling concurrency gaps.
+6. Consistent SQLite snapshots, validated/rollback-capable SQLite restore, and
+   truthful background-job lifecycle.
+7. Automated restore verification for scheduled PostgreSQL backups.
+8. Checked-in browser rehearsals, PostgreSQL concurrency tests, recovery
+   runbooks, and the requirements-to-evidence ledger.
+9. Tournament-safe cache invalidation and truthful export-artifact lifecycle.
+
+### Out Of Scope
+
+- Changing event format, show order, placements, payouts, handicaps, partner
+  policy, gear-sharing policy, or physical stand policy.
+- Enabling in-app PostgreSQL restore against production.
+- Interactive reading or mutation of production competitor data, or exposing
+  backup contents. The existing hosted backup may perform an automated dump
+  read only through a dedicated least-privilege role; no agent/operator step
+  inspects rows.
+- Making an external ecosystem service race-day critical.
+- Claiming an owner-approved RPO, RTO, or 2027 event window before the owner
+  supplies or confirms it.
+- Silently resolving the annual/event-rule decisions listed in the Owner Rule
+  Ledger. Reliability work may ship without those decisions; certification may
+  not.
+
+## Planning Contract
+
+- Implementation uses an isolated feature worktree from current `origin/main`.
+- Tests use disposable databases only. Browser fixtures are synthetic.
+- Every behavior change starts with a failing focused test.
+- Ordinary pytest, disposable PostgreSQL, production-mirror, browser, CI, and
+  production smoke evidence are reported as separate lanes.
+- No PR merges until exact-head required checks pass. `main` deployment is
+  verified without production writes.
+
+## Key Technical Decisions
+
+### KTD-1: LocalStorage queue is canonical; IndexedDB becomes legacy-drain only
+
+- Decision: the heat page owns new offline submissions. The service worker no
+  longer intercepts score POSTs, but can replay previously queued legacy
+  IndexedDB entries until they drain.
+- Provenance: current code trace and R27-005.
+- Rejected alternative: keep both queues and deduplicate during replay.
+- Reason: two independent queues cannot give operators one truthful inventory.
+
+### KTD-2: Idempotency is a database receipt, not a browser heuristic
+
+- Decision: every heat submission carries a UUID and payload fingerprint. A
+  receipt committed with the score stores the accepted outcome. The same user,
+  heat, ID, and fingerprint returns that outcome; mismatched reuse fails.
+- Provenance: lost-response audit finding and R27-005.
+- Rejected alternative: treat a version conflict as presumed success.
+- Reason: a conflict does not prove which payload committed.
+
+Receipt contract:
+
+- Table `score_submission_receipts`: UUID request ID primary key, tournament
+  ID, heat ID, issuing user ID, canonical payload SHA-256, stored accepted
+  outcome JSON, and creation timestamp; indexed by tournament/heat/user. The
+  tournament is the owning historical aggregate and cascades on explicit
+  tournament deletion. The heat ID is a non-FK historical snapshot so heat
+  regeneration cannot erase the tombstone. User deletion sets the issuer to
+  null, retains the receipt, and permanently disables replay.
+- Canonical payload excludes transport credentials (`csrf_token` and
+  `replay_token`) and includes every score/status/reason, heat identity, and
+  posted version in sorted key/value form.
+- Receipt, score/result changes, heat state, and saved-score audit row commit in
+  one transaction. A duplicate matching binding returns the stored accepted
+  outcome without a second mutation/audit. Any changed binding is `409`.
+- PostgreSQL uniqueness races re-query the committed receipt after rollback;
+  they do not guess success. Automatic queue replay is limited to 30 days.
+  After the seven-day token window, only the original reauthenticated user may
+  renew replay authority. Older entries require manual reconciliation and
+  never mutate automatically. Receipts/tombstones have no automatic deletion
+  in this phase and remain with tournament history, so an exported old queue
+  can never make a request ID reusable merely by waiting.
+
+### KTD-3: Offline operation requires explicit preparation and evidence
+
+- Decision: Offline Operations exposes a preparation command that asks the
+  service worker to cache all current scheduled heat-entry pages and required
+  local assets, then reports per-page success/failure.
+- Provenance: local-first authority boundary and cold-outage audit.
+- Rejected alternative: imply that opportunistically visited pages constitute
+  an offline show package.
+- Reason: operators need a deterministic pre-show gate.
+
+Offline package contract:
+
+- Versioned manifest binds application build, schedule fingerprint,
+  tournament, issuing user, current role, prepared timestamp, and URL digests.
+- A schedule rebuild, application build change, logout, or user/role mismatch
+  invalidates the package. Logout clears prepared page caches but does not
+  silently delete unsynced queue data.
+- Queue transfer is versioned data only. It carries issuer/tournament/schedule
+  bindings, never a new user's authority. Import under another user is visible
+  but cannot sync.
+- CSRF expiry is a structured JSON error and alone may invoke HMAC replay.
+  Session expiry requires reauthentication as the issuer. Authorization `403`
+  and role/tournament loss remain blocked. Redirects/HTML never delete entries.
+- Queue entries carry creation/expiry state. At 30 days they become
+  `manual_reconciliation_required`; export remains available but Sync cannot
+  mutate the database.
+
+### KTD-4: Stale operators receive conflicts, never silent last-writer wins
+
+- Decision: use the existing tournament writer lock for serialization and
+  add narrow expected-state tokens/digests for stale-client detection. Enforce
+  monotonic state machines where transitions are ordered.
+- Provenance: concurrent-operator audit.
+- Rejected alternative: add one global lock without stale-state validation.
+- Reason: serialization alone still lets a later stale snapshot erase a valid
+  earlier action.
+
+### KTD-5: A backup is recoverable only after restore verification
+
+- Decision: SQLite uses the online backup API and integrity checks. Scheduled
+  PostgreSQL automation restores each new dump into an ephemeral PostgreSQL
+  database and checks schema/migration invariants before artifact publication.
+- Provenance: recovery audit and existing production PostgreSQL boundary.
+- Rejected alternative: continue treating file size and SQL text as proof.
+- Reason: an unreadable or non-restorable backup is not recovery evidence.
+
+Hosted restore guard:
+
+- Existing automation may use only a dedicated production dump role whose
+  non-superuser, read-only privileges are verified before `pg_dump`; it must
+  never print row data. The production URL secret is scoped only to the dump
+  and privilege-check steps. Restore steps receive only job-local credentials
+  and have no production secret or network target.
+- The restore step rejects external/Railway hosts and production database
+  names before any destructive flag or SQL is used.
+- U6 must replace plaintext publication with recipient-based client-side
+  encryption. The recipient public key and separately held recovery private
+  key must be approved before merge. If encryption is absent or fails, the
+  workflow skips upload, securely removes the runner copy, and fails loudly;
+  an unencrypted dump is never published.
+
+### KTD-6: Process-local jobs carry boot ownership
+
+- Decision: each job records a boot/worker owner. Startup reconciles only jobs
+  owned by a demonstrably dead prior boot; a returned result with `ok: false`
+  is a failed job. The deployed one-process assumption is explicit and tested.
+- Provenance: background-job audit and R27-008.
+- Rejected alternative: leave stale rows running until manual interpretation.
+- Reason: the executor cannot resume work after its process disappears.
+
+### KTD-7: SQLite restore is an offline maintenance operation
+
+- Decision: the web route validates and stages a restore package; actual file
+  replacement runs under an offline maintenance command with a cross-process
+  file fence, exclusive DB access, drained jobs/connections, same-volume
+  staging, fsync, safety snapshot, post-reopen validation, and rollback.
+- Provenance: restore security review and R27-009.
+- Rejected alternative: replace the live SQLite file inside an ordinary web
+  request.
+- Reason: a request cannot prove that another process or in-flight writer has
+  released the database.
+
+## Implementation Units
+
+### U1: Certification Ledger And Baseline
+
+Owned files:
+
+- `docs/2027_RACE_DAY_CERTIFICATION.md`
+- this plan
+- focused evidence reports produced during verification
+
+Acceptance:
+
+- Every owner-authored rule family has a stable ID, controlling clause,
+  operator step, current evidence state, and required evidence.
+- Missing historical documents and owner-only recovery objectives are not
+  fabricated.
+
+### U2: Exactly-Once Prepared Offline Scoring
+
+Owned files:
+
+- `static/sw.js`
+- `static/offline_queue.js`
+- `static/js/offline_queue_shared.js`
+- `templates/scoring/enter_heat.html`
+- `templates/scoring/offline_ops.html`
+- `routes/scoring.py`
+- scoring workflow/model/migration files needed for request receipts
+- focused offline, replay, idempotency, and presentation tests
+
+Work:
+
+1. Stop new score POST interception in the service worker.
+2. Add stable request IDs to queue entries and normal submissions.
+3. Persist an idempotency receipt atomically with accepted scores.
+4. Make queue sync fall back to the HMAC replay endpoint on CSRF rejection.
+5. Bind queue transfer/replay to the issuing user and reject payload drift.
+6. Add prepared-offline caching with visible completeness and refresh states.
+7. Preserve replay of legacy IndexedDB entries without creating new ones.
+8. Require verified JSON success or a matching durable receipt before any
+   legacy or canonical queue entry is deleted; redirects and HTML never count.
+
+Acceptance:
+
+- Offline submit, reconnect, double-click, lost response, and explicit retry
+  each cause one score mutation and one saved-score audit action.
+- An ID reused with different payload or user is rejected.
+- A prepared browser restarted offline can open every scheduled heat page.
+- Operators see one current queue and a separate truthful legacy-drain status.
+- Logout/user switch clears prepared pages, preserves unsynced data, and blocks
+  replay until the original authorized user returns.
+
+### U3: Concurrent Operator Integrity
+
+Owned files:
+
+- relay route/service/templates and tests
+- partner route/service/templates and tests
+- scratch route/service/templates and tests
+- flight route/templates and tests
+- Birling route/service/templates and tests
+
+Work:
+
+1. Lock and stale-check relay snapshot updates.
+2. Serialize partner claims and re-evaluate reciprocal availability under lock.
+3. Reject a scratch confirmation when its effect digest changed.
+4. Add a flight-order digest and reject stale reorder payloads.
+5. Enforce monotonic flight transitions.
+6. Add expected fall state so duplicate Birling submissions are idempotent or
+   rejected without adding a second physical fall.
+7. Preserve existing Heat/EventResult optimistic-lock behavior and add it to a
+   compatible/conflicting/duplicate/out-of-order operation matrix.
+
+Acceptance:
+
+- Two-client PostgreSQL tests prove compatible changes survive together and
+  conflicting/stale requests produce exactly one winner plus an actionable
+  conflict. Each test asserts response, mutation count, audit count, and final
+  database digest.
+- No scenario silently drops, duplicates, or regresses accepted state.
+
+### U4: Backup, Restore, And Job Recovery
+
+Owned files:
+
+- `services/backup.py`
+- `services/reporting_backup.py`
+- `services/restore_workflow.py`
+- `services/background_jobs.py`
+- `routes/reporting.py`
+- affected operator templates and focused tests
+
+Work:
+
+1. Create SQLite backups with the SQLite online backup API and validate the
+   completed snapshot before upload/download.
+2. Make the web route validate and stage restores only; file replacement moves
+   to an offline maintenance command that proves exclusive access.
+3. Validate integrity, foreign keys, revision, tournament identity, checksum,
+   and provenance; keep a same-volume safety snapshot and roll back every
+   injected replacement/reopen failure.
+4. Append and fsync an out-of-database restore journal before and after each
+   phase, recording actor, source/safety hashes, audit-chain head, validation,
+   replacement, and rollback outcomes without row data.
+5. Turn `ok: false` backup results into failed jobs.
+6. Reconcile process-interrupted jobs by boot ownership and surface their
+   status to operators.
+7. Scope recent-job queries by tournament before applying the limit.
+
+Acceptance:
+
+- Active SQLite writes cannot produce a torn backup.
+- Corrupt, foreign-key-invalid, or wrong-revision uploads never replace the DB.
+- Injected post-replace validation failure restores the prior DB.
+- Failed and interrupted jobs are never displayed as completed/running.
+- Crash injection at journal, stage, safety snapshot, replacement, reopen, and
+  validation boundaries yields either the old valid DB or new validated DB.
+
+### U5: Cache And Export Durability
+
+Owned files:
+
+- `services/cache_invalidation.py`
+- `services/report_cache.py`
+- `services/reporting_export.py`
+- affected routes and focused tests
+
+Work:
+
+1. Delimit every tournament cache prefix so tournament 1 cannot invalidate
+   tournament 10 or 11.
+2. Add an invalidation generation guard so a read begun before commit cannot
+   repopulate a stale entry after invalidation in the current process model.
+3. Store export checksums and verify file existence/checksum when resolving a
+   completed job.
+4. Mark missing or changed ephemeral artifacts expired/failed instead of
+   offering a dead download.
+
+Acceptance:
+
+- Cross-tournament invalidation tests preserve unrelated cache entries.
+- A controlled stale-reader race cannot repopulate invalid data.
+- Restart/missing/tampered export tests never report a usable completion.
+
+### U6: PostgreSQL Restore Proof And Runbooks
+
+Owned files:
+
+- `.github/workflows/daily-backup.yml`
+- `docs/ROLLBACK_SOP.md`
+- `docs/RELEASE_CHECKLIST.md`
+- recovery drill scripts/tests as needed
+
+Work:
+
+1. Restore the new dump into ephemeral PostgreSQL in the backup workflow.
+2. Verify required tables, migration metadata, and non-sensitive aggregate
+   invariants before artifact upload.
+3. Correct stale 2026 scheduling claims without guessing the 2027 event dates.
+4. Document disposable restore rehearsal, evidence capture, and the explicit
+   prohibition on in-place production restore from the application.
+5. Verify the dump credential is a non-superuser read-only role before use,
+   client-side encrypt the verified artifact to the approved recipient, upload
+   only ciphertext, and delete plaintext in an unconditional cleanup step.
+
+Acceptance:
+
+- A deliberately invalid dump fails before artifact publication.
+- A synthetic dump restores and passes schema checks locally and in CI.
+- The runbook distinguishes provider recovery, disposable verification, and
+  application rollback.
+- The workflow never emits row data and hard-fails if its restore target is not
+  the runner-local PostgreSQL service.
+- No plaintext artifact is uploaded; encryption and decryption are both tested
+  using the approved, separately held key path.
+
+### U7: Browser And Adversarial Certification
+
+Owned files:
+
+- checked-in browser test configuration/specs
+- synthetic fixture/bootstrap helpers
+- certification evidence update
+
+Work:
+
+1. Exercise desktop and phone scoring with network transitions and browser
+   restart.
+2. Exercise two authenticated sessions on the same heat and each repaired
+   stale-writer path.
+3. Rehearse special events, scratch/undo, standings, payouts, export, backup,
+   and recovery entry points with synthetic data.
+4. Capture console/page errors, overflow, hidden controls, queue counts, audit
+   counts, and database digests.
+
+Acceptance:
+
+- No console/page errors, hidden primary action, incoherent overlap, or
+  horizontal overflow at tested viewports.
+- Evidence names the exact commit, browser, database backend, and scenario.
+
+## Verification Contract
+
+Every evidence receipt records the exact commit, UTC date, backend, isolation
+fixture/database, command or hosted artifact URL, and pass/fail result. Planned
+tests are never entered as existing evidence.
+
+### Focused Gates
+
+- New red/green tests for every implementation unit.
+- Existing scoring, relay, partner, scratch, flight, Birling, reporting,
+  infrastructure, presentation, and lifecycle tests.
+
+### Repository Gates
+
+- `ruff check .`
+- Python 3.10 AST parse for changed Python files.
+- standard `python -m pytest` with isolated base temp, explicitly excluding
+  `proam_regression/` per repository configuration.
+- PostgreSQL runtime smoke, migration safety, migration integrity, and new
+  two-client tests on disposable PostgreSQL.
+- `git diff --check`.
+- explicit `proam_regression/` production-mirror lane when legitimate isolated
+  mirror access is available; absence is reported and cannot be replaced by
+  SQLite or synthetic PostgreSQL claims.
+
+### Recovery Gates
+
+- Synthetic SQLite active-write backup and forced-rollback restore drill.
+- Synthetic PostgreSQL dump/restore drill.
+- Hosted backup workflow restore verification.
+
+### Browser Gates
+
+- Prepared cold-offline score entry.
+- Lost-response and reconnect idempotency.
+- Expired session and queue transfer.
+- Two-operator conflicts.
+- Desktop and phone layout/interaction review.
+
+## Definition Of Done
+
+### Reliability Release Complete
+
+1. All in-scope reliability blockers are fixed. Annual owner decisions may
+   remain visibly blocked, but backup encryption/key custody cannot: U6 does
+   not merge while plaintext publication is possible.
+2. Focused, standard, PostgreSQL, migration, recovery, and browser lanes pass
+   on the exact branch head.
+3. Independent structural, security, and operator reviews have no unresolved
+   high-severity finding.
+4. The PR passes required hosted checks and merges at its reviewed head.
+5. Railway deploys the merge; health, one authenticated read-only page, and one
+   public page pass without production data mutation.
+6. The ledger records exact executed evidence and remaining gaps.
+
+### 2027 Race-Day Certified
+
+1. Every applicable reliability and owner-rule row is `Certified`.
+2. Every owner-decision row is approved and incorporated into the Domain
+   Contract/configuration or explicitly signed not applicable.
+3. Event dates, recovery objectives, and encrypted-backup key custody are
+   approved and rehearsed.
+4. Exact-head browser, PostgreSQL, production-mirror, hosted CI, deploy, and
+   read-only production smoke evidence is current.
+
+## Execution Order
+
+1. Complete the rule-level ledger and keep annual decisions blocked.
+2. Add receipt/job persistence contracts and migrations; run SQLite,
+   PostgreSQL upgrade, downgrade/rollback, migration integrity, and available
+   production-mirror migration gates.
+3. Implement transactional scoring/concurrency and backend recovery behavior.
+4. Implement the offline client/package against the stable receipt API.
+5. Add cache/export durability and hosted PostgreSQL restore proof against the
+   final migration head.
+6. Run browser/operator/adversarial certification, then PR/CI/deploy evidence.

--- a/migrations/versions/a6b7c8d9e0f1_race_day_recovery_receipts.py
+++ b/migrations/versions/a6b7c8d9e0f1_race_day_recovery_receipts.py
@@ -1,0 +1,85 @@
+"""Add score submission receipts and background job boot ownership.
+
+Revision ID: a6b7c8d9e0f1
+Revises: c8a9b0c1d2e3
+Create Date: 2026-08-18
+
+Receipts make a committed heat score idempotent across lost responses and
+offline replay. Boot ownership lets startup distinguish abandoned process-local
+jobs from work owned by the current process.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a6b7c8d9e0f1"
+down_revision = "c8a9b0c1d2e3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "background_jobs",
+        sa.Column("owner_boot_id", sa.String(length=32), nullable=True),
+    )
+    op.create_index(
+        "ix_background_jobs_owner_boot_id",
+        "background_jobs",
+        ["owner_boot_id"],
+        unique=False,
+    )
+    op.add_column(
+        "background_jobs",
+        sa.Column("owner_heartbeat_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "ix_background_jobs_owner_heartbeat_at",
+        "background_jobs",
+        ["owner_heartbeat_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "score_submission_receipts",
+        sa.Column("request_id", sa.String(length=36), nullable=False),
+        sa.Column("tournament_id", sa.Integer(), nullable=False),
+        sa.Column("heat_id", sa.Integer(), nullable=False),
+        sa.Column("issuing_user_id", sa.Integer(), nullable=True),
+        sa.Column("canonical_payload_sha256", sa.String(length=64), nullable=False),
+        sa.Column("accepted_outcome_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["issuing_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["tournament_id"], ["tournaments.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("request_id"),
+    )
+    op.create_index(
+        "ix_score_submission_receipts_binding",
+        "score_submission_receipts",
+        ["tournament_id", "heat_id", "issuing_user_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "ix_score_submission_receipts_binding",
+        table_name="score_submission_receipts",
+    )
+    op.drop_table("score_submission_receipts")
+
+    op.drop_index(
+        "ix_background_jobs_owner_boot_id",
+        table_name="background_jobs",
+    )
+    op.drop_index(
+        "ix_background_jobs_owner_heartbeat_at",
+        table_name="background_jobs",
+    )
+    op.drop_column("background_jobs", "owner_heartbeat_at")
+    op.drop_column("background_jobs", "owner_boot_id")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -20,6 +20,7 @@ from .print_tracker import PrintTracker
 from .pro_event_rank import ProEventRank
 from .relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
 from .school_captain import SchoolCaptain
+from .score_submission_receipt import ScoreSubmissionReceipt
 from .shadow_handicap import (
     CompetitorExternalIdentity,
     ShadowContextObservation,
@@ -51,6 +52,7 @@ __all__ = [
     'AuditLog',
     'BackgroundJob',
     'SchoolCaptain',
+    'ScoreSubmissionReceipt',
     'WoodConfig',
     'ProEventRank',
     'PayoutTemplate',

--- a/models/background_job.py
+++ b/models/background_job.py
@@ -12,12 +12,16 @@ class BackgroundJob(db.Model):
         db.Index('ix_background_jobs_status', 'status'),
         db.Index('ix_background_jobs_submitted_at', 'submitted_at'),
         db.Index('ix_background_jobs_tournament_id', 'tournament_id'),
+        db.Index('ix_background_jobs_owner_boot_id', 'owner_boot_id'),
+        db.Index('ix_background_jobs_owner_heartbeat_at', 'owner_heartbeat_at'),
     )
 
     id = db.Column(db.String(32), primary_key=True)
     label = db.Column(db.String(120), nullable=False)
     status = db.Column(db.String(20), nullable=False)
     tournament_id = db.Column(db.Integer, nullable=True)
+    owner_boot_id = db.Column(db.String(32), nullable=True)
+    owner_heartbeat_at = db.Column(db.DateTime, nullable=True)
     submitted_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
     started_at = db.Column(db.DateTime, nullable=True)
     finished_at = db.Column(db.DateTime, nullable=True)

--- a/models/score_submission_receipt.py
+++ b/models/score_submission_receipt.py
@@ -1,0 +1,43 @@
+"""Durable idempotency receipts for heat score submissions."""
+
+from database import db
+from services.time_utils import utc_now_naive
+
+
+class ScoreSubmissionReceipt(db.Model):
+    """Binds one accepted request to historical tournament scoring state."""
+
+    __tablename__ = 'score_submission_receipts'
+    __table_args__ = (
+        db.Index(
+            'ix_score_submission_receipts_binding',
+            'tournament_id',
+            'heat_id',
+            'issuing_user_id',
+        ),
+    )
+
+    request_id = db.Column(db.String(36), primary_key=True)
+    tournament_id = db.Column(
+        db.Integer,
+        db.ForeignKey('tournaments.id', ondelete='CASCADE'),
+        nullable=False,
+    )
+    # Heat rows can be regenerated after a score is undone. Keep the original
+    # integer as historical identity so deleting that mutable row cannot make
+    # an old offline request ID reusable.
+    heat_id = db.Column(db.Integer, nullable=False)
+    issuing_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    canonical_payload_sha256 = db.Column(db.String(64), nullable=False)
+    accepted_outcome_json = db.Column(db.JSON, nullable=False)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now_naive)
+
+    def __repr__(self):
+        return (
+            f'<ScoreSubmissionReceipt {self.request_id} '
+            f't={self.tournament_id} h={self.heat_id} u={self.issuing_user_id}>'
+        )

--- a/routes/main.py
+++ b/routes/main.py
@@ -1012,15 +1012,14 @@ def ops_dashboard(tid):
     # ------------------------------------------------------------------
     from services.background_jobs import list_recent as list_recent_jobs
 
-    recent_jobs = [
-        job
-        for job in list_recent_jobs(limit=30)
-        if int((job.get('metadata') or {}).get('tournament_id', -1)) == tid
-    ]
+    recent_jobs = list_recent_jobs(limit=30, tournament_id=tid)
     job_summary = {
         'queued': sum(1 for job in recent_jobs if job['status'] == 'queued'),
         'running': sum(1 for job in recent_jobs if job['status'] == 'running'),
-        'failed': sum(1 for job in recent_jobs if job['status'] == 'failed'),
+        'failed': sum(
+            1 for job in recent_jobs
+            if job['status'] in {'failed', 'interrupted'}
+        ),
     }
 
     return render_template(

--- a/routes/proam_relay.py
+++ b/routes/proam_relay.py
@@ -1,6 +1,11 @@
 """
 Routes for Pro-Am Relay lottery and management.
 """
+import hashlib
+import hmac
+import json
+from functools import wraps
+
 from flask import Blueprint, abort, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user
 from sqlalchemy.orm.exc import StaleDataError
@@ -11,7 +16,12 @@ from models.event import Event
 from models.relay import RelayTeam
 from services.audit import log_action
 from services.cache_invalidation import invalidate_tournament_caches
+from services.flight_builder import (
+    lock_tournament_schedule,
+    serialize_sqlite_schedule_writer,
+)
 from services.proam_relay import (
+    RelayStateConflict,
     compute_team_health,
     create_proam_relay_event,
     get_proam_relay,
@@ -25,8 +35,54 @@ _STALE_DATA_FLASH = (
     'Another judge updated this in parallel. Reload the page and try again — '
     'your last input was not saved.'
 )
+_RELAY_STATE_FLASH = (
+    'Relay state changed since this page was loaded. Refresh and review the '
+    'current relay before saving again.'
+)
+_RELAY_PAYOUT_FLASH = (
+    'Relay payouts or results changed since this page was loaded. '
+    'Refresh and review the current amounts before saving again.'
+)
 
 bp = Blueprint('proam_relay', __name__, url_prefix='/tournament/<int:tournament_id>/proam-relay')
+
+
+def _relay_conflict_response():
+    db.session.rollback()
+    return _RELAY_STATE_FLASH, 409
+
+
+def _require_relay_digest(func):
+    """Reject tokenless relay writes before validation or lock acquisition."""
+    @wraps(func)
+    def guarded(*args, **kwargs):
+        if request.method == 'POST':
+            expected_digest = request.form.get('expected_relay_digest', '').strip()
+            if not expected_digest:
+                return _relay_conflict_response()
+        return func(*args, **kwargs)
+
+    return guarded
+
+
+def _relay_payout_state_digest(tournament, relay_event) -> str:
+    payload = {
+        'event_id': relay_event.id,
+        'payouts': relay_event.get_payouts(),
+        'relay_state': get_proam_relay(tournament).state_digest(),
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=True,
+    ).encode('ascii')
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _relay_payout_conflict_response():
+    db.session.rollback()
+    return _RELAY_PAYOUT_FLASH, 409
 
 
 @bp.route('/')
@@ -46,6 +102,7 @@ def relay_dashboard(tournament_id):
                          relay=relay,
                          status=relay.get_status(),
                          teams=teams,
+                         relay_state_digest=relay.state_digest(),
                          team_health=team_health,
                          capacity=relay.get_lottery_capacity(),
                          eligible_pro=relay.get_eligible_pro_competitors(),
@@ -53,9 +110,11 @@ def relay_dashboard(tournament_id):
 
 
 @bp.route('/draw', methods=['POST'])
+@_require_relay_digest
+@serialize_sqlite_schedule_writer
 def draw_lottery(tournament_id):
     """Run the Pro-Am Relay lottery."""
-    tournament = db.get_or_404(Tournament, tournament_id)
+    tournament = lock_tournament_schedule(tournament_id)
     relay = get_proam_relay(tournament)
 
     try:
@@ -67,9 +126,14 @@ def draw_lottery(tournament_id):
         return redirect(url_for('proam_relay.relay_dashboard', tournament_id=tournament_id))
 
     try:
-        result = relay.run_lottery(num_teams=num_teams)
+        result = relay.run_lottery(
+            num_teams=num_teams,
+            expected_digest=request.form.get('expected_relay_digest'),
+        )
         invalidate_tournament_caches(tournament_id)
         flash(result['message'], 'success')
+    except RelayStateConflict:
+        return _relay_conflict_response()
     except StaleDataError:
         db.session.rollback()
         flash(_STALE_DATA_FLASH, 'warning')
@@ -80,9 +144,11 @@ def draw_lottery(tournament_id):
 
 
 @bp.route('/redraw', methods=['POST'])
+@_require_relay_digest
+@serialize_sqlite_schedule_writer
 def redraw_lottery(tournament_id):
     """Clear and redraw the lottery."""
-    tournament = db.get_or_404(Tournament, tournament_id)
+    tournament = lock_tournament_schedule(tournament_id)
     relay = get_proam_relay(tournament)
 
     existing_team_count = len(relay.get_teams()) or 2
@@ -99,9 +165,14 @@ def redraw_lottery(tournament_id):
             return redirect(url_for('proam_relay.relay_dashboard', tournament_id=tournament_id))
 
     try:
-        result = relay.redraw_lottery(num_teams=num_teams)
+        result = relay.redraw_lottery(
+            num_teams=num_teams,
+            expected_digest=request.form.get('expected_relay_digest'),
+        )
         invalidate_tournament_caches(tournament_id)
         flash(f"Lottery has been redrawn with {num_teams} team(s).", 'success')
+    except RelayStateConflict:
+        return _relay_conflict_response()
     except StaleDataError:
         db.session.rollback()
         flash(_STALE_DATA_FLASH, 'warning')
@@ -118,22 +189,54 @@ def view_teams(tournament_id):
     relay = get_proam_relay(tournament)
     teams = relay.get_teams()
     team_health = {t['team_number']: compute_team_health(t, tournament) for t in teams}
+    assigned_ids = {
+        'pro': {
+            member['id']
+            for team in teams
+            for member in team.get('pro_members', [])
+        },
+        'college': {
+            member['id']
+            for team in teams
+            for member in team.get('college_members', [])
+        },
+    }
+    replacement_options = {'pro': {'M': [], 'F': []}, 'college': {'M': [], 'F': []}}
+    for competitor_type, eligible in (
+        ('pro', relay.get_eligible_pro_competitors()),
+        ('college', relay.get_eligible_college_competitors()),
+    ):
+        for competitor in eligible:
+            if competitor['id'] not in assigned_ids[competitor_type]:
+                replacement_options[competitor_type].setdefault(
+                    competitor['gender'], []
+                ).append(competitor)
 
     return render_template('proam_relay/teams.html',
                          tournament=tournament,
                          relay=relay,
                          teams=teams,
+                         team_state_digests={
+                             team['team_number']: relay.team_state_digest(
+                                 team['team_number']
+                             )
+                             for team in teams
+                         },
+                         replacement_options=replacement_options,
                          team_health=team_health,
                          status=relay.get_status())
 
 
 @bp.route('/results', methods=['GET', 'POST'])
+@_require_relay_digest
+@serialize_sqlite_schedule_writer
 def enter_results(tournament_id):
     """Enter relay total times per team."""
     tournament = db.get_or_404(Tournament, tournament_id)
-    relay = get_proam_relay(tournament)
 
     if request.method == 'POST':
+        tournament = lock_tournament_schedule(tournament)
+        relay = get_proam_relay(tournament)
         try:
             team_number = int(request.form.get('team_number'))
         except (TypeError, ValueError):
@@ -152,9 +255,15 @@ def enter_results(tournament_id):
             else:
                 total_seconds = float(time_input)
 
-            relay.record_total_time(team_number, total_seconds)
+            relay.record_total_time(
+                team_number,
+                total_seconds,
+                expected_digest=request.form.get('expected_relay_digest'),
+            )
             invalidate_tournament_caches(tournament_id)
             flash(f'Time recorded for Team {team_number}.', 'success')
+        except RelayStateConflict:
+            return _relay_conflict_response()
         except StaleDataError:
             db.session.rollback()
             flash(_STALE_DATA_FLASH, 'warning')
@@ -163,10 +272,18 @@ def enter_results(tournament_id):
 
         return redirect(url_for('proam_relay.enter_results', tournament_id=tournament_id))
 
+    relay = get_proam_relay(tournament)
+    teams = relay.get_teams()
     return render_template('proam_relay/results.html',
                          tournament=tournament,
                          relay=relay,
-                         teams=relay.get_teams(),
+                         teams=teams,
+                         team_state_digests={
+                             team['team_number']: relay.team_state_digest(
+                                 team['team_number']
+                             )
+                             for team in teams
+                         },
                          status=relay.get_status())
 
 
@@ -195,14 +312,17 @@ def manual_teams(tournament_id):
                          relay=relay,
                          status=relay.get_status(),
                          teams=relay.get_teams(),
+                         relay_state_digest=relay.state_digest(),
                          eligible_pro=relay.get_eligible_pro_competitors(),
                          eligible_college=relay.get_eligible_college_competitors())
 
 
 @bp.route('/manual-teams/save', methods=['POST'])
+@_require_relay_digest
+@serialize_sqlite_schedule_writer
 def save_manual_teams(tournament_id):
     """Save manually assigned teams."""
-    tournament = db.get_or_404(Tournament, tournament_id)
+    tournament = lock_tournament_schedule(tournament_id)
     relay = get_proam_relay(tournament)
 
     try:
@@ -214,9 +334,14 @@ def save_manual_teams(tournament_id):
             flash('No team assignments provided.', 'warning')
             return redirect(url_for('proam_relay.manual_teams', tournament_id=tournament_id))
 
-        result = relay.set_teams_manually(team_assignments)
+        result = relay.set_teams_manually(
+            team_assignments,
+            expected_digest=request.form.get('expected_relay_digest'),
+        )
         invalidate_tournament_caches(tournament_id)
         flash(result['message'], 'success')
+    except RelayStateConflict:
+        return _relay_conflict_response()
     except StaleDataError:
         db.session.rollback()
         flash(_STALE_DATA_FLASH, 'warning')
@@ -227,9 +352,11 @@ def save_manual_teams(tournament_id):
 
 
 @bp.route('/replace-competitor', methods=['POST'])
+@_require_relay_digest
+@serialize_sqlite_schedule_writer
 def replace_competitor(tournament_id):
     """Replace a competitor on a team (e.g., due to injury)."""
-    tournament = db.get_or_404(Tournament, tournament_id)
+    tournament = lock_tournament_schedule(tournament_id)
     relay = get_proam_relay(tournament)
 
     try:
@@ -243,9 +370,17 @@ def replace_competitor(tournament_id):
     competitor_type = request.form.get('competitor_type')  # 'pro' or 'college'
 
     try:
-        relay.replace_competitor(team_number, old_competitor_id, new_competitor_id, competitor_type)
+        relay.replace_competitor(
+            team_number,
+            old_competitor_id,
+            new_competitor_id,
+            competitor_type,
+            expected_digest=request.form.get('expected_relay_digest'),
+        )
         invalidate_tournament_caches(tournament_id)
         flash('Competitor replaced successfully', 'success')
+    except RelayStateConflict:
+        return _relay_conflict_response()
     except StaleDataError:
         db.session.rollback()
         flash(_STALE_DATA_FLASH, 'warning')
@@ -276,18 +411,30 @@ def relay_payouts(tournament_id):
         tournament=tournament,
         relay_event=relay_event,
         current_payouts=current_payouts,
+        expected_payout_digest=_relay_payout_state_digest(
+            tournament,
+            relay_event,
+        ),
     )
 
 
 @bp.route('/payouts', methods=['POST'])
+@serialize_sqlite_schedule_writer
 def save_relay_payouts(tournament_id):
     """Save per-team lump sum payout amounts."""
-    db.get_or_404(Tournament, tournament_id)
+    tournament = lock_tournament_schedule(tournament_id)
     relay_event = Event.query.filter_by(
         tournament_id=tournament_id, name='Pro-Am Relay'
-    ).first()
+    ).populate_existing().with_for_update().first()
     if relay_event is None:
         abort(404)
+    expected_digest = request.form.get('expected_payout_digest', '').strip()
+    current_digest = _relay_payout_state_digest(tournament, relay_event)
+    if not expected_digest or not hmac.compare_digest(
+        expected_digest,
+        current_digest,
+    ):
+        return _relay_payout_conflict_response()
 
     payouts = {}
     for i in range(1, 9):
@@ -297,6 +444,7 @@ def save_relay_payouts(tournament_id):
                 amount = max(0.0, float(raw))
                 payouts[str(i)] = amount
             except (TypeError, ValueError):
+                db.session.rollback()
                 flash(f'Invalid payout amount for position {i}: {raw!r}', 'error')
                 return redirect(url_for('proam_relay.relay_payouts',
                                         tournament_id=tournament_id))

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -36,17 +36,19 @@ from services.report_cache import get as cache_get
 from services.report_cache import set as cache_set
 from services.reporting_backup import sqlite_backup_download_plan, submit_database_backup_job
 from services.reporting_export import (
+    ExportArtifactError,
     build_chopping_export,
     build_chopping_json_payload,
     build_results_export,
     build_video_judge_export,
+    open_verified_export,
     resolve_completed_export_path,
     safe_download_name,
     submit_results_export_job,
     submit_video_judge_export_job,
 )
-from services.restore_workflow import prepare_sqlite_restore
 from services.restore_workflow import sqlite_schema_info as _restore_schema_info
+from services.restore_workflow import stage_sqlite_restore
 
 reporting_bp = Blueprint('reporting', __name__)
 
@@ -434,7 +436,10 @@ def export_results_job_status(tournament_id, job_id):
     job_kind = (job_meta or {}).get('kind') or ''
 
     if job['status'] != 'completed':
-        if job['status'] == 'failed':
+        if job['status'] == 'expired':
+            flash(f"Export expired: {job.get('error', 'Artifact unavailable')}", 'error')
+            return redirect(url_for('main.tournament_detail', tournament_id=tournament_id))
+        if job['status'] in {'failed', 'interrupted'}:
             flash(f"Export job failed: {job.get('error', 'Unknown error')}", 'error')
             if job_kind == 'build_pro_flights':
                 return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
@@ -464,18 +469,11 @@ def export_results_job_status(tournament_id, job_id):
         flash_spillover_result(result.get('spillover'), include_success=False)
         return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
 
-    path = job.get('result')
-    if not path or not os.path.exists(path):
-        flash('Export file is no longer available.', 'error')
+    try:
+        artifact_handle = open_verified_export(job)
+    except ExportArtifactError as exc:
+        flash(f'Export expired: {exc}', 'error')
         return redirect(url_for('main.tournament_detail', tournament_id=tournament_id))
-
-    @after_this_request
-    def cleanup_file(response):
-        try:
-            os.remove(path)
-        except OSError:
-            pass
-        return response
 
     # Download-name suffix depends on the kind of export the job produced.
     # Defaults to 'results.xlsx' for the original all-results job; other
@@ -486,7 +484,13 @@ def export_results_job_status(tournament_id, job_id):
     download_name = safe_download_name(
         tournament, suffix_by_kind.get(job_kind, 'results.xlsx')
     )
-    return send_file(path, as_attachment=True, download_name=download_name)
+    response = send_file(
+        artifact_handle,
+        as_attachment=True,
+        download_name=download_name,
+    )
+    response.call_on_close(artifact_handle.close)
+    return response
 
 
 @reporting_bp.route('/<int:tournament_id>/export-video-judge')
@@ -551,14 +555,29 @@ def backup_database(tournament_id):
         return redirect(url_for('main.tournament_detail', tournament_id=tournament_id))
 
     db_path = backup_plan['path']
-    log_action('database_backup_downloaded', 'tournament', tournament_id, {'path': db_path})
+    log_action('database_backup_downloaded', 'tournament', tournament_id, {
+        'sha256': backup_plan['sha256'],
+        'size_bytes': backup_plan['size_bytes'],
+    })
     db.session.commit()
-    return send_file(db_path, as_attachment=True, download_name=f'proam_backup_{tournament_id}.db')
+    response = send_file(
+        db_path,
+        as_attachment=True,
+        download_name=f'proam_backup_{tournament_id}.db',
+    )
+    if backup_plan.get('cleanup'):
+        def cleanup_backup_snapshot():
+            try:
+                os.remove(db_path)
+            except OSError:
+                pass
+        response.call_on_close(cleanup_backup_snapshot)
+    return response
 
 
 @reporting_bp.route('/<int:tournament_id>/restore', methods=['POST'])
 def restore_database(tournament_id):
-    """Restore SQLite database from an uploaded backup file."""
+    """Validate and stage a SQLite backup for offline maintenance."""
     db.get_or_404(Tournament, tournament_id)
     if not current_user.is_authenticated or not current_user.is_admin:
         abort(403)
@@ -588,20 +607,26 @@ def restore_database(tournament_id):
     f.save(temp_path)
 
     try:
-        restore_plan = prepare_sqlite_restore(
+        restore_plan = stage_sqlite_restore(
             upload_path=temp_path,
             db_uri=uri,
             instance_path=current_app.instance_path,
+            tournament_id=tournament_id,
+            actor=f'user:{current_user.id}',
+            source_filename=f.filename,
             malware_scan_enabled=bool(current_app.config.get('ENABLE_UPLOAD_MALWARE_SCAN', False)),
             malware_scan_command=current_app.config.get('MALWARE_SCAN_COMMAND', ''),
         )
-        db_path = restore_plan['target_path']
-        db.session.remove()
-        db.engine.dispose()
-        os.replace(temp_path, db_path)
-        log_action('database_restored', 'tournament', tournament_id, {'target_path': db_path})
+        log_action('database_restore_staged', 'tournament', tournament_id, {
+            'stage_id': restore_plan['stage_id'],
+            'source_sha256': restore_plan['source_sha256'],
+        })
         db.session.commit()
-        flash('Database restore complete.', 'success')
+        flash(
+            'Backup validated and staged for offline maintenance. '
+            f"Staging ID: {restore_plan['stage_id']}.",
+            'success',
+        )
     except Exception as exc:
         db.session.rollback()
         log_action('database_restore_failed', 'tournament', tournament_id, {
@@ -997,3 +1022,4 @@ def _send_ala_email(pdf_path, tournament, report):
     )
     if result.status != 'sent':
         raise RuntimeError(result.error or 'Email send failed.')
+    open_verified_export,

--- a/routes/scheduling/birling.py
+++ b/routes/scheduling/birling.py
@@ -55,6 +55,21 @@ def _handle_projection_refusal(exc):
     )
 
 
+def _birling_fall_conflict_response(exc, tournament_id, event_id):
+    """Return a retryable conflict without losing the no-JS reload path."""
+    db.session.rollback()
+    flash(str(exc), 'warning')
+    response = redirect(url_for(
+        'scheduling.birling_manage',
+        tournament_id=tournament_id,
+        event_id=event_id,
+    ))
+    response.status_code = 409
+    response.headers['X-Retryable'] = 'true'
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
 def _college_birling_event_or_404(tournament_id: int, event_id: int) -> Event:
     """Load the college-only bracket event authorized by the tournament rule."""
     event = db.get_or_404(Event, event_id)
@@ -144,7 +159,12 @@ def birling_manage(tournament_id, event_id):
     comp_lookup = {str(c['id']): c['name'] for c in bracket_data.get('competitors', [])}
 
     # Get current playable matches
-    current_matches = bb.get_current_matches() if has_bracket else []
+    current_matches = [
+        dict(match)
+        for match in (bb.get_current_matches() if has_bracket else [])
+    ]
+    for match in current_matches:
+        match['fall_digest'] = bb.match_fall_digest(match['match_id'])
     placements = bracket_data.get('placements', {})
 
     # Check if bracket is complete
@@ -153,6 +173,10 @@ def birling_manage(tournament_id, event_id):
 
     # Compute which decided matches can be undone (no downstream play)
     undoable_match_ids = bb.get_undoable_matches() if has_bracket else set()
+    undo_match_digests = {
+        match_id: bb.match_fall_digest(match_id)
+        for match_id in undoable_match_ids
+    }
 
     return render_template(
         'scheduling/birling_manage.html',
@@ -167,6 +191,8 @@ def birling_manage(tournament_id, event_id):
         is_complete=is_complete,
         total_competitors=total_competitors,
         undoable_match_ids=undoable_match_ids,
+        undo_match_digests=undo_match_digests,
+        bracket_state_digest=bb.bracket_state_digest() if has_bracket else '',
     )
 
 
@@ -294,11 +320,22 @@ def birling_record_match(tournament_id, event_id):
         return redirect(url_for('scheduling.birling_manage',
                                 tournament_id=tournament_id, event_id=event_id))
 
-    from services.birling_bracket import BirlingBracket
+    from services.birling_bracket import BirlingBracket, BirlingFallConflict
     bb = BirlingBracket(event)
+    expected_fall_digest = request.form.get('expected_fall_digest')
 
     try:
-        bb.record_match_result(match_id, winner_id)
+        bb.record_direct_winner(
+            match_id,
+            winner_id,
+            expected_fall_digest=expected_fall_digest,
+        )
+    except BirlingFallConflict as exc:
+        return _birling_fall_conflict_response(
+            exc,
+            tournament_id,
+            event_id,
+        )
     except birling_rows.ProjectionRefused as exc:
         _handle_projection_refusal(exc)
         return redirect(url_for('scheduling.birling_manage',
@@ -350,11 +387,30 @@ def birling_record_fall(tournament_id, event_id):
         return redirect(url_for('scheduling.birling_manage',
                                 tournament_id=tournament_id, event_id=event_id))
 
-    from services.birling_bracket import BirlingBracket
+    from services.birling_bracket import BirlingBracket, BirlingFallConflict
     bb = BirlingBracket(event)
 
+    expected_fall_digest = request.form.get('expected_fall_digest')
+    if not expected_fall_digest:
+        return _birling_fall_conflict_response(
+            'Birling fall state changed since this page was loaded. '
+            'Refresh the bracket before recording another physical fall.',
+            tournament_id,
+            event_id,
+        )
+
     try:
-        result = bb.record_fall(match_id, fall_winner_id)
+        result = bb.record_fall(
+            match_id,
+            fall_winner_id,
+            expected_fall_digest=expected_fall_digest,
+        )
+    except BirlingFallConflict as exc:
+        return _birling_fall_conflict_response(
+            exc,
+            tournament_id,
+            event_id,
+        )
     except birling_rows.ProjectionRefused as exc:
         _handle_projection_refusal(exc)
         return redirect(url_for('scheduling.birling_manage',
@@ -419,7 +475,7 @@ def birling_undo_match(tournament_id, event_id):
         return redirect(url_for('scheduling.birling_manage',
                                 tournament_id=tournament_id, event_id=event_id))
 
-    from services.birling_bracket import BirlingBracket
+    from services.birling_bracket import BirlingBracket, BirlingStateConflict
     bb = BirlingBracket(event)
 
     # Capture previous state for audit log
@@ -428,7 +484,16 @@ def birling_undo_match(tournament_id, event_id):
     prev_loser = match['loser'] if match else None
 
     try:
-        result = bb.undo_match_result(match_id)
+        result = bb.undo_match_result(
+            match_id,
+            expected_undo_digest=request.form.get('expected_undo_digest'),
+        )
+    except BirlingStateConflict as exc:
+        return _birling_fall_conflict_response(
+            exc,
+            tournament_id,
+            event_id,
+        )
     except birling_rows.ProjectionRefused as exc:
         _handle_projection_refusal(exc)
         return redirect(url_for('scheduling.birling_manage',
@@ -474,10 +539,19 @@ def birling_reset(tournament_id, event_id):
         return redirect(url_for('scheduling.birling_manage',
                                 tournament_id=tournament_id, event_id=event_id))
 
-    # Payouts are independent configuration. Resetting a bracket must not
-    # discard the event's prize schedule.
-    birling_rows.clear_event(event.id)
-    db.session.commit()
+    from services.birling_bracket import BirlingBracket, BirlingStateConflict
+    bb = BirlingBracket(event)
+
+    try:
+        # Payouts are independent configuration. Resetting a bracket must not
+        # discard the event's prize schedule.
+        bb.reset_bracket(request.form.get('expected_bracket_digest'))
+    except BirlingStateConflict as exc:
+        return _birling_fall_conflict_response(
+            exc,
+            tournament_id,
+            event_id,
+        )
 
     log_action('birling_bracket_reset', 'event', event_id, {
         'event_name': event.display_name,

--- a/routes/scheduling/flights.py
+++ b/routes/scheduling/flights.py
@@ -2,6 +2,10 @@
 Flight management routes: flight_list, build_flights, start_flight, complete_flight,
 reorder_flight_heats, and the SMS notification helper.
 """
+import hashlib
+import hmac
+import json
+
 from flask import abort, flash, jsonify, redirect, render_template, request, session, url_for
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import StaleDataError
@@ -47,6 +51,45 @@ from services.schedule_generation import (
 
 from . import _build_pro_flights_if_possible, scheduling_bp
 from .spillover_feedback import flash_spillover_result, spillover_result_payload
+
+
+def flight_order_digest(flight_or_id) -> str:
+    """Digest one flight's heat membership and order."""
+    flight_id = int(getattr(flight_or_id, 'id', flight_or_id))
+    order = [
+        {'heat_id': heat.id, 'position': heat.flight_position}
+        for heat in Heat.query.filter_by(flight_id=flight_id).order_by(
+            Heat.flight_position,
+            Heat.id,
+        ).all()
+    ]
+    encoded = json.dumps(
+        {'flight_id': flight_id, 'order': order},
+        sort_keys=True,
+        separators=(',', ':'),
+    ).encode('ascii')
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _flight_order_digests(flight_ids) -> dict[str, str]:
+    """Return JSON-ready post-commit digests for affected flights."""
+    return {
+        str(flight_id): flight_order_digest(flight_id)
+        for flight_id in flight_ids
+    }
+
+
+def _flight_order_matches_expected(
+    flight: Flight,
+    expected_digest: str | None,
+    expected_heat_ids: list[int] | None,
+) -> bool:
+    if expected_digest:
+        return hmac.compare_digest(expected_digest, flight_order_digest(flight))
+    if expected_heat_ids is not None:
+        current_ids = [heat.id for heat in flight.get_heats_ordered()]
+        return current_ids == expected_heat_ids
+    return False
 
 
 def _discard_success_flashes_since(checkpoint: int) -> None:
@@ -162,7 +205,11 @@ def flight_list(tournament_id):
                     for cid in comp_ids
                 ],
             })
-        flight_data.append({'flight': flight, 'heats': heat_rows})
+        flight_data.append({
+            'flight': flight,
+            'heats': heat_rows,
+            'order_digest': flight_order_digest(flight),
+        })
 
     return render_template('pro/flights.html',
                            tournament=tournament,
@@ -622,6 +669,18 @@ def _flight_order_conflict_response():
     }), 409
 
 
+def _stale_flight_order_response():
+    db.session.rollback()
+    return jsonify({
+        'ok': False,
+        'code': 'stale_flight_order',
+        'error': (
+            'Flight order changed since this page was loaded. '
+            'Refresh and apply the move to the current order.'
+        ),
+    }), 409
+
+
 def _reject_started_flight_mutation(flights: list[Flight]):
     """Freeze manual running-order and roster edits once any flight starts."""
     active = [flight for flight in flights if flight.status != 'pending']
@@ -669,8 +728,22 @@ def reorder_flight_heats(tournament_id, flight_id):
     try:
         data = request.get_json(force=True)
         heat_ids = [int(hid) for hid in data.get('heat_ids', [])]
+        expected_digest = data.get('expected_digest')
+        raw_expected_heat_ids = data.get('expected_heat_ids')
+        expected_heat_ids = (
+            [int(hid) for hid in raw_expected_heat_ids]
+            if raw_expected_heat_ids is not None
+            else None
+        )
     except (TypeError, ValueError, AttributeError):
         return jsonify({'ok': False, 'error': 'Invalid heat_ids'}), 400
+
+    if not _flight_order_matches_expected(
+        flight,
+        expected_digest,
+        expected_heat_ids,
+    ):
+        return _stale_flight_order_response()
 
     existing = {h.id: h for h in flight.get_heats_ordered()}
     if len(heat_ids) != len(existing) or set(heat_ids) != set(existing.keys()):
@@ -712,7 +785,10 @@ def reorder_flight_heats(tournament_id, flight_id):
     from services.saw_block_assignment import trigger_saw_block_recompute
     trigger_saw_block_recompute(tournament)
 
-    return jsonify({'ok': True})
+    return jsonify({
+        'ok': True,
+        'order_digests': _flight_order_digests([flight_id]),
+    })
 
 
 @scheduling_bp.route('/<int:tournament_id>/flights/bulk-reorder', methods=['POST'])
@@ -733,10 +809,20 @@ def bulk_reorder_flights(tournament_id):
         data = request.get_json(force=True)
         entries = data.get('flights', [])
         payload: list[tuple[int, list[int]]] = []
+        expected_states = {}
         for entry in entries:
             fid = int(entry['flight_id'])
             hids = [int(h) for h in entry.get('heat_ids', [])]
             payload.append((fid, hids))
+            raw_expected_heat_ids = entry.get('expected_heat_ids')
+            expected_states[fid] = (
+                entry.get('expected_digest'),
+                (
+                    [int(hid) for hid in raw_expected_heat_ids]
+                    if raw_expected_heat_ids is not None
+                    else None
+                ),
+            )
     except (TypeError, ValueError, KeyError, AttributeError):
         return jsonify({'ok': False, 'error': 'Invalid payload'}), 400
 
@@ -760,6 +846,14 @@ def bulk_reorder_flights(tournament_id):
     flights = [flights_by_id[fid] for fid in flight_ids if fid in flights_by_id]
     if len(flights) != len(flight_ids):
         return jsonify({'ok': False, 'error': 'Unknown flight id'}), 400
+    for flight in flights:
+        expected_digest, expected_heat_ids = expected_states[flight.id]
+        if not _flight_order_matches_expected(
+            flight,
+            expected_digest,
+            expected_heat_ids,
+        ):
+            return _stale_flight_order_response()
 
     # Heat set check: every heat currently in these flights must still be
     # present in the payload. Prevents a half-loaded DOM from dropping heats.
@@ -819,7 +913,10 @@ def bulk_reorder_flights(tournament_id):
     from services.saw_block_assignment import trigger_saw_block_recompute
     trigger_saw_block_recompute(tournament)
 
-    return jsonify({'ok': True})
+    return jsonify({
+        'ok': True,
+        'order_digests': _flight_order_digests(flight_ids),
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -1102,6 +1199,12 @@ def start_flight(tournament_id, flight_id):
     lock_tournament_schedule(tournament)
     flight = Flight.query.filter_by(id=flight_id, tournament_id=tournament_id).first_or_404()
 
+    if flight.status == 'completed':
+        flash(
+            f'Flight {flight.flight_number} is completed and cannot be restarted.',
+            'warning',
+        )
+        return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
     if flight.status == 'in_progress':
         flash(f'Flight {flight.flight_number} is already in progress.', 'warning')
         return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
@@ -1127,6 +1230,15 @@ def complete_flight(tournament_id, flight_id):
     tournament = db.get_or_404(Tournament, tournament_id)
     lock_tournament_schedule(tournament)
     flight = Flight.query.filter_by(id=flight_id, tournament_id=tournament_id).first_or_404()
+    if flight.status == 'pending':
+        flash(
+            f'Flight {flight.flight_number} must be started before it can be completed.',
+            'warning',
+        )
+        return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
+    if flight.status == 'completed':
+        flash(f'Flight {flight.flight_number} is already completed.', 'warning')
+        return redirect(url_for('scheduling.flight_list', tournament_id=tournament_id))
     flight.status = 'completed'
     log_action('flight_completed', 'flight', flight_id, {'tournament_id': tournament_id})
     db.session.commit()

--- a/routes/scheduling/partners.py
+++ b/routes/scheduling/partners.py
@@ -6,8 +6,10 @@ Routes:
   POST /<tid>/events/<eid>/reassign-partner  — assign new partner
 """
 
+import hmac
 import json
 import logging
+from functools import wraps
 
 from flask import abort, flash, redirect, render_template, request, url_for
 
@@ -15,9 +17,14 @@ from database import db
 from models.competitor import CollegeCompetitor, ProCompetitor
 from models.event import Event, EventResult
 from services.audit import log_action
+from services.flight_builder import (
+    lock_tournament_schedule,
+    sqlite_schedule_writer_guard,
+)
 from services.partner_matching import (
     get_partner_repair_cases,
     get_unclaimed_partner_candidates,
+    partner_claim_digest,
 )
 from services.partner_matching import (
     set_partner_bidirectional as _set_partner_bidirectional,
@@ -26,6 +33,52 @@ from services.partner_matching import (
 from . import _competitor_entered_event, scheduling_bp
 
 logger = logging.getLogger(__name__)
+
+_PARTNER_CLAIM_CONFLICT = (
+    'Partner claims changed since this page was loaded. '
+    'Refresh the queue and review the current declarations.'
+)
+
+
+def _decode_partner_claim(raw_claim):
+    """Decode a no-JS option value containing candidate ID and state digest."""
+    if not raw_claim or ':' not in raw_claim:
+        return None
+    candidate_id, expected_digest = raw_claim.split(':', 1)
+    try:
+        candidate_id = int(candidate_id)
+    except (TypeError, ValueError):
+        return None
+    if candidate_id < 1 or not expected_digest.strip():
+        return None
+    return candidate_id, expected_digest.strip()
+
+
+def _partner_conflict_response():
+    db.session.rollback()
+    return _PARTNER_CLAIM_CONFLICT, 409
+
+
+def _require_partner_claim_digest(func):
+    """Reject tokenless reassignment requests before taking the writer lock."""
+    @wraps(func)
+    def guarded(*args, **kwargs):
+        expected_digest = request.form.get('expected_claim_digest', '').strip()
+        encoded_claim = _decode_partner_claim(request.form.get('partner_claim'))
+        if not expected_digest and encoded_claim is None:
+            return _partner_conflict_response()
+        return func(*args, **kwargs)
+
+    return guarded
+
+
+def _partner_writer(func):
+    @wraps(func)
+    def locked(tid, *args, **kwargs):
+        with sqlite_schedule_writer_guard(tid):
+            return func(tid, *args, **kwargs)
+
+    return locked
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +300,16 @@ def partner_queue(tid, eid):
     available = get_unclaimed_partner_candidates(
         event, {case['competitor'].id for case in repairs}
     )
+    claim_digests = {}
+    for repair in repairs:
+        candidates = list(available)
+        suggested = repair.get('suggested_partner')
+        if suggested is not None and all(row.id != suggested.id for row in candidates):
+            candidates.append(suggested)
+        for candidate in candidates:
+            claim_digests[(repair['competitor'].id, candidate.id)] = (
+                partner_claim_digest(event, repair['competitor'], candidate)
+            )
 
     return render_template(
         "scheduling/partner_queue.html",
@@ -254,20 +317,29 @@ def partner_queue(tid, eid):
         event=event,
         repairs=repairs,
         available=available,
+        claim_digests=claim_digests,
         partner_repairs_locked=_partner_repair_is_locked(event),
     )
 
 
 @scheduling_bp.route("/<int:tid>/events/<int:eid>/reassign-partner", methods=["POST"])
+@_require_partner_claim_digest
+@_partner_writer
 def reassign_partner(tid, eid):
     """POST: Assign a new partner to an orphaned competitor."""
+    lock_tournament_schedule(tid)
     event = db.get_or_404(Event, eid)
     if event.tournament_id != tid:
         abort(404)
 
     orphan_id = request.form.get("orphan_id", type=int)
     orphan_type = request.form.get("orphan_type", "pro")
-    new_partner_id = request.form.get("new_partner_id", type=int)
+    encoded_claim = _decode_partner_claim(request.form.get('partner_claim'))
+    if encoded_claim is not None:
+        new_partner_id, expected_claim_digest = encoded_claim
+    else:
+        new_partner_id = request.form.get("new_partner_id", type=int)
+        expected_claim_digest = request.form.get('expected_claim_digest', '').strip()
     new_partner_type = request.form.get("new_partner_type", "pro")
 
     if not orphan_id or not new_partner_id:
@@ -284,6 +356,13 @@ def reassign_partner(tid, eid):
     if not orphan or not new_partner:
         flash("Competitor not found.", "error")
         return redirect(url_for("scheduling.partner_queue", tid=tid, eid=eid))
+
+    current_claim_digest = partner_claim_digest(event, orphan, new_partner)
+    if not hmac.compare_digest(
+        expected_claim_digest,
+        current_claim_digest,
+    ):
+        return _partner_conflict_response()
 
     # Check pairing compatibility before the current-roster error so an
     # operator gets the specific correction for a visibly invalid selection.
@@ -321,7 +400,6 @@ def reassign_partner(tid, eid):
     # Apply bidirectional update
     previous_partner_name = orphan.get_partners().get(str(event.id))
     set_partner_bidirectional(orphan, new_partner, event)
-    db.session.commit()
     log_action(
         "partner_reassigned",
         "event",
@@ -336,7 +414,9 @@ def reassign_partner(tid, eid):
             "new_partner_id": new_partner.id,
             "new_partner_type": new_partner_type,
         },
+        use_request_transaction=True,
     )
+    db.session.commit()
 
     flash(f"Reassigned {orphan.name} with new partner {new_partner.name}.", "success")
     logger.info(

--- a/routes/scoring.py
+++ b/routes/scoring.py
@@ -5,8 +5,12 @@ undo, throw-off resolution, bulk CSV import, payout templates, and next-event na
 from __future__ import annotations
 
 import csv
+import hashlib
 import io
-from datetime import datetime, timezone
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 from flask import (
     Blueprint,
@@ -14,6 +18,7 @@ from flask import (
     abort,
     current_app,
     flash,
+    g,
     jsonify,
     redirect,
     render_template,
@@ -23,6 +28,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user, login_required
+from flask_wtf.csrf import CSRFError
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import StaleDataError
 
@@ -45,10 +51,31 @@ from services.scoring_workflow import (
     competitor_lookup_for_event,
     existing_results_for_event,
     finalize_event_results,
+    heat_scoring_state_digest,
+    heat_submission_identity,
+    revoke_heat_submission_receipts_for_undo,
     save_heat_results_submission,
 )
 
 scoring_bp = Blueprint('scoring', __name__)
+
+_OFFLINE_PACKAGE_SCHEMA_VERSION = 2
+_OFFLINE_QUEUE_MAX_AGE = timedelta(days=30)
+_OFFLINE_ASSET_FILENAMES = (
+    'vendor/bootstrap/css/bootstrap.min.css',
+    'vendor/bootstrap-icons/font/bootstrap-icons.min.css',
+    'vendor/bootstrap-icons/font/fonts/bootstrap-icons.woff2?2820a3852bdb9a5832199cc61cec4e65',
+    'vendor/bootstrap-icons/font/fonts/bootstrap-icons.woff?2820a3852bdb9a5832199cc61cec4e65',
+    'vendor/bootstrap/js/bootstrap.bundle.min.js',
+    'css/theme.css',
+    'img/favicon.svg',
+    'img/flag_of_arapaho_nation.svg',
+    'img/missoula-pro-am-logo.png',
+    'offline_queue.js',
+    'js/offline_queue_shared.js',
+    'js/onboarding.js',
+    'js/csp_handlers.js',
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,7 +96,35 @@ def _heat_for_tournament_or_404(tournament_id: int, heat_id: int) -> Heat:
 
 
 def _is_async() -> bool:
-    return request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+    return (
+        request.headers.get('X-Requested-With') == 'XMLHttpRequest'
+        or request.accept_mimetypes.best_match(
+            ['application/json', 'text/html']
+        ) == 'application/json'
+    )
+
+
+def _json_error(code: str, message: str, status_code: int, **extra):
+    payload = {
+        'ok': False,
+        'category': 'error',
+        'message': message,
+        'error': {'code': code, 'message': message},
+    }
+    payload.update(extra)
+    return jsonify(payload), status_code
+
+
+@scoring_bp.errorhandler(CSRFError)
+def _scoring_csrf_error(_error):
+    if _is_async():
+        return _json_error(
+            'csrf_expired',
+            'The score form security token expired.',
+            400,
+        )
+    flash('Your session expired for security. Please try that action again.', 'warning')
+    return redirect(request.referrer or request.path or '/')
 
 
 def _current_user_id() -> int | None:
@@ -77,6 +132,153 @@ def _current_user_id() -> int | None:
     if current_user and current_user.is_authenticated:
         return current_user.id
     return None
+
+
+def _current_user_can_score_tournament(tournament_id: int) -> bool:
+    if not current_user.is_authenticated or not getattr(current_user, 'can_score', False):
+        return False
+    user_tournament_id = getattr(current_user, 'tournament_id', None)
+    return user_tournament_id is None or int(user_tournament_id) == int(tournament_id)
+
+
+def _offline_build_id() -> str:
+    configured = str(current_app.config.get('OFFLINE_BUILD_ID') or '').strip()
+    if configured:
+        return configured
+    for key in ('RAILWAY_GIT_COMMIT_SHA', 'GIT_COMMIT_SHA', 'SOURCE_VERSION'):
+        value = os.environ.get(key, '').strip()
+        if value:
+            return value
+
+    hasher = hashlib.sha256()
+    for relative in (
+        'app.py',
+        'routes/scoring.py',
+        'services/scoring_workflow.py',
+        'templates/scoring/enter_heat.html',
+        'static/sw.js',
+        'static/offline_queue.js',
+        'static/js/offline_queue_shared.js',
+    ):
+        try:
+            with open(os.path.join(current_app.root_path, relative), 'rb') as source:
+                hasher.update(source.read())
+        except OSError:
+            hasher.update(relative.encode('utf-8'))
+    return hasher.hexdigest()[:20]
+
+
+def _offline_schedule_snapshot(tournament_id: int) -> tuple[str, list[Heat]]:
+    heats = (
+        Heat.query.join(Event, Heat.event_id == Event.id)
+        .filter(Event.tournament_id == tournament_id)
+        .order_by(
+            Event.id,
+            Heat.heat_number,
+            Heat.run_number,
+            Heat.id,
+        )
+        .all()
+    )
+    schedule = [
+        {
+            'event_id': heat.event_id,
+            'heat_id': heat.id,
+            'identity': heat_submission_identity(heat),
+            'version': heat.version_id,
+        }
+        for heat in heats
+    ]
+    encoded = json.dumps(
+        schedule,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(encoded.encode('utf-8')).hexdigest(), heats
+
+
+def _static_content_sha256(filename: str) -> str:
+    path = os.path.join(current_app.static_folder, filename)
+    hasher = hashlib.sha256()
+    with open(path, 'rb') as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b''):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _offline_context(tournament_id: int, schedule_fingerprint: str) -> dict:
+    return {
+        'schema_version': _OFFLINE_PACKAGE_SCHEMA_VERSION,
+        'application_build': _offline_build_id(),
+        'schedule_fingerprint': schedule_fingerprint,
+        'tournament_id': tournament_id,
+        'issuer_user_id': current_user.id,
+        'issuer_role': current_user.role,
+    }
+
+
+def _offline_final_html_sha256(response: Response) -> str:
+    """Hash the bytes produced by the app's deterministic HTML post-processing."""
+    body = response.get_data(as_text=True)
+    active_lang = text.get_language()
+    if active_lang != text.DEFAULT_LANGUAGE and active_lang in text.TRANSLATIONS:
+        body = text.translate_html(body, lang=active_lang)
+    nonce = getattr(g, 'csp_nonce', None)
+    if nonce:
+        # Imported lazily to avoid a route-registration cycle during app startup.
+        from app import _inject_csp_nonce
+
+        body = _inject_csp_nonce(body, nonce)
+    return hashlib.sha256(body.encode('utf-8')).hexdigest()
+
+
+def _offline_manifest(tournament_id: int) -> tuple[dict, dict]:
+    schedule_fingerprint, heats = _offline_schedule_snapshot(tournament_id)
+    context = _offline_context(tournament_id, schedule_fingerprint)
+    pages = []
+    for heat in heats:
+        page_url = url_for(
+            'scoring.enter_heat_results',
+            tournament_id=tournament_id,
+            heat_id=heat.id,
+        )
+        fetch_url = url_for(
+            'scoring.enter_heat_results',
+            tournament_id=tournament_id,
+            heat_id=heat.id,
+            offline_prepare=1,
+            prepared_schedule=schedule_fingerprint,
+        )
+        pages.append({
+            'kind': 'page',
+            'url': page_url,
+            'fetch_url': fetch_url,
+        })
+
+    assets = []
+    theme_version = str(int(os.path.getmtime(
+        os.path.join(current_app.root_path, 'static', 'css', 'theme.css')
+    )))
+    for filename in _OFFLINE_ASSET_FILENAMES:
+        clean_filename, separator, query = filename.partition('?')
+        asset_url = url_for('static', filename=clean_filename)
+        if separator:
+            asset_url = f'{asset_url}?{query}'
+        elif clean_filename == 'css/theme.css':
+            asset_url = f'{asset_url}?v={theme_version}'
+        assets.append({
+            'kind': 'asset',
+            'url': asset_url,
+            'content_sha256': _static_content_sha256(clean_filename),
+        })
+
+    manifest = dict(context)
+    manifest.update({
+        'pages': pages,
+        'assets': assets,
+    })
+    return manifest, context
 
 
 def _normalized_heat_competitor_ids(heat: Heat) -> list[int]:
@@ -499,6 +701,26 @@ def _save_heat_results_submission(tournament_id: int, heat: Heat, event: Event) 
 # Route-level shim: keep HTTP details here while the scoring workflow lives in
 # services.scoring_workflow for direct testing outside request handlers.
 def _save_heat_results_submission(tournament_id: int, heat: Heat, event: Event) -> dict:
+    posted_tournament_id = request.form.get('tournament_id', type=int)
+    posted_heat_id = request.form.get('heat_id', type=int)
+    posted_role = str(request.form.get('issuer_role') or '').strip()
+    if (
+        (posted_tournament_id is not None and posted_tournament_id != tournament_id)
+        or (posted_heat_id is not None and posted_heat_id != heat.id)
+        or (posted_role and posted_role != getattr(current_user, 'role', None))
+    ):
+        return {
+            'ok': False,
+            'category': 'error',
+            'message': 'This queued score is bound to another user role, tournament, or heat.',
+            'error_code': 'authorization_denied',
+            'redirect_url': url_for(
+                'scoring.enter_heat_results',
+                tournament_id=tournament_id,
+                heat_id=heat.id,
+            ),
+            'status_code': 403,
+        }
     outcome = save_heat_results_submission(
         tournament_id=tournament_id,
         heat=heat,
@@ -710,32 +932,39 @@ def finalize_event(tournament_id, event_id):
 @login_required
 @write_limit('60 per minute')
 def enter_heat_results(tournament_id, heat_id):
+    if not _current_user_can_score_tournament(tournament_id):
+        if _is_async():
+            return _json_error(
+                'authorization_denied',
+                'Your current account cannot score this tournament.',
+                403,
+            )
+        abort(403)
     tournament = db.get_or_404(Tournament, tournament_id)
     heat = _heat_for_tournament_or_404(tournament_id, heat_id)
     event = heat.event
 
     if request.method == 'POST':
-        # Reject POST if the heat is locked by a different judge.  This is the server-side
-        # enforcement of the advisory lock shown on the GET form — a second tab or another
-        # device cannot overwrite results while someone else holds the lock.
-        user_id = _current_user_id()
-        if heat.is_locked() and heat.locked_by_user_id != (user_id or -1):
-            from models.user import User
-            locker = db.session.get(User, heat.locked_by_user_id)
-            owner = locker.username if locker else f'User #{heat.locked_by_user_id}'
-            msg = f'Heat is currently being edited by {owner}. Your submission was not saved.'
-            if _is_async():
-                return jsonify({'ok': False, 'category': 'warning', 'message': msg}), 423
-            flash(msg, 'warning')
-            return redirect(url_for('scoring.enter_heat_results',
-                                    tournament_id=tournament_id, heat_id=heat_id))
-
         outcome = _save_heat_results_submission(tournament_id=tournament_id,
                                                 heat=heat, event=event)
         if _is_async():
-            return jsonify({k: outcome[k] for k in
-                            ('ok', 'message', 'redirect_url', 'category',
-                             'undo_heat_id') if k in outcome}), outcome['status_code']
+            payload = {
+                k: outcome[k] for k in (
+                    'ok',
+                    'message',
+                    'redirect_url',
+                    'category',
+                    'undo_heat_id',
+                    'receipt',
+                    'receipt_replayed',
+                ) if k in outcome
+            }
+            if outcome.get('error_code'):
+                payload['error'] = {
+                    'code': outcome['error_code'],
+                    'message': outcome['message'],
+                }
+            return jsonify(payload), outcome['status_code']
         flash(outcome['message'], outcome['category'])
         redirect_url = outcome['redirect_url']
         if outcome.get('undo_heat_id'):
@@ -743,10 +972,19 @@ def enter_heat_results(tournament_id, heat_id):
         return redirect(redirect_url)
 
     # -- GET: acquire heat lock --
+    schedule_fingerprint, _schedule_heats = _offline_schedule_snapshot(tournament_id)
+    preparing_offline = request.args.get('offline_prepare') == '1'
+    if preparing_offline and request.args.get('prepared_schedule') != schedule_fingerprint:
+        return Response(
+            'Schedule changed while the offline package was being prepared.',
+            status=409,
+            mimetype='text/plain',
+        )
+
     user_id = _current_user_id()
     lock_owner = None
     lock_blocked = False
-    if user_id:
+    if user_id and not preparing_offline:
         if heat.is_locked() and heat.locked_by_user_id != user_id:
             lock_blocked = True
             from models.user import User
@@ -803,15 +1041,42 @@ def enter_heat_results(tournament_id, heat_id):
     next_heat_url = (url_for('scoring.enter_heat_results', tournament_id=tournament_id,
                              heat_id=next_heat.id) if next_heat else None)
 
-    return render_template('scoring/enter_heat.html',
-                           tournament=tournament, heat=heat, event=event,
-                           competitors=competitors, heat_version=heat.version_id,
-                           heat_identity=(
-                               heat.locked_at.isoformat(timespec='microseconds')
-                               if heat.locked_at is not None else ''
-                           ),
-                           next_heat_url=next_heat_url,
-                           lock_blocked=lock_blocked, lock_owner=lock_owner)
+    offline_context = _offline_context(tournament_id, schedule_fingerprint)
+    rendered = render_template(
+        'scoring/enter_heat.html',
+        tournament=tournament,
+        heat=heat,
+        event=event,
+        competitors=competitors,
+        heat_version=heat.version_id,
+        score_request_id=str(uuid4()),
+        heat_identity=heat_submission_identity(heat),
+        scoring_state_digest=heat_scoring_state_digest(
+            heat, event, result_lookup.values()
+        ),
+        offline_context=offline_context,
+        next_heat_url=next_heat_url,
+        lock_blocked=lock_blocked,
+        lock_owner=lock_owner,
+    )
+    response = current_app.make_response(rendered)
+    if preparing_offline:
+        response.headers['Cache-Control'] = 'no-store'
+        response.headers['X-ProAm-Offline-Build'] = offline_context[
+            'application_build'
+        ]
+        response.headers['X-ProAm-Offline-Schedule'] = offline_context[
+            'schedule_fingerprint'
+        ]
+        response.headers['X-ProAm-Offline-Tournament'] = str(tournament_id)
+        response.headers['X-ProAm-Offline-Issuer'] = str(
+            offline_context['issuer_user_id']
+        )
+        response.headers['X-ProAm-Offline-Role'] = offline_context['issuer_role']
+        response.headers[
+            'X-ProAm-Offline-Content-SHA256'
+        ] = _offline_final_html_sha256(response)
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -968,6 +1233,12 @@ def undo_heat_save(tournament_id, heat_id):
             heat.status = 'pending'
             event.status = 'in_progress'
             event.is_finalized = False
+            revoke_heat_submission_receipts_for_undo(
+                tournament_id=tournament_id,
+                heat_id=heat.id,
+                event_id=event.id,
+                judge_user_id=_current_user_id(),
+            )
 
         db.session.commit()
     except Exception as exc:
@@ -983,8 +1254,6 @@ def undo_heat_save(tournament_id, heat_id):
 
     invalidate_tournament_caches(tournament_id)
     session.pop(f'undo_heat_{heat_id}', None)
-    log_action('heat_undo', 'heat', heat_id,
-               {'event_id': event.id, 'judge_user_id': _current_user_id()})
 
     if _is_async():
         return jsonify({'ok': True, 'message': 'Heat results reverted to pending.'})
@@ -1202,13 +1471,21 @@ def scratch_preview(tournament_id, competitor_id):
     "competitor_type": str, "effects": [CascadeEffect dicts]}.
     """
     comp, tournament = _load_competitor_for_tournament(tournament_id, competitor_id)
-    from services.scratch_cascade import compute_scratch_effects, find_undoable_scratch
+    from services.scratch_cascade import (
+        compute_scratch_effects,
+        find_undoable_scratch,
+        scratch_effect_digest,
+        scratch_undo_token,
+    )
     try:
         effects = compute_scratch_effects(comp, tournament)
     except ValueError:
         abort(403)
 
     comp_type = _competitor_type_of(comp)
+    effect_digest = scratch_effect_digest(comp, effects)
+    undo_entry = find_undoable_scratch(comp.id, comp_type)
+    undo_token = scratch_undo_token(undo_entry) if undo_entry is not None else None
 
     if not _scratch_preview_wants_json():
         # Resolve an explicit heat-board return target from its event id, never
@@ -1223,14 +1500,19 @@ def scratch_preview(tournament_id, competitor_id):
             competitor=comp,
             competitor_type=comp_type,
             effects=effects,
+            effect_digest=effect_digest,
             cancel_url=cancel_url,
             return_event_id=return_event_id,
-            undo_available=find_undoable_scratch(comp.id, comp_type) is not None,
+            undo_available=undo_token is not None,
+            undo_token=undo_token,
         )
 
     return jsonify({
         'competitor_name': comp.name,
         'competitor_type': comp_type,
+        'effect_digest': effect_digest,
+        'undo_available': undo_token is not None,
+        'undo_token': undo_token,
         'effects': [
             {
                 'effect_type': e.effect_type,
@@ -1268,6 +1550,7 @@ def scratch_confirm(tournament_id, competitor_id):
         ScratchCascadeConflict,
         compute_scratch_effects,
         execute_cascade,
+        scratch_effect_digest,
     )
 
     # Re-compute from fresh DB state so we can't be fed stale/forged IDs.
@@ -1275,6 +1558,24 @@ def scratch_confirm(tournament_id, competitor_id):
         fresh_effects = compute_scratch_effects(comp, tournament)
     except ValueError:
         abort(403)
+
+    expected_effect_digest = request.form.get('expected_effect_digest', '')
+    current_effect_digest = scratch_effect_digest(comp, fresh_effects)
+    if not expected_effect_digest or expected_effect_digest != current_effect_digest:
+        db.session.rollback()
+        message = (
+            'Scratch effects changed since you reviewed them. '
+            'Review the current effects and confirm again.'
+        )
+        if _is_async():
+            return jsonify({'ok': False, 'message': message}), 409
+        flash(message, 'warning')
+        return redirect(url_for(
+            'scoring.scratch_preview',
+            tournament_id=tournament_id,
+            competitor_id=competitor_id,
+            return_event_id=request.form.get('return_event_id'),
+        ))
 
     # Build a lookup of fresh effects keyed by (effect_type, affected_entity_id).
     fresh_lookup: dict[tuple, CascadeEffect] = {
@@ -1378,9 +1679,12 @@ def scratch_undo(tournament_id, competitor_id):
         result = reverse_cascade(
             comp.id, judge_id, tournament,
             competitor_type=_competitor_type_of(comp),
+            expected_undo_token=request.form.get('expected_undo_token'),
         )
         if result['success']:
             db.session.commit()
+        else:
+            db.session.rollback()
     except (StaleDataError, ScratchCascadeConflict):
         db.session.rollback()
         message = (
@@ -1396,11 +1700,19 @@ def scratch_undo(tournament_id, competitor_id):
             competitor_id=competitor_id,
         ))
 
-    if result['success']:
-        invalidate_tournament_caches(tournament_id)
-        flash(f'Scratch reversed for {comp.name}.', 'success')
-    else:
+    if not result['success']:
+        status_code = result.get('status_code', 409)
+        if _is_async():
+            return jsonify({'ok': False, 'message': result['message']}), status_code
         flash(result['message'], 'warning')
+        return redirect(url_for(
+            'scoring.scratch_preview',
+            tournament_id=tournament_id,
+            competitor_id=competitor_id,
+        ))
+
+    invalidate_tournament_caches(tournament_id)
+    flash(f'Scratch reversed for {comp.name}.', 'success')
 
     from models.competitor import CollegeCompetitor as _CC
     if isinstance(comp, _CC):
@@ -1419,11 +1731,17 @@ def scratch_undo(tournament_id, competitor_id):
 
 @scoring_bp.route('/<int:tournament_id>/offline-ops')
 def offline_ops(tournament_id):
+    if not _current_user_can_score_tournament(tournament_id):
+        abort(403)
     tournament = db.get_or_404(Tournament, tournament_id)
     events = tournament.events.order_by(Event.name).all()
     event_directory = {e.id: {'name': e.display_name, 'type': e.event_type} for e in events}
+    offline_manifest, offline_context = _offline_manifest(tournament_id)
     return render_template('scoring/offline_ops.html',
-                           tournament=tournament, event_directory=event_directory)
+                           tournament=tournament,
+                           event_directory=event_directory,
+                           offline_manifest=offline_manifest,
+                           offline_context=offline_context)
 
 
 # ---------------------------------------------------------------------------
@@ -1949,27 +2267,88 @@ def issue_replay_token():
     replay_offline_score endpoint when connectivity returns.
     """
     if not current_user.is_authenticated:
-        return jsonify({'ok': False, 'message': 'Login required.'}), 401
+        return _json_error('session_required', 'Login required.', 401)
     import hashlib
     import hmac as _hmac
     import time as _time
     secret = current_app.config.get('SECRET_KEY', '')
     if not secret:
-        return jsonify({'ok': False, 'message': 'Server not configured.'}), 500
+        return _json_error('server_error', 'Server not configured.', 500)
     ts = int(_time.time())
     msg = f'{current_user.id}:{ts}'.encode('utf-8')
     sig = _hmac.new(secret.encode('utf-8'), msg, hashlib.sha256).hexdigest()[:32]
-    return jsonify({'ok': True, 'replay_token': f'{ts}.{sig}'})
+    return jsonify({
+        'ok': True,
+        'replay_token': f'{ts}.{sig}',
+        'issuer_user_id': current_user.id,
+        'issuer_role': current_user.role,
+        'expires_at': (
+            datetime.fromtimestamp(ts, tz=timezone.utc).replace(microsecond=0)
+            + timedelta(days=7)
+        ).isoformat(),
+    })
 
 
 @scoring_bp.route('/api/replay', methods=['POST'])
 def replay_offline_score():
     """Accept an offline-queued score submission without CSRF validation."""
-    from app import csrf
-    # CSRF exemption is applied via decorator-free approach below
-
     if not current_user.is_authenticated:
-        return jsonify({'ok': False, 'message': 'Login required.'}), 401
+        return _json_error('session_required', 'Login required.', 401)
+
+    request_id = str(request.form.get('request_id') or '').strip()
+    if not request_id:
+        return _json_error(
+            'request_id_required',
+            'Queued score request ID is required.',
+            400,
+        )
+
+    issuer_user_id = request.form.get('issuer_user_id', type=int)
+    issuer_role = str(request.form.get('issuer_role') or '').strip()
+    if issuer_user_id is None or not issuer_role:
+        return _json_error(
+            'issuer_identity_required',
+            'Queued score issuer identity is required for automatic replay.',
+            409,
+        )
+    if (
+        issuer_user_id != current_user.id
+    ) or (
+        issuer_role != current_user.role
+    ):
+        return _json_error(
+            'authorization_denied',
+            'This queued score belongs to another user or role.',
+            403,
+        )
+
+    queued_at_raw = str(request.form.get('queued_at') or '').strip()
+    if queued_at_raw:
+        try:
+            queued_at = datetime.fromisoformat(
+                queued_at_raw.replace('Z', '+00:00')
+            )
+            if queued_at.tzinfo is None:
+                queued_at = queued_at.replace(tzinfo=timezone.utc)
+            queued_age = datetime.now(timezone.utc) - queued_at.astimezone(timezone.utc)
+        except ValueError:
+            return _json_error(
+                'queued_at_invalid',
+                'Queued score timestamp is invalid.',
+                400,
+            )
+        if queued_age > _OFFLINE_QUEUE_MAX_AGE:
+            return _json_error(
+                'manual_reconciliation_required',
+                'This queued score is older than 30 days and cannot sync automatically.',
+                409,
+            )
+        if queued_age < timedelta(minutes=-5):
+            return _json_error(
+                'queued_at_invalid',
+                'Queued score timestamp is in the future.',
+                400,
+            )
 
     replay_token = request.form.get('replay_token', '').strip()
     # SECURITY (CSO #6): replay_token must be a real HMAC bound to (user_id, ts).
@@ -1978,7 +2357,11 @@ def replay_offline_score():
     # scorers. Token format: "{ts}.{hex_sig}" where sig is HMAC-SHA256 truncated
     # to 32 hex chars over f"{user_id}:{ts}" using SECRET_KEY.
     if not replay_token or '.' not in replay_token:
-        return jsonify({'ok': False, 'message': 'Missing or malformed replay token.'}), 403
+        return _json_error(
+            'replay_token_required',
+            'Missing or malformed replay token.',
+            403,
+        )
     import hashlib
     import hmac as _hmac
     import time as _time
@@ -1986,39 +2369,63 @@ def replay_offline_score():
         ts_str, sig = replay_token.split('.', 1)
         ts = int(ts_str)
     except (ValueError, TypeError):
-        return jsonify({'ok': False, 'message': 'Malformed replay token.'}), 403
+        return _json_error('replay_token_invalid', 'Malformed replay token.', 403)
     # Reject tokens older than 7 days (race weekend buffer + offline replay window)
     if _time.time() - ts > 7 * 24 * 60 * 60:
-        return jsonify({'ok': False, 'message': 'Replay token expired.'}), 403
+        return _json_error('replay_token_expired', 'Replay token expired.', 403)
     secret = current_app.config.get('SECRET_KEY', '')
     expected_msg = f'{current_user.id}:{ts}'.encode('utf-8')
     expected_sig = _hmac.new(secret.encode('utf-8'), expected_msg, hashlib.sha256).hexdigest()[:32]
     if not _hmac.compare_digest(sig, expected_sig):
-        return jsonify({'ok': False, 'message': 'Invalid replay token.'}), 403
+        return _json_error('authorization_denied', 'Invalid replay token.', 403)
 
     # Extract tournament_id and heat_id from the original URL stored in the body
     # The form body contains the same fields as the regular score entry form
     tournament_id = request.form.get('tournament_id', type=int)
     heat_id = request.form.get('heat_id', type=int)
     if not tournament_id or not heat_id:
-        return jsonify({'ok': False, 'message': 'Missing tournament or heat ID.'}), 400
+        return _json_error(
+            'binding_required',
+            'Missing tournament or heat ID.',
+            400,
+        )
+    if not _current_user_can_score_tournament(tournament_id):
+        return _json_error(
+            'authorization_denied',
+            'Your current account cannot score this tournament.',
+            403,
+        )
 
     tournament = db.session.get(Tournament, tournament_id)
     if not tournament:
-        return jsonify({'ok': False, 'message': 'Tournament not found.'}), 404
+        return _json_error('tournament_not_found', 'Tournament not found.', 404)
 
     heat = db.session.get(Heat, heat_id)
     if not heat or not heat.event or heat.event.tournament_id != tournament_id:
-        return jsonify({'ok': False, 'message': 'Heat not found.'}), 404
+        return _json_error('heat_not_found', 'Heat not found.', 404)
 
     event = heat.event
 
     outcome = _save_heat_results_submission(
         tournament_id=tournament_id, heat=heat, event=event
     )
-    return jsonify({
-        k: outcome[k] for k in ('ok', 'message', 'category') if k in outcome
-    }), outcome['status_code']
+    payload = {
+        key: outcome[key]
+        for key in (
+            'ok',
+            'message',
+            'category',
+            'receipt',
+            'receipt_replayed',
+        )
+        if key in outcome
+    }
+    if outcome.get('error_code'):
+        payload['error'] = {
+            'code': outcome['error_code'],
+            'message': outcome['message'],
+        }
+    return jsonify(payload), outcome['status_code']
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci_build_smoke_db.py
+++ b/scripts/ci_build_smoke_db.py
@@ -4,16 +4,16 @@ Why this exists
 ---------------
 `smoke_env` in tests/test_route_smoke.py has two branches:
 
-    use_real_db = SOURCE_DB.exists()          # instance/proam.db
-    if use_real_db:
+    use_source_db = SOURCE_DB is not None and SOURCE_DB.exists()
+    if use_source_db:
         shutil.copy2(SOURCE_DB, db_copy)      # cheap
     ...
-    if not use_real_db:
+    if not use_source_db:
         upgrade(directory=str(migrations_dir))  # <-- runs the WHOLE alembic
         _seed_minimal_smoke_data(app)           #     chain, per test
 
-`instance/` is gitignored, so on a fresh CI checkout the file is absent and
-CI takes the second branch for all 245 parametrized route tests. Replaying
+CI explicitly supplies the dedicated database built by this script. Without
+that source, all 245 parametrized route tests take the second branch. Replaying
 the full migration chain 245 times inside one process leaks roughly
 17 MB per test on top of the ~3.3 MB per test that `create_app()` costs on
 its own. Measured stair, same machine, same suite:

--- a/scripts/verify_strathmark_shadow_contract.py
+++ b/scripts/verify_strathmark_shadow_contract.py
@@ -483,6 +483,12 @@ def _verify_isolated(*, root: Path, empty_cwd: Path) -> dict[str, Any]:
         with missoula_app.app_context():
             db.session.remove()
             db.engine.dispose()
+        fence_finalizer = missoula_app.extensions.pop(
+            "sqlite_process_fence_finalizer", None
+        )
+        if fence_finalizer is not None:
+            fence_finalizer()
+        missoula_app.extensions.pop("sqlite_process_fence", None)
 
     if calculate_payload is None or outcome_payload is None:
         raise AssertionError("Missoula release rehearsal did not build its request payloads")

--- a/services/audit.py
+++ b/services/audit.py
@@ -34,7 +34,14 @@ def _supports_independent_write() -> bool:
         return False
 
 
-def log_action(action: str, entity_type: str, entity_id: int | None = None, details: dict | None = None) -> None:
+def log_action(
+    action: str,
+    entity_type: str,
+    entity_id: int | None = None,
+    details: dict | None = None,
+    *,
+    use_request_transaction: bool = False,
+) -> None:
     """Append an audit log record on its own connection.
 
     Why this does not simply ``db.session.add()``, and why it does not simply
@@ -69,11 +76,12 @@ def log_action(action: str, entity_type: str, entity_id: int | None = None, deta
     at ``sqlite3.OperationalError: database is locked`` on the login audit row,
     and three more failed the same way inside the route's commit.
 
-    So on SQLite this function does exactly what it did before: add to the
-    caller's session and let the caller decide. That preserves the old
-    lost-attribution bug on SQLite and nowhere else. Production is PostgreSQL,
-    which is where payout settlement, fee payment and Saturday ordering actually
-    run, and PostgreSQL is where the durable write applies.
+    So on SQLite the default path adds to the caller's session and lets the
+    caller decide. A mutation that needs its audit row to commit atomically can
+    pass ``use_request_transaction=True`` and call this helper before its own
+    commit; that same mode deliberately bypasses the independent connection on
+    PostgreSQL. Existing commit-then-log call sites retain the durable
+    independent-write behavior where the database supports it.
     """
     try:
         actor_id = current_user.id if getattr(current_user, 'is_authenticated', False) else None
@@ -100,7 +108,7 @@ def log_action(action: str, entity_type: str, entity_id: int | None = None, deta
         'created_at': utc_now_naive(),
     }
 
-    if _supports_independent_write():
+    if not use_request_transaction and _supports_independent_write():
         try:
             with db.engine.connect() as conn:
                 conn.execute(AuditLog.__table__.insert().values(**values))

--- a/services/background_jobs.py
+++ b/services/background_jobs.py
@@ -2,10 +2,17 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import threading
+import time
 import uuid
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timedelta
+
+from sqlalchemy import inspect, or_
+from sqlalchemy.exc import SQLAlchemyError
 
 from database import db
 from models.background_job import BackgroundJob
@@ -15,10 +22,32 @@ _executor = ThreadPoolExecutor(max_workers=2)
 _jobs = {}
 _lock = threading.Lock()
 _app = None
+_BOOT_ID = uuid.uuid4().hex
+_heartbeat_thread = None
+_heartbeat_stop = threading.Event()
+PROCESS_MODEL = 'one-gunicorn-worker-with-threads'
+logger = logging.getLogger(__name__)
+_PERSIST_RETRY_ATTEMPTS = 3
+_PERSIST_RETRY_DELAY_SECONDS = 0.05
+
+
+def boot_id() -> str:
+    """Return the immutable owner ID for this worker process boot."""
+    return _BOOT_ID
+
+
+def _assert_single_process_job_model() -> None:
+    configured = os.environ.get('WEB_CONCURRENCY', '').strip()
+    if configured and configured != '1':
+        raise RuntimeError(
+            'In-process background jobs require WEB_CONCURRENCY=1. '
+            f'Configured value: {configured}.'
+        )
 
 
 def configure(max_workers: int, app=None) -> None:
     global _app, _executor
+    _assert_single_process_job_model()
     if max_workers < 1:
         max_workers = 1
     try:
@@ -66,33 +95,97 @@ def _persist_job(
     result=None,
     error: str | None = None,
     metadata: dict | None = None,
+    owner_boot_id: str | None = None,
+    owner_heartbeat_at: datetime | None = None,
+    require_active_owner: bool = False,
 ):
     if _app is None:
         return
 
     with _app.app_context():
+        updates = {}
+        if label is not None:
+            updates['label'] = label
+        if status is not None:
+            updates['status'] = status
+        if submitted_at is not None:
+            updates['submitted_at'] = submitted_at
+        if started_at is not None:
+            updates['started_at'] = started_at
+        if finished_at is not None:
+            updates['finished_at'] = finished_at
+        if error is not None:
+            updates['error_text'] = error
+        if metadata is not None:
+            updates['metadata_json'] = _serialize_json(metadata)
+            updates['tournament_id'] = (metadata or {}).get('tournament_id')
+        if owner_boot_id is not None:
+            updates['owner_boot_id'] = owner_boot_id
+        if owner_heartbeat_at is not None:
+            updates['owner_heartbeat_at'] = owner_heartbeat_at
+        if result is not None:
+            updates['result_json'] = _serialize_json(result)
+
+        if require_active_owner:
+            # Keep owner/status verification and the completion write in one
+            # SQL statement. A concurrent reconciliation that wins the row
+            # lock changes the predicate and this update affects zero rows;
+            # an old process can never overwrite ``interrupted`` afterward.
+            updated = (
+                BackgroundJob.query
+                .filter_by(id=job_id, owner_boot_id=_BOOT_ID)
+                .filter(BackgroundJob.status.in_(('queued', 'running')))
+                .update(updates, synchronize_session=False)
+            )
+            db.session.commit()
+            return updated == 1
+
         row = db.session.get(BackgroundJob, job_id)
         if row is None:
             row = BackgroundJob(id=job_id)
             db.session.add(row)
-        if label is not None:
-            row.label = label
-        if status is not None:
-            row.status = status
-        if submitted_at is not None:
-            row.submitted_at = submitted_at
-        if started_at is not None:
-            row.started_at = started_at
-        if finished_at is not None:
-            row.finished_at = finished_at
-        if error is not None:
-            row.error_text = error
-        if metadata is not None:
-            row.metadata_json = _serialize_json(metadata)
-            row.tournament_id = (metadata or {}).get('tournament_id')
-        if result is not None:
-            row.result_json = _serialize_json(result)
+        for attribute, value in updates.items():
+            setattr(row, attribute, value)
         db.session.commit()
+        return True
+
+
+def _persist_job_with_retry(job_id: str, **updates):
+    """Persist a lifecycle transition, tolerating brief database outages."""
+    for attempt in range(1, _PERSIST_RETRY_ATTEMPTS + 1):
+        try:
+            return _persist_job(job_id, **updates)
+        except SQLAlchemyError:
+            if _app is not None:
+                with _app.app_context():
+                    db.session.rollback()
+            if attempt == _PERSIST_RETRY_ATTEMPTS:
+                logger.error(
+                    'Background job %s lifecycle write failed after %d attempts.',
+                    job_id,
+                    attempt,
+                    exc_info=True,
+                )
+                return None
+            time.sleep(_PERSIST_RETRY_DELAY_SECONDS * attempt)
+
+
+def _persist_terminal_snapshot(job_id: str, snapshot: dict) -> bool:
+    persisted = _persist_job_with_retry(
+        job_id,
+        status=snapshot['status'],
+        finished_at=snapshot['finished_at'],
+        result=snapshot['result'],
+        error=snapshot['error'],
+        owner_heartbeat_at=snapshot['finished_at'],
+        require_active_owner=True,
+    )
+    resolved = persisted is not None
+    with _lock:
+        job = _jobs.get(job_id)
+        if job is not None:
+            job['terminal_persisted'] = resolved
+    return resolved
 
 
 def _snapshot(job: dict) -> dict:
@@ -105,6 +198,8 @@ def _snapshot(job: dict) -> dict:
         'result': job['result'],
         'error': job['error'],
         'metadata': dict(job.get('metadata') or {}),
+        'owner_boot_id': job.get('owner_boot_id'),
+        'owner_heartbeat_at': job.get('owner_heartbeat_at'),
     }
 
 
@@ -118,6 +213,8 @@ def _row_to_dict(row: BackgroundJob) -> dict:
         'result': _deserialize_json(row.result_json),
         'error': row.error_text,
         'metadata': _deserialize_json(row.metadata_json) or {},
+        'owner_boot_id': row.owner_boot_id,
+        'owner_heartbeat_at': row.owner_heartbeat_at,
     }
 
 
@@ -134,6 +231,9 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
             'result': None,
             'error': None,
             'metadata': dict(metadata or {}),
+            'owner_boot_id': _BOOT_ID,
+            'owner_heartbeat_at': submitted_at,
+            'terminal_persisted': False,
         }
     _persist_job(
         job_id,
@@ -141,9 +241,30 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
         status='queued',
         submitted_at=submitted_at,
         metadata=dict(metadata or {}),
+        owner_boot_id=_BOOT_ID,
+        owner_heartbeat_at=submitted_at,
     )
 
-    future = _executor.submit(_run_with_app_context, fn, *args, **kwargs)
+    def _run_job():
+        started_at = utc_now_naive()
+        with _lock:
+            job = _jobs.get(job_id)
+            if job is not None:
+                job['status'] = 'running'
+                job['started_at'] = started_at
+                job['owner_heartbeat_at'] = started_at
+        owner_active = _persist_job_with_retry(
+            job_id,
+            status='running',
+            started_at=started_at,
+            owner_heartbeat_at=started_at,
+            require_active_owner=True,
+        )
+        if owner_active is False:
+            raise RuntimeError('Background job ownership expired before execution.')
+        return _run_with_app_context(fn, *args, **kwargs)
+
+    future = _executor.submit(_run_job)
 
     def _done_callback(done_future):
         with _lock:
@@ -152,26 +273,29 @@ def submit(label: str, fn, *args, metadata: dict | None = None, **kwargs) -> str
                 return
             try:
                 job['result'] = done_future.result()
-                job['status'] = 'completed'
+                if (
+                    isinstance(job['result'], Mapping)
+                    and job['result'].get('ok') is False
+                ):
+                    job['status'] = 'failed'
+                    job['error'] = str(
+                        job['result'].get('error')
+                        or job['result'].get('message')
+                        or 'Background job returned ok=false.'
+                    )
+                else:
+                    job['status'] = 'completed'
             except Exception as exc:
                 job['status'] = 'failed'
                 job['error'] = str(exc)
             job['finished_at'] = utc_now_naive()
+            job['owner_heartbeat_at'] = job['finished_at']
+            job['terminal_persisted'] = False
             snapshot = _snapshot(job)
-        _persist_job(
-            job_id,
-            status=snapshot['status'],
-            finished_at=snapshot['finished_at'],
-            result=snapshot['result'],
-            error=snapshot['error'],
-        )
+        _persist_terminal_snapshot(job_id, snapshot)
 
     with _lock:
-        _jobs[job_id]['status'] = 'running'
         _jobs[job_id]['future'] = future
-        started_at = utc_now_naive()
-        _jobs[job_id]['started_at'] = started_at
-    _persist_job(job_id, status='running', started_at=started_at)
 
     future.add_done_callback(_done_callback)
     return job_id
@@ -191,24 +315,173 @@ def get(job_id: str) -> dict | None:
         return _row_to_dict(row)
 
 
-def list_recent(limit: int = 20) -> list[dict]:
+def list_recent(limit: int = 20, tournament_id: int | None = None) -> list[dict]:
     """Return the most recent jobs first for operator diagnostics."""
     if limit < 1:
         return []
     if _app is not None:
         with _app.app_context():
-            rows = (
-                BackgroundJob.query
-                .order_by(BackgroundJob.submitted_at.desc())
-                .limit(limit)
-                .all()
-            )
+            query = BackgroundJob.query
+            if tournament_id is not None:
+                query = query.filter(BackgroundJob.tournament_id == tournament_id)
+            rows = query.order_by(BackgroundJob.submitted_at.desc()).limit(limit).all()
             return [_row_to_dict(row) for row in rows]
     with _lock:
         rows = [_snapshot(job) for job in _jobs.values()]
+    if tournament_id is not None:
+        rows = [
+            row for row in rows
+            if (row.get('metadata') or {}).get('tournament_id') == tournament_id
+        ]
     rows.sort(
         key=lambda job: job.get('submitted_at') or datetime.min,
         reverse=True,
     )
     return rows[:limit]
+
+
+def reconcile_interrupted_jobs(
+    app=None,
+    *,
+    now: datetime | None = None,
+    lease_timeout_seconds: int | None = None,
+) -> int:
+    """Mark queued/running rows from prior process boots as interrupted.
+
+    The deployment contract is one gunicorn worker with threads. A different
+    boot can still be alive during a graceful traffic handoff, so ownership is
+    considered abandoned only after its heartbeat lease expires.
+    """
+    active_app = app or _app
+    if active_app is None:
+        return 0
+
+    with active_app.app_context():
+        try:
+            inspector = inspect(db.engine)
+            if not inspector.has_table(BackgroundJob.__tablename__):
+                return 0
+            columns = {
+                column['name']
+                for column in inspector.get_columns(BackgroundJob.__tablename__)
+            }
+            if not {'owner_boot_id', 'owner_heartbeat_at'} <= columns:
+                return 0
+            current_time = now or utc_now_naive()
+            timeout = lease_timeout_seconds
+            if timeout is None:
+                timeout = int(active_app.config.get('JOB_LEASE_TIMEOUT_SECONDS', 30))
+            cutoff = current_time - timedelta(seconds=max(1, timeout))
+            rows = (
+                BackgroundJob.query
+                .filter(BackgroundJob.status.in_(('queued', 'running')))
+                .filter(or_(
+                    BackgroundJob.owner_boot_id.is_(None),
+                    BackgroundJob.owner_boot_id != _BOOT_ID,
+                ))
+                .filter(or_(
+                    BackgroundJob.owner_heartbeat_at < cutoff,
+                    BackgroundJob.owner_heartbeat_at.is_(None),
+                ))
+                .all()
+            )
+            finished_at = current_time
+            for row in rows:
+                row.status = 'interrupted'
+                row.finished_at = finished_at
+                row.error_text = (
+                    'Worker process restarted before this in-process job finished; '
+                    'the job cannot resume.'
+                )
+            db.session.commit()
+            return len(rows)
+        except SQLAlchemyError:
+            db.session.rollback()
+            logger.warning(
+                'Background job reconciliation deferred after a database error.',
+                exc_info=True,
+            )
+            return 0
+
+
+def _heartbeat_once(app) -> None:
+    with _lock:
+        terminal_job_ids = {
+            job_id
+            for job_id, job in _jobs.items()
+            if job.get('status') in {'completed', 'failed'}
+        }
+    with app.app_context():
+        now = utc_now_naive()
+        query = BackgroundJob.query.filter(
+            BackgroundJob.owner_boot_id == _BOOT_ID,
+            BackgroundJob.status.in_(('queued', 'running')),
+        )
+        if terminal_job_ids:
+            query = query.filter(BackgroundJob.id.notin_(terminal_job_ids))
+        query.update(
+            {BackgroundJob.owner_heartbeat_at: now},
+            synchronize_session=False,
+        )
+        db.session.commit()
+
+
+def _retry_unpersisted_terminal_jobs() -> None:
+    with _lock:
+        pending = [
+            (job_id, _snapshot(job))
+            for job_id, job in _jobs.items()
+            if job.get('status') in {'completed', 'failed'}
+            and not job.get('terminal_persisted')
+        ]
+    for job_id, snapshot in pending:
+        _persist_terminal_snapshot(job_id, snapshot)
+
+
+def _heartbeat_loop(app, interval_seconds: int) -> None:
+    while not _heartbeat_stop.wait(max(1, interval_seconds)):
+        try:
+            _retry_unpersisted_terminal_jobs()
+            _heartbeat_once(app)
+            reconcile_interrupted_jobs(app)
+        except SQLAlchemyError:
+            with app.app_context():
+                db.session.rollback()
+            logger.warning('Background job heartbeat failed.', exc_info=True)
+
+
+def start_heartbeat(app) -> None:
+    """Start the production lease heartbeat after database initialization."""
+    global _heartbeat_thread
+    uri = str(app.config.get('SQLALCHEMY_DATABASE_URI', ''))
+    testing = (
+        bool(app.config.get('TESTING'))
+        or os.environ.get('FLASK_ENV', '').strip().lower() == 'testing'
+        or bool(os.environ.get('TESTING', '').strip())
+        or os.environ.get('PROAM_UNIT_PG', '').strip() == '1'
+    )
+    if testing or not uri.startswith('postgresql'):
+        return
+    if _heartbeat_thread is not None and _heartbeat_thread.is_alive():
+        return
+    with app.app_context():
+        inspector = inspect(db.engine)
+        if not inspector.has_table(BackgroundJob.__tablename__):
+            return
+        columns = {
+            column['name']
+            for column in inspector.get_columns(BackgroundJob.__tablename__)
+        }
+        if not {'owner_boot_id', 'owner_heartbeat_at'} <= columns:
+            return
+    _heartbeat_stop.clear()
+    interval = int(app.config.get('JOB_HEARTBEAT_INTERVAL_SECONDS', 5))
+    _heartbeat_once(app)
+    _heartbeat_thread = threading.Thread(
+        target=_heartbeat_loop,
+        args=(app, interval),
+        name='proam-job-heartbeat',
+        daemon=True,
+    )
+    _heartbeat_thread.start()
 

--- a/services/backup.py
+++ b/services/backup.py
@@ -14,16 +14,22 @@ Usage:
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
-import shutil
+import sqlite3
 import subprocess
 import tempfile
-from urllib.parse import urlparse
+from pathlib import Path
+from uuid import uuid4
 
 from services.time_utils import utc_timestamp_for_filename
 
 logger = logging.getLogger(__name__)
+
+
+class SQLiteBackupValidationError(RuntimeError):
+    """Raised when a completed SQLite snapshot is not recoverable."""
 
 
 # ---------------------------------------------------------------------------
@@ -32,6 +38,11 @@ logger = logging.getLogger(__name__)
 
 def _timestamp() -> str:
     return utc_timestamp_for_filename()
+
+
+def _artifact_stamp() -> str:
+    """Return a sortable, collision-resistant backup artifact stamp."""
+    return f'{_timestamp()}_{uuid4().hex[:12]}'
 
 
 def is_postgres(uri: str) -> bool:
@@ -47,6 +58,129 @@ def _db_path_from_uri(uri: str, instance_path: str) -> str | None:
     if not os.path.isabs(path):
         path = os.path.join(instance_path, path)
     return path if os.path.exists(path) else None
+
+
+def sha256_file(path: str) -> str:
+    """Return the SHA-256 digest of *path* without loading it into memory."""
+    digest = hashlib.sha256()
+    with open(path, 'rb') as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_only_sqlite_connection(path: str) -> sqlite3.Connection:
+    resolved = Path(path).resolve()
+    if not resolved.is_file():
+        raise SQLiteBackupValidationError(f'SQLite database file not found: {resolved}')
+    return sqlite3.connect(f'{resolved.as_uri()}?mode=ro', uri=True, timeout=30)
+
+
+def _fsync_file(path: str) -> None:
+    with open(path, 'r+b') as handle:
+        os.fsync(handle.fileno())
+
+
+def _replace_file_durably(source: str, destination: str) -> None:
+    """Publish a file and durably commit the containing-directory entry."""
+    if os.name == 'nt':
+        import ctypes
+
+        move_file_ex = ctypes.windll.kernel32.MoveFileExW
+        move_file_ex.argtypes = [ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint]
+        move_file_ex.restype = ctypes.c_int
+        movefile_replace_existing = 0x1
+        movefile_write_through = 0x8
+        if not move_file_ex(
+            str(source),
+            str(destination),
+            movefile_replace_existing | movefile_write_through,
+        ):
+            raise ctypes.WinError()
+        return
+
+    os.replace(source, destination)
+    directory = os.path.dirname(os.path.abspath(destination)) or '.'
+    flags = os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0)
+    directory_fd = os.open(directory, flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def validate_sqlite_snapshot(path: str) -> dict:
+    """Prove a SQLite snapshot is readable, integral, and FK-consistent."""
+    try:
+        conn = _read_only_sqlite_connection(path)
+        try:
+            integrity_rows = [row[0] for row in conn.execute('PRAGMA integrity_check')]
+            if integrity_rows != ['ok']:
+                raise SQLiteBackupValidationError(
+                    'SQLite integrity check failed for completed backup.'
+                )
+            fk_row = conn.execute('PRAGMA foreign_key_check').fetchone()
+            if fk_row is not None:
+                raise SQLiteBackupValidationError(
+                    'SQLite foreign key check failed for completed backup.'
+                )
+        finally:
+            conn.close()
+    except SQLiteBackupValidationError:
+        raise
+    except sqlite3.Error as exc:
+        raise SQLiteBackupValidationError(
+            f'Completed SQLite backup could not be opened: {exc}'
+        ) from exc
+
+    return {
+        'integrity_check': 'ok',
+        'foreign_key_violations': 0,
+        'size_bytes': os.path.getsize(path),
+        'sha256': sha256_file(path),
+    }
+
+
+def create_sqlite_snapshot(db_path: str, destination_path: str | None = None) -> dict:
+    """Create and validate a consistent snapshot with SQLite's online API.
+
+    The source remains online while ``Connection.backup`` takes a transactionally
+    consistent image. The destination is fsynced and independently reopened for
+    integrity and foreign-key checks before the caller can publish it.
+    """
+    source_path = str(Path(db_path).resolve())
+    owns_destination = destination_path is None
+    if destination_path is None:
+        fd, destination_path = tempfile.mkstemp(
+            prefix='proam_sqlite_snapshot_', suffix='.db'
+        )
+        os.close(fd)
+    destination_path = str(Path(destination_path).resolve())
+
+    source = None
+    destination = None
+    try:
+        source = _read_only_sqlite_connection(source_path)
+        destination = sqlite3.connect(destination_path, timeout=30)
+        source.backup(destination, pages=256, sleep=0.05)
+        destination.commit()
+        destination.close()
+        destination = None
+        _fsync_file(destination_path)
+        validation = validate_sqlite_snapshot(destination_path)
+        return {'path': destination_path, **validation}
+    except Exception:
+        if owns_destination or destination_path != source_path:
+            try:
+                os.remove(destination_path)
+            except OSError:
+                pass
+        raise
+    finally:
+        if destination is not None:
+            destination.close()
+        if source is not None:
+            source.close()
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +267,7 @@ def backup_pg_to_s3(db_uri: str, tournament_id: int) -> dict:
         return {'ok': False, 'error': 'S3 not configured (missing boto3 or env vars)'}
 
     prefix = os.environ.get('BACKUP_S3_PREFIX', 'proam-backups').strip().rstrip('/')
-    s3_key = f'{prefix}/tournament_{tournament_id}/proam_{_timestamp()}.dump'
+    s3_key = f'{prefix}/tournament_{tournament_id}/proam_{_artifact_stamp()}.dump'
 
     dump_file = None
     try:
@@ -168,26 +302,43 @@ def backup_pg_to_s3(db_uri: str, tournament_id: int) -> dict:
 
 
 def backup_pg_to_local(db_uri: str, dest_dir: str, tournament_id: int) -> dict:
-    """Run pg_dump and save the dump locally."""
+    """Run pg_dump into a private temp file, then publish it atomically."""
+    temp_dest = None
     try:
         os.makedirs(dest_dir, exist_ok=True)
-        filename = f'proam_t{tournament_id}_{_timestamp()}.dump'
+        filename = f'proam_t{tournament_id}_{_artifact_stamp()}.dump'
         dest = os.path.join(dest_dir, filename)
+        fd, temp_dest = tempfile.mkstemp(
+            prefix='.proam_pg_backup_', suffix='.tmp', dir=dest_dir,
+        )
+        os.close(fd)
 
         connection_args, env_overlay = _pg_dump_args_and_env(db_uri)
         env = os.environ.copy()
         env.update(env_overlay)
         result = subprocess.run(
-            ['pg_dump', '--format=custom', f'--file={dest}', *connection_args],
+            ['pg_dump', '--format=custom', f'--file={temp_dest}', *connection_args],
             capture_output=True, text=True, timeout=300, env=env,
         )
         if result.returncode != 0:
             logger.error('pg_dump failed: %s', result.stderr)
             return {'ok': False, 'error': f'pg_dump failed: {result.stderr[:500]}'}
 
-        size = os.path.getsize(dest)
+        size = os.path.getsize(temp_dest)
+        if size < 1:
+            return {'ok': False, 'error': 'pg_dump produced an empty archive'}
+        digest = sha256_file(temp_dest)
+        _replace_file_durably(temp_dest, dest)
+        temp_dest = None
+        _fsync_file(dest)
         logger.info('PG backup saved to %s (%d bytes)', dest, size)
-        return {'ok': True, 'dest': dest, 'size_bytes': size, 'error': None}
+        return {
+            'ok': True,
+            'dest': dest,
+            'size_bytes': size,
+            'sha256': digest,
+            'error': None,
+        }
 
     except FileNotFoundError:
         return {'ok': False, 'error': 'pg_dump not found — is PostgreSQL client installed?'}
@@ -196,6 +347,12 @@ def backup_pg_to_local(db_uri: str, dest_dir: str, tournament_id: int) -> dict:
     except Exception as exc:
         logger.error('PG local backup failed: %s', exc)
         return {'ok': False, 'error': str(exc)}
+    finally:
+        if temp_dest:
+            try:
+                os.remove(temp_dest)
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -207,21 +364,30 @@ def backup_database(db_uri: str, tournament_id: int, instance_path: str = '') ->
 
     Tries S3 first, falls back to local. Works for both SQLite and PostgreSQL.
     """
+    dest_dir = os.environ.get('LOCAL_BACKUP_DIR', 'instance/backups')
     if is_postgres(db_uri):
         if is_s3_configured():
-            return backup_pg_to_s3(db_uri, tournament_id)
-        else:
-            dest_dir = os.environ.get('LOCAL_BACKUP_DIR', 'instance/backups')
-            return backup_pg_to_local(db_uri, dest_dir, tournament_id)
-    else:
-        db_path = _db_path_from_uri(db_uri, instance_path)
-        if not db_path:
-            return {'ok': False, 'error': 'SQLite database file not found'}
-        if is_s3_configured():
-            return backup_to_s3(db_path, tournament_id)
-        else:
-            dest_dir = os.environ.get('LOCAL_BACKUP_DIR', 'instance/backups')
-            return backup_to_local(db_path, dest_dir, tournament_id)
+            primary = backup_pg_to_s3(db_uri, tournament_id)
+            if primary.get('ok'):
+                return primary
+            fallback = backup_pg_to_local(db_uri, dest_dir, tournament_id)
+            fallback['fallback_from'] = 's3'
+            fallback['primary_error'] = primary.get('error')
+            return fallback
+        return backup_pg_to_local(db_uri, dest_dir, tournament_id)
+
+    db_path = _db_path_from_uri(db_uri, instance_path)
+    if not db_path:
+        return {'ok': False, 'error': 'SQLite database file not found'}
+    if is_s3_configured():
+        primary = backup_to_s3(db_path, tournament_id)
+        if primary.get('ok'):
+            return primary
+        fallback = backup_to_local(db_path, dest_dir, tournament_id)
+        fallback['fallback_from'] = 's3'
+        fallback['primary_error'] = primary.get('error')
+        return fallback
+    return backup_to_local(db_path, dest_dir, tournament_id)
 
 
 # ---------------------------------------------------------------------------
@@ -229,25 +395,66 @@ def backup_database(db_uri: str, tournament_id: int, instance_path: str = '') ->
 # ---------------------------------------------------------------------------
 
 def backup_to_s3(db_path: str, tournament_id: int) -> dict:
-    """Upload SQLite *db_path* to S3."""
+    """Create a validated SQLite snapshot and upload that snapshot to S3."""
     if not is_s3_configured():
         return {'ok': False, 'error': 'S3 not configured (missing boto3 or env vars)'}
 
     prefix = os.environ.get('BACKUP_S3_PREFIX', 'proam-backups').strip().rstrip('/')
-    key = f'{prefix}/tournament_{tournament_id}/proam_{_timestamp()}.db'
-    return _upload_to_s3(db_path, key)
+    key = f'{prefix}/tournament_{tournament_id}/proam_{_artifact_stamp()}.db'
+    snapshot_path = None
+    try:
+        snapshot = create_sqlite_snapshot(db_path)
+        snapshot_path = snapshot['path']
+        result = _upload_to_s3(snapshot_path, key)
+        if result.get('ok'):
+            result.update({
+                'sha256': snapshot['sha256'],
+                'integrity_check': snapshot['integrity_check'],
+                'foreign_key_violations': snapshot['foreign_key_violations'],
+            })
+        return result
+    except Exception as exc:
+        logger.error('SQLite S3 backup failed: %s', exc)
+        return {'ok': False, 'error': str(exc)}
+    finally:
+        if snapshot_path:
+            try:
+                os.remove(snapshot_path)
+            except OSError:
+                pass
 
 
 def backup_to_local(db_path: str, dest_dir: str, tournament_id: int) -> dict:
-    """Copy SQLite *db_path* to *dest_dir*."""
+    """Create a validated SQLite snapshot in *dest_dir*."""
+    temp_dest = None
     try:
         os.makedirs(dest_dir, exist_ok=True)
-        filename = f'proam_t{tournament_id}_{_timestamp()}.db'
+        filename = f'proam_t{tournament_id}_{_artifact_stamp()}.db'
         dest = os.path.join(dest_dir, filename)
-        shutil.copy2(db_path, dest)
-        size = os.path.getsize(dest)
-        logger.info('Local DB backup saved to %s (%d bytes)', dest, size)
-        return {'ok': True, 'dest': dest, 'size_bytes': size, 'error': None}
+        fd, temp_dest = tempfile.mkstemp(
+            prefix='.proam_backup_', suffix='.tmp', dir=dest_dir,
+        )
+        os.close(fd)
+        snapshot = create_sqlite_snapshot(db_path, temp_dest)
+        _replace_file_durably(temp_dest, dest)
+        temp_dest = None
+        _fsync_file(dest)
+        logger.info('Local DB backup saved to %s (%d bytes)', dest, snapshot['size_bytes'])
+        return {
+            'ok': True,
+            'dest': dest,
+            'size_bytes': snapshot['size_bytes'],
+            'sha256': snapshot['sha256'],
+            'integrity_check': snapshot['integrity_check'],
+            'foreign_key_violations': snapshot['foreign_key_violations'],
+            'error': None,
+        }
     except Exception as exc:
         logger.error('Local backup failed: %s', exc)
         return {'ok': False, 'error': str(exc)}
+    finally:
+        if temp_dest:
+            try:
+                os.remove(temp_dest)
+            except OSError:
+                pass

--- a/services/birling_bracket.py
+++ b/services/birling_bracket.py
@@ -2,6 +2,9 @@
 Birling double-elimination bracket service.
 Handles bracket generation and match progression for Birling events.
 """
+import hashlib
+import hmac
+import json
 import logging
 import math
 from datetime import datetime, timezone
@@ -11,6 +14,14 @@ from models import Event, EventResult
 from services import birling_rows
 
 logger = logging.getLogger(__name__)
+
+
+class BirlingStateConflict(RuntimeError):
+    """Authoritative bracket state changed after the operator loaded a form."""
+
+
+class BirlingFallConflict(BirlingStateConflict):
+    """The match's fall state changed after the operator loaded the page."""
 
 
 class BirlingBracket:
@@ -30,6 +41,91 @@ class BirlingBracket:
         birling_rows.project_document(self.event, self.bracket_data)
         self.projection_refused = None
         db.session.commit()
+
+    def match_fall_digest(self, match_id: str) -> str:
+        """Digest the contestants, decision, and physical falls for one match."""
+        match = self._find_match(match_id)
+        if match is None:
+            raise ValueError(f'Match {match_id} not found')
+        payload = {
+            'match_id': match_id,
+            'competitor1': match.get('competitor1'),
+            'competitor2': match.get('competitor2'),
+            'winner': match.get('winner'),
+            'loser': match.get('loser'),
+            'is_bye': bool(match.get('is_bye', False)),
+            'needed': match.get('needed'),
+            'falls': [
+                {
+                    'fall_number': fall.get('fall_number'),
+                    'winner': fall.get('winner'),
+                }
+                for fall in match.get('falls', [])
+            ],
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(',', ':'),
+        ).encode('ascii')
+        return hashlib.sha256(encoded).hexdigest()
+
+    def bracket_state_digest(self) -> str:
+        """Digest every authoritative row represented by this bracket."""
+        payload = {
+            'event_id': self.event.id,
+            'bracket_data': self.bracket_data,
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(',', ':'),
+        ).encode('ascii')
+        return hashlib.sha256(encoded).hexdigest()
+
+    def _require_match_fall_digest(
+        self,
+        match_id: str,
+        expected_fall_digest: str | None,
+    ) -> None:
+        """Refuse a write based on an absent or stale match snapshot."""
+        if not expected_fall_digest or not hmac.compare_digest(
+            expected_fall_digest,
+            self.match_fall_digest(match_id),
+        ):
+            raise BirlingFallConflict(
+                'Birling fall state changed since this page was loaded. '
+                'Refresh the bracket before recording a result.'
+            )
+
+    def _require_match_undo_digest(
+        self,
+        match_id: str,
+        expected_undo_digest: str | None,
+    ) -> None:
+        """Refuse an undo based on an absent or stale match snapshot."""
+        if not expected_undo_digest or not hmac.compare_digest(
+            expected_undo_digest,
+            self.match_fall_digest(match_id),
+        ):
+            raise BirlingStateConflict(
+                'Birling match state changed since this page was loaded. '
+                'Refresh the bracket before undoing a result.'
+            )
+
+    def _require_bracket_state_digest(
+        self,
+        expected_bracket_digest: str | None,
+    ) -> None:
+        """Refuse a reset based on an absent or stale bracket snapshot."""
+        if not expected_bracket_digest or not hmac.compare_digest(
+            expected_bracket_digest,
+            self.bracket_state_digest(),
+        ):
+            raise BirlingStateConflict(
+                'Birling bracket state changed since this page was loaded. '
+                'Refresh the bracket before resetting it.'
+            )
 
     def _expected_round_1_match_count(self, n: int) -> int:
         """Compact-shape round-1 match count for N entrants.
@@ -429,7 +525,12 @@ class BirlingBracket:
                         self._advance_loser_winner(match)
                         changed = True
 
-    def record_fall(self, match_id: str, fall_winner_id: int) -> dict:
+    def record_fall(
+        self,
+        match_id: str,
+        fall_winner_id: int,
+        expected_fall_digest: str | None = None,
+    ) -> dict:
         """Record a single fall in a best-of-3 birling match.
 
         Args:
@@ -442,6 +543,8 @@ class BirlingBracket:
         match = self._find_match(match_id)
         if not match:
             raise ValueError(f"Match {match_id} not found")
+        if expected_fall_digest is not None:
+            self._require_match_fall_digest(match_id, expected_fall_digest)
 
         # Validate the match is currently playable
         playable_ids = {m['match_id'] for m in self.get_current_matches()}
@@ -495,6 +598,17 @@ class BirlingBracket:
             'match_decided': decided,
             'winner': winner,
         }
+
+    def record_direct_winner(
+        self,
+        match_id: str,
+        winner_id: int,
+        *,
+        expected_fall_digest: str | None,
+    ) -> None:
+        """Declare a winner only against the operator's current fall state."""
+        self._require_match_fall_digest(match_id, expected_fall_digest)
+        self.record_match_result(match_id, winner_id)
 
     def record_match_result(self, match_id: str, winner_id: int,
                             _from_fall: bool = False):
@@ -877,7 +991,11 @@ class BirlingBracket:
             target_match_idx = len(target_rnd) - 1
         return target_rnd[target_match_idx]
 
-    def undo_match_result(self, match_id: str) -> dict:
+    def undo_match_result(
+        self,
+        match_id: str,
+        expected_undo_digest: str | None = None,
+    ) -> dict:
         """Undo a decided match result, returning both competitors to the match.
 
         Only allowed if no downstream match has been decided.
@@ -888,6 +1006,7 @@ class BirlingBracket:
         Raises:
             ValueError if the match cannot be undone.
         """
+        self._require_match_undo_digest(match_id, expected_undo_digest)
         match = self._find_match(match_id)
         if not match:
             raise ValueError(f"Match {match_id} not found")
@@ -963,6 +1082,13 @@ class BirlingBracket:
             'undone': True,
             'message': 'Match result cleared. Both competitors returned to this match.',
         }
+
+    def reset_bracket(self, expected_bracket_digest: str | None = None) -> None:
+        """Clear this bracket only when the operator submitted its exact state."""
+        self._require_bracket_state_digest(expected_bracket_digest)
+        birling_rows.clear_event(self.event.id)
+        db.session.commit()
+        self.bracket_data = birling_rows.empty_document()
 
     def finalize_to_event_results(self):
         """Write final placements and points to EventResult records.

--- a/services/cache_invalidation.py
+++ b/services/cache_invalidation.py
@@ -6,6 +6,6 @@ def invalidate_tournament_caches(tournament_id: int) -> None:
     """Invalidate cached payloads affected by tournament data mutations."""
     tid = int(tournament_id)
     invalidate_prefix(f'reports:{tid}:')
-    invalidate_prefix(f'portal:college:{tid}')
-    invalidate_prefix(f'portal:pro:{tid}')
-    invalidate_prefix(f'api:standings-poll:{tid}')
+    invalidate_prefix(f'portal:college:{tid}:')
+    invalidate_prefix(f'portal:pro:{tid}:')
+    invalidate_prefix(f'api:standings-poll:{tid}:')

--- a/services/partner_matching.py
+++ b/services/partner_matching.py
@@ -27,6 +27,8 @@ DOMAIN_CONTRACT (2026-04-27): the partner resolver must:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 
 from database import db
@@ -222,6 +224,56 @@ def get_unclaimed_partner_candidates(event: Event, exclude_ids: set[int] | None 
         and competitor.id not in inbound_claims
         and not _read_partner_name(competitor, event)
     ]
+
+
+def partner_claim_digest(event: Event, orphan, candidate) -> str:
+    """Digest only the two competitors and claims that govern this repair."""
+    pool = _event_pool(event)
+
+    def state(competitor):
+        inbound_claims = []
+        for claimant in pool:
+            partner_name = _read_partner_name(claimant, event)
+            if not partner_name:
+                continue
+            resolved = _resolve_partner(partner_name, pool, exclude_id=claimant.id)
+            if resolved is not None and resolved.id == competitor.id:
+                inbound_claims.append((claimant.id, partner_name))
+        entered_events = (
+            competitor.get_events_entered()
+            if hasattr(competitor, 'get_events_entered')
+            else []
+        )
+        return {
+            'id': competitor.id,
+            'name': competitor.name,
+            'status': competitor.status,
+            'gender': competitor.gender,
+            'entered': _is_entered(event, entered_events),
+            'partner': _read_partner_name(competitor, event),
+            'inbound_claims': sorted(inbound_claims),
+        }
+
+    payload = {
+        'event': {
+            'id': event.id,
+            'status': event.status,
+            'is_finalized': bool(event.is_finalized),
+            'scoring_started': EventResult.query.filter_by(
+                event_id=event.id,
+                status='completed',
+            ).first() is not None,
+        },
+        'orphan': state(orphan),
+        'candidate': state(candidate),
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=True,
+    ).encode('ascii')
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def auto_assign_event_partners(event: Event) -> dict:

--- a/services/proam_relay.py
+++ b/services/proam_relay.py
@@ -9,16 +9,43 @@ Each team has 8 members:
 - 2 College Women
 """
 import copy
+import hashlib
+import hmac
 import json
 import math
 import random
+from functools import wraps
 
-from flask import has_app_context
+from flask import has_app_context, has_request_context
 
 from database import db
 from models import Event, EventResult, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 from models.relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
+
+
+class RelayStateConflict(RuntimeError):
+    """The relay state no longer matches the operator's reviewed snapshot."""
+
+
+def _relay_writer(func):
+    """Serialize a relay write and reload its snapshot after taking the lock."""
+    @wraps(func)
+    def locked(self, *args, **kwargs):
+        if not has_app_context():
+            return func(self, *args, **kwargs)
+
+        from services.flight_builder import (
+            lock_tournament_schedule,
+            sqlite_schedule_writer_guard,
+        )
+
+        with sqlite_schedule_writer_guard(self.tournament):
+            self.tournament = lock_tournament_schedule(self.tournament)
+            self.relay_data = self._load_relay_data()
+            return func(self, *args, **kwargs)
+
+    return locked
 
 
 def relay_payout_summary(tournament: Tournament) -> dict:
@@ -464,7 +491,73 @@ class ProAmRelay:
             'max_teams': max_teams,
         }
 
-    def run_lottery(self, num_teams: int = 2) -> dict:
+    @staticmethod
+    def _state_hash(payload) -> str:
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(',', ':'),
+            ensure_ascii=True,
+        ).encode('ascii')
+        return hashlib.sha256(encoded).hexdigest()
+
+    def state_digest(self) -> str:
+        """Digest the full relay roster/results snapshot for replacement writes."""
+        return self._state_hash({
+            'status': self.get_status(),
+            'teams': sorted(
+                self.get_teams(), key=lambda team: team.get('team_number', 0)
+            ),
+        })
+
+    def team_state_digest(self, team_number: int) -> str:
+        """Digest one team so writes to different teams remain compatible."""
+        team = next(
+            (
+                row for row in self.get_teams()
+                if row.get('team_number') == int(team_number)
+            ),
+            None,
+        )
+        return self._state_hash({'team_number': int(team_number), 'team': team})
+
+    def require_state_digest(
+        self,
+        expected_digest: str | None,
+        *,
+        team_number: int | None = None,
+    ) -> None:
+        """Reject a missing or stale full-state/team-state operator token."""
+        current = (
+            self.team_state_digest(team_number)
+            if team_number is not None
+            else self.state_digest()
+        )
+        if not expected_digest or not hmac.compare_digest(expected_digest, current):
+            raise RelayStateConflict(
+                'Relay state changed since this page was loaded. '
+                'Refresh and review the current relay before saving again.'
+            )
+
+    def require_request_state_digest(
+        self,
+        expected_digest: str | None,
+        *,
+        team_number: int | None = None,
+    ) -> None:
+        """Fence every HTTP mutation while preserving trusted setup callers."""
+        if has_request_context() or expected_digest is not None:
+            self.require_state_digest(
+                expected_digest,
+                team_number=team_number,
+            )
+
+    @_relay_writer
+    def run_lottery(
+        self,
+        num_teams: int = 2,
+        expected_digest: str | None = None,
+    ) -> dict:
         """
         Run the Pro-Am Relay lottery to create teams.
 
@@ -480,6 +573,8 @@ class ProAmRelay:
         Returns:
             Dict with lottery results
         """
+        self.require_request_state_digest(expected_digest)
+
         eligible_pro = self.get_eligible_pro_competitors()
         eligible_college = self.get_eligible_college_competitors()
 
@@ -561,7 +656,12 @@ class ProAmRelay:
             'message': f'Successfully drew {num_teams} team(s) of 8 competitors each.'
         }
 
-    def redraw_lottery(self, num_teams: int = 2) -> dict:
+    @_relay_writer
+    def redraw_lottery(
+        self,
+        num_teams: int = 2,
+        expected_digest: str | None = None,
+    ) -> dict:
         """Clear and redraw the lottery.
 
         The clear is in memory only. It used to be written through
@@ -577,6 +677,8 @@ class ProAmRelay:
         the previous state is restored in memory and the stored state was
         never modified at all.
         """
+        self.require_request_state_digest(expected_digest)
+
         previous = copy.deepcopy(self.relay_data)
         self.relay_data = {
             'status': 'not_drawn',
@@ -587,7 +689,10 @@ class ProAmRelay:
             'drawn_pro': []
         }
         try:
-            return self.run_lottery(num_teams=num_teams)
+            return self.run_lottery(
+                num_teams=num_teams,
+                expected_digest=expected_digest,
+            )
         except Exception:
             # Also covers a StaleDataError out of run_lottery's commit, where
             # the caller rolls back the session but this object would
@@ -603,7 +708,13 @@ class ProAmRelay:
         """Get the current lottery status."""
         return self.relay_data.get('status', 'not_drawn')
 
-    def record_total_time(self, team_number: int, total_time: float):
+    @_relay_writer
+    def record_total_time(
+        self,
+        team_number: int,
+        total_time: float,
+        expected_digest: str | None = None,
+    ):
         """
         Record the total relay time for a team directly.
 
@@ -611,6 +722,11 @@ class ProAmRelay:
             team_number: Team number
             total_time: Total relay time in seconds
         """
+        self.require_request_state_digest(
+            expected_digest,
+            team_number=team_number,
+        )
+
         teams = self.relay_data.get('teams', [])
         total_time = self._validated_relay_time(total_time)
         team = next((team for team in teams if team['team_number'] == team_number), None)
@@ -626,7 +742,14 @@ class ProAmRelay:
 
         self._save_relay_data()
 
-    def record_event_result(self, team_number: int, event_name: str, time_seconds: float):
+    @_relay_writer
+    def record_event_result(
+        self,
+        team_number: int,
+        event_name: str,
+        time_seconds: float,
+        expected_digest: str | None = None,
+    ):
         """
         Record a result for a team's event.
 
@@ -635,6 +758,11 @@ class ProAmRelay:
             event_name: One of the configured relay event keys
             time_seconds: Time in seconds
         """
+        self.require_request_state_digest(
+            expected_digest,
+            team_number=team_number,
+        )
+
         teams = self.relay_data.get('teams', [])
         if event_name not in self.RELAY_EVENTS:
             raise ValueError(f'Unknown relay event: {event_name}')
@@ -690,7 +818,12 @@ class ProAmRelay:
         completed = [t for t in teams if t.get('total_time') is not None]
         return sorted(completed, key=lambda t: t['total_time'])
 
-    def set_teams_manually(self, team_assignments: list[dict]) -> dict:
+    @_relay_writer
+    def set_teams_manually(
+        self,
+        team_assignments: list[dict],
+        expected_digest: str | None = None,
+    ) -> dict:
         """
         Set relay teams manually instead of using the lottery.
 
@@ -704,6 +837,7 @@ class ProAmRelay:
         Returns:
             Dict with result message.
         """
+        self.require_request_state_digest(expected_digest)
         if not team_assignments:
             raise ValueError("At least one team is required.")
 
@@ -817,8 +951,15 @@ class ProAmRelay:
             'message': f'Manually set {len(teams)} team(s).',
         }
 
-    def replace_competitor(self, team_number: int, old_competitor_id: int,
-                          new_competitor_id: int, competitor_type: str):
+    @_relay_writer
+    def replace_competitor(
+        self,
+        team_number: int,
+        old_competitor_id: int,
+        new_competitor_id: int,
+        competitor_type: str,
+        expected_digest: str | None = None,
+    ):
         """
         Replace a competitor on a team (e.g., due to injury).
 
@@ -828,6 +969,11 @@ class ProAmRelay:
             new_competitor_id: ID of replacement competitor
             competitor_type: 'pro' or 'college'
         """
+        self.require_request_state_digest(
+            expected_digest,
+            team_number=team_number,
+        )
+
         teams = self.relay_data.get('teams', [])
 
         # Get new competitor info. Filter on tournament_id + active status +

--- a/services/report_cache.py
+++ b/services/report_cache.py
@@ -1,26 +1,22 @@
 """TTL cache for report payloads.
 
 Storage strategy (in priority order):
-  1. In-process memory dict — always used as L1 for speed.
-  2. Disk shelve in instance/report_cache/ — used as L2 so that cache entries
-     survive gunicorn worker recycling and Railway redeploys.  The disk layer
-     is skipped gracefully if the instance directory is not writable.
+  1. In-process memory dict for SQLite/local operation.
+  2. No cross-process disk layer. Report invalidation generations are
+     process-local, so sharing a shelf across overlapping boots would let an
+     old process repopulate stale data after a new process invalidates it.
+  3. PostgreSQL deployments bypass this cache. A rolling deployment can have
+     two live processes, and a write in one cannot invalidate memory in the
+     other without a shared generation store.
 
-Callers must hand this module plain data. Anything stored here has to survive
-a pickle round trip into a different process, and a SQLAlchemy-mapped instance
-does not: it pickles without complaint, unpickles without complaint, and comes
-back detached from any session, so the first attribute the reader touches that
-was not already loaded when the pickle was taken raises DetachedInstanceError.
-The failure lands far from the write, in whatever renders the value, and it
-repeats for every request until the entry ages out. ``set`` therefore refuses
-the disk layer for values that carry mapped instances and says so in the log.
+Callers should still hand this module plain data. Process-local mapped entities
+can expire with their SQLAlchemy session, so caching them is allowed only in L1
+for backward compatibility and emits a warning.
 """
 from __future__ import annotations
 
 import builtins
 import logging
-import os
-import shelve
 import threading
 import time
 
@@ -29,80 +25,85 @@ logger = logging.getLogger(__name__)
 _cache: dict = {}
 _lock = threading.Lock()
 
+# A cache miss records the generation for that key in the reading thread. If
+# an invalidation affecting the key lands before the reader calls set(), the
+# stale fill is discarded. Generations are prefix-specific so an update to one
+# tournament does not suppress a concurrent fill for another tournament.
+_generation_counter = 0
+_prefix_generations: dict[str, int] = {}
+_read_state = threading.local()
+
 # Resolved once on first use; None means disk layer is unavailable.
 _shelf_path: str | None = None
 _shelf_resolved = False
 
 
-def _get_shelf_path() -> str | None:
-    """Return the path prefix for the shelve file, or None if unavailable."""
-    global _shelf_path, _shelf_resolved
-    if _shelf_resolved:
-        return _shelf_path
-    _shelf_resolved = True
+def _cache_enabled() -> bool:
     try:
-        # Walk up from this file to find the instance/ directory.
-        base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        cache_dir = os.path.join(base, 'instance', 'report_cache')
-        os.makedirs(cache_dir, exist_ok=True)
-        _shelf_path = os.path.join(cache_dir, 'cache')
-    except Exception as exc:
-        logger.debug('Disk cache unavailable: %s', exc)
-        _shelf_path = None
-    return _shelf_path
+        from flask import current_app, has_app_context
+    except ModuleNotFoundError:
+        return True
+    if not has_app_context():
+        return True
+    uri = str(current_app.config.get('SQLALCHEMY_DATABASE_URI', '')).lower()
+    return not (uri.startswith('postgresql://') or uri.startswith('postgres://'))
+
+
+def _matches_prefix(key: str, prefix: str) -> bool:
+    """Return whether ``key`` belongs to a delimited cache namespace.
+
+    A trailing colon is the tournament boundary. It matches both the namespace
+    root (for example ``portal:college:1``) and children below it, but never a
+    larger tournament ID such as ``portal:college:10``.
+    """
+    if not prefix:
+        return True
+    if prefix.endswith(':'):
+        return key == prefix[:-1] or key.startswith(prefix)
+    return key.startswith(prefix)
+
+
+def _generation_for_key_locked(key: str) -> int:
+    return max(
+        (
+            generation
+            for prefix, generation in _prefix_generations.items()
+            if _matches_prefix(key, prefix)
+        ),
+        default=0,
+    )
+
+
+def _miss_generations() -> dict[str, int]:
+    misses = getattr(_read_state, 'misses', None)
+    if misses is None:
+        misses = {}
+        _read_state.misses = misses
+    return misses
+
+
+def _get_shelf_path() -> str | None:
+    """Return ``None`` because cache generations are process-local."""
+    global _shelf_path, _shelf_resolved
+    _shelf_resolved = True
+    _shelf_path = None
+    return None
 
 
 def _shelf_get(key: str):
-    path = _get_shelf_path()
-    if not path:
-        return None
-    try:
-        with shelve.open(path, flag='c') as shelf:
-            item = shelf.get(key)
-        if not item:
-            return None
-        if item['expires_at'] < time.time():
-            _shelf_delete(key)
-            return None
-        return item['value']
-    except Exception as exc:
-        logger.debug('Disk cache read error for %s: %s', key, exc)
-        return None
+    return None
 
 
 def _shelf_set(key: str, value, expires_at: float) -> None:
-    path = _get_shelf_path()
-    if not path:
-        return
-    try:
-        with shelve.open(path, flag='c') as shelf:
-            shelf[key] = {'value': value, 'expires_at': expires_at}
-    except Exception as exc:
-        logger.debug('Disk cache write error for %s: %s', key, exc)
+    return None
 
 
 def _shelf_delete(key: str) -> None:
-    path = _get_shelf_path()
-    if not path:
-        return
-    try:
-        with shelve.open(path, flag='c') as shelf:
-            shelf.pop(key, None)
-    except Exception:
-        pass
+    return None
 
 
 def _shelf_delete_prefix(prefix: str) -> None:
-    path = _get_shelf_path()
-    if not path:
-        return
-    try:
-        with shelve.open(path, flag='c') as shelf:
-            doomed = [k for k in shelf.keys() if k.startswith(prefix)]
-            for k in doomed:
-                del shelf[k]
-    except Exception as exc:
-        logger.debug('Disk cache prefix-delete error: %s', exc)
+    return None
 
 
 # Deep enough for a report payload (dict -> list -> row dict -> entity), and
@@ -138,45 +139,61 @@ def _contains_orm_entity(value, depth: int = 0) -> bool:
 
 
 def get(key: str):
+    if not _cache_enabled():
+        return None
     now = time.time()
     with _lock:
+        generation = _generation_for_key_locked(key)
         item = _cache.get(key)
         if item:
             if item['expires_at'] >= now:
+                _miss_generations().pop(key, None)
                 return item['value']
             _cache.pop(key, None)
 
-    # L2: disk
-    value = _shelf_get(key)
-    if value is not None:
-        # Warm L1 — TTL already validated by _shelf_get.
-        with _lock:
+        # Keep disk access serialized with invalidation. A reader that starts
+        # after an invalidation cannot observe the pre-delete shelf entry.
+        value = _shelf_get(key)
+        if value is not None:
+            # Warm L1 — TTL already validated by _shelf_get.
             _cache[key] = {'value': value, 'expires_at': now + 60}
-    return value
+            _miss_generations().pop(key, None)
+            return value
+
+        _miss_generations()[key] = generation
+        return None
 
 
 def set(key: str, value, ttl_seconds: int) -> None:
+    if not _cache_enabled():
+        return
     ttl_seconds = max(1, int(ttl_seconds))
     expires_at = time.time() + ttl_seconds
+    contains_orm_entity = _contains_orm_entity(value)
+    miss_generation = _miss_generations().pop(key, None)
     with _lock:
+        if (
+            miss_generation is not None
+            and miss_generation != _generation_for_key_locked(key)
+        ):
+            logger.debug('Discarding stale cache fill for %s after invalidation.', key)
+            return
         _cache[key] = {'value': value, 'expires_at': expires_at}
-    if _contains_orm_entity(value):
-        # L1 is fine: the objects stay in the process that loaded them. L2 is
-        # not, for the reason spelled out in the module docstring. Keep the
-        # in-memory entry, refuse the disk one, and make the mistake loud
-        # rather than letting it surface later as a render-time 500.
-        logger.warning(
-            'Refusing disk cache write for %s: payload contains SQLAlchemy '
-            'entities, which unpickle detached. Serialize to plain data '
-            'before caching.', key)
-        return
-    _shelf_set(key, value, expires_at)
+        if contains_orm_entity:
+            logger.warning(
+                'Cache payload for %s contains SQLAlchemy entities. Serialize '
+                'to plain data so cached values do not outlive their session.', key)
+            return
+        _shelf_set(key, value, expires_at)
 
 
 def invalidate_prefix(prefix: str) -> None:
+    global _generation_counter
     with _lock:
-        doomed = [k for k in _cache.keys() if k.startswith(prefix)]
+        _generation_counter += 1
+        _prefix_generations[prefix] = _generation_counter
+        doomed = [k for k in _cache.keys() if _matches_prefix(k, prefix)]
         for key in doomed:
             _cache.pop(key, None)
-    _shelf_delete_prefix(prefix)
+        _shelf_delete_prefix(prefix)
 

--- a/services/reporting_backup.py
+++ b/services/reporting_backup.py
@@ -5,6 +5,7 @@ import os
 
 from services.background_jobs import submit as submit_job
 from services.backup import backup_database as run_backup_database
+from services.backup import create_sqlite_snapshot
 
 
 def sqlite_backup_download_plan(db_uri: str, instance_path: str) -> dict:
@@ -27,7 +28,22 @@ def sqlite_backup_download_plan(db_uri: str, instance_path: str) -> dict:
             'message': 'Database file not found.',
         }
 
-    return {'ok': True, 'path': db_path}
+    try:
+        snapshot = create_sqlite_snapshot(db_path)
+    except Exception as exc:
+        return {
+            'ok': False,
+            'reason': 'validation_failed',
+            'message': f'Could not create a recoverable SQLite backup: {exc}',
+        }
+
+    return {
+        'ok': True,
+        'path': snapshot['path'],
+        'cleanup': True,
+        'sha256': snapshot['sha256'],
+        'size_bytes': snapshot['size_bytes'],
+    }
 
 
 def run_database_backup(db_uri: str, tournament_id: int, instance_path: str) -> dict:

--- a/services/reporting_export.py
+++ b/services/reporting_export.py
@@ -5,14 +5,24 @@ download naming, JSON payload assembly, and async job submission details.
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
 import os
 import tempfile
+import threading
+import time
+from pathlib import Path
 
 from database import db
 from models import Tournament
 from services.background_jobs import submit as submit_job
 from services.excel_io import export_results_to_excel
 from services.handicap_export import build_chopping_rows, export_chopping_results_to_excel
+
+_EXPORT_PREFIX = 'proam_export_'
+_EXPORT_MAX_AGE_SECONDS = 60 * 60
+_EXPORT_MAX_FILES = 100
+_export_reservation_lock = threading.Lock()
 
 
 def safe_download_name(tournament: Tournament, suffix: str) -> str:
@@ -21,12 +31,104 @@ def safe_download_name(tournament: Tournament, suffix: str) -> str:
 
 
 def _reserve_export_path(tournament_id: int, *, suffix: str = '.xlsx', label: str = '') -> str:
-    prefix = f'proam_{tournament_id}_'
-    if label:
-        prefix = f'{prefix}{label}_'
-    fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix)
-    os.close(fd)
-    return path
+    with _export_reservation_lock:
+        prune_export_artifacts(reserve_slots=1)
+        prefix = f'{_EXPORT_PREFIX}{tournament_id}_'
+        if label:
+            prefix = f'{prefix}{label}_'
+        fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix)
+        os.close(fd)
+        return path
+
+
+def prune_export_artifacts(
+    *,
+    directory: str | None = None,
+    now: float | None = None,
+    max_age_seconds: int = _EXPORT_MAX_AGE_SECONDS,
+    max_files: int = _EXPORT_MAX_FILES,
+    reserve_slots: int = 0,
+) -> int:
+    """Bound retryable async artifacts by age and count.
+
+    Files remain available for repeat download for up to one hour. Each new
+    export performs best-effort cleanup; open Windows files are left for the
+    next pass instead of making a new export fail.
+    """
+    root = Path(directory or tempfile.gettempdir())
+    current_time = time.time() if now is None else float(now)
+    candidates = []
+    for path in root.glob(f'{_EXPORT_PREFIX}*.xlsx'):
+        try:
+            if path.is_file():
+                candidates.append((path.stat().st_mtime, path))
+        except OSError:
+            continue
+    candidates.sort(key=lambda item: (item[0], item[1].name))
+    expired = {
+        path for modified, path in candidates
+        if current_time - modified > max(1, int(max_age_seconds))
+    }
+    survivors = [item for item in candidates if item[1] not in expired]
+    overflow = max(
+        0,
+        len(survivors) + max(0, int(reserve_slots)) - max(0, int(max_files)),
+    )
+    doomed = expired | {path for _modified, path in survivors[:overflow]}
+    removed = 0
+    for path in doomed:
+        try:
+            path.unlink()
+            removed += 1
+        except OSError:
+            pass
+    return removed
+
+
+def _sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, 'rb') as artifact:
+        for chunk in iter(lambda: artifact.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+class ExportArtifactError(RuntimeError):
+    """Raised when an export cannot be opened and verified for delivery."""
+
+
+def open_verified_export(job: dict):
+    """Open and hash the exact file descriptor that the response will stream."""
+    artifact = job.get('result')
+    if not isinstance(artifact, dict):
+        raise ExportArtifactError(
+            'Export artifact has no checksum metadata and cannot be verified.'
+        )
+    path = artifact.get('path')
+    expected_sha256 = artifact.get('sha256')
+    if not path or not expected_sha256:
+        raise ExportArtifactError(
+            'Export artifact has no checksum metadata and cannot be verified.'
+        )
+    try:
+        handle = open(path, 'rb')
+    except OSError as exc:
+        raise ExportArtifactError(
+            'Export artifact is no longer readable on this application instance.'
+        ) from exc
+    try:
+        digest = hashlib.sha256()
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+        if not hmac.compare_digest(digest.hexdigest(), str(expected_sha256).lower()):
+            raise ExportArtifactError(
+                'Export artifact checksum verification failed; the file changed.'
+            )
+        handle.seek(0)
+        return handle
+    except BaseException:
+        handle.close()
+        raise
 
 
 def build_results_export(tournament: Tournament) -> dict:
@@ -38,6 +140,7 @@ def build_results_export(tournament: Tournament) -> dict:
         'download_name': safe_download_name(tournament, 'results.xlsx'),
         'format': 'xlsx',
         'kind': 'all_results',
+        'sha256': _sha256_file(path),
     }
 
 
@@ -50,6 +153,7 @@ def build_chopping_export(tournament: Tournament) -> dict:
         'download_name': safe_download_name(tournament, 'chopping_results.xlsx'),
         'format': 'xlsx',
         'kind': 'chopping_results',
+        'sha256': _sha256_file(path),
     }
 
 
@@ -65,12 +169,12 @@ def build_chopping_json_payload(tournament: Tournament) -> dict:
     }
 
 
-def build_results_export_for_job(tournament_id: int) -> str:
+def build_results_export_for_job(tournament_id: int) -> dict:
     """Background-job entry point for a full results export."""
     tournament = db.session.get(Tournament, tournament_id)
     if not tournament:
         raise RuntimeError(f'Tournament {tournament_id} not found.')
-    return build_results_export(tournament)['path']
+    return build_results_export(tournament)
 
 
 def submit_results_export_job(tournament_id: int) -> str:
@@ -95,15 +199,16 @@ def build_video_judge_export(tournament: Tournament) -> dict:
         'download_name': safe_download_name(tournament, 'video_judge_sheets.xlsx'),
         'format': 'xlsx',
         'kind': 'video_judge_sheets',
+        'sha256': _sha256_file(path),
     }
 
 
-def build_video_judge_export_for_job(tournament_id: int) -> str:
+def build_video_judge_export_for_job(tournament_id: int) -> dict:
     """Background-job entry point for the Video Judge workbook."""
     tournament = db.session.get(Tournament, tournament_id)
     if not tournament:
         raise RuntimeError(f'Tournament {tournament_id} not found.')
-    return build_video_judge_export(tournament)['path']
+    return build_video_judge_export(tournament)
 
 
 def submit_video_judge_export_job(tournament_id: int) -> str:
@@ -122,4 +227,31 @@ def resolve_completed_export_path(tournament_id: int, job_id: str, job_getter) -
     job_meta = job.get('metadata') if job else {}
     if not job or int((job_meta or {}).get('tournament_id', -1)) != tournament_id:
         return None
+
+    if job.get('status') != 'completed' or (job_meta or {}).get('kind') == 'build_pro_flights':
+        return job
+
+    def expired(message: str) -> dict:
+        snapshot = dict(job)
+        snapshot['status'] = 'expired'
+        snapshot['error'] = message
+        return snapshot
+
+    artifact = job.get('result')
+    if not isinstance(artifact, dict):
+        return expired('Export artifact has no checksum metadata and cannot be verified.')
+
+    path = artifact.get('path')
+    expected_sha256 = artifact.get('sha256')
+    if not path or not expected_sha256:
+        return expired('Export artifact has no checksum metadata and cannot be verified.')
+    if not os.path.isfile(path):
+        return expired('Export artifact no longer exists on this application instance.')
+
+    try:
+        actual_sha256 = _sha256_file(path)
+    except OSError:
+        return expired('Export artifact is no longer readable on this application instance.')
+    if not hmac.compare_digest(actual_sha256, str(expected_sha256).lower()):
+        return expired('Export artifact checksum verification failed; the file changed.')
     return job

--- a/services/restore_workflow.py
+++ b/services/restore_workflow.py
@@ -1,27 +1,358 @@
+"""Validated staging and offline-only SQLite restore workflow."""
 from __future__ import annotations
 
+import argparse
+import hashlib
+import hmac
+import json
 import os
+import shutil
 import sqlite3
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+import weakref
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
 
+from services.backup import create_sqlite_snapshot, sha256_file
 from services.upload_security import malware_scan
 
-REQUIRED_SQLITE_TABLES = {'tournaments', 'events', 'event_results', 'heats', 'users'}
+STAGING_DIRNAME = '.restore-staging'
+PACKAGE_VERSION = 2
+ACTIVE_JOB_STATUSES = ('queued', 'running')
+SQLITE_SIDECAR_SUFFIXES = ('-wal', '-shm')
+_PROCESS_FENCES: dict[str, dict[str, object]] = {}
+_PROCESS_FENCES_LOCK = threading.Lock()
+
+
+class RestoreValidationError(RuntimeError):
+    """Raised when a restore artifact fails a recovery invariant."""
+
+
+class MaintenanceFenceBusy(RuntimeError):
+    """Raised when another process owns an incompatible database fence."""
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _read_only_connection(path: str) -> sqlite3.Connection:
+    resolved = Path(path).resolve()
+    if not resolved.is_file():
+        raise RestoreValidationError(f'SQLite database file not found: {resolved}')
+    return sqlite3.connect(f'{resolved.as_uri()}?mode=ro', uri=True, timeout=30)
+
+
+def _fsync_file(path: Path) -> None:
+    with path.open('r+b') as handle:
+        os.fsync(handle.fileno())
+
+
+def _fsync_directory(path: Path) -> None:
+    if os.name == 'nt':
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _chmod_if_supported(path: Path, mode: int) -> None:
+    """Restrict restore material on filesystems that expose POSIX-like modes."""
+    try:
+        os.chmod(path, mode)
+    except (NotImplementedError, OSError):
+        if os.name != 'nt':
+            raise
+
+
+def _restrict_windows_acl(path: Path) -> None:
+    """Set and verify a protected ACL containing only the process identity."""
+    script_body = r'''
+$ErrorActionPreference = 'Stop'
+$target = [Environment]::GetEnvironmentVariable('PROAM_RESTORE_ACL_TARGET')
+$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+$item = Get-Item -LiteralPath $target
+if ($item.PSIsContainer) {
+    $acl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]'ContainerInherit,ObjectInherit'
+} else {
+    $acl = [System.Security.AccessControl.FileSecurity]::new()
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
+}
+$acl.SetAccessRuleProtection($true, $false)
+$rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+    $sid,
+    [System.Security.AccessControl.FileSystemRights]::FullControl,
+    $inheritance,
+    [System.Security.AccessControl.PropagationFlags]::None,
+    [System.Security.AccessControl.AccessControlType]::Allow
+)
+$acl.SetAccessRule($rule)
+$item.SetAccessControl($acl)
+$verified = $item.GetAccessControl(
+    [System.Security.AccessControl.AccessControlSections]::Access
+)
+$rules = @($verified.GetAccessRules(
+    $true,
+    $false,
+    [System.Security.Principal.SecurityIdentifier]
+))
+$full = [System.Security.AccessControl.FileSystemRights]::FullControl
+if (-not $verified.AreAccessRulesProtected -or
+    $rules.Count -ne 1 -or
+    $rules[0].IdentityReference.Value -ne $sid.Value -or
+    $rules[0].AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
+    (($rules[0].FileSystemRights -band $full) -ne $full)) {
+    throw 'Restore ACL verification failed.'
+}
+'''.strip()
+    script = f'& {{\n{script_body}\n}}'
+    result = subprocess.run(
+        [
+            'powershell.exe',
+            '-NoProfile',
+            '-NonInteractive',
+            '-ExecutionPolicy',
+            'Bypass',
+            '-Command',
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+        env={**os.environ, 'PROAM_RESTORE_ACL_TARGET': str(path)},
+    )
+    if result.returncode != 0:
+        raise RestoreValidationError(
+            'Could not establish and verify a private Windows ACL for restore material.'
+        )
+
+
+def _restrict_restore_path(path: Path, mode: int) -> None:
+    _chmod_if_supported(path, mode)
+    if os.name == 'nt':
+        _restrict_windows_acl(path)
+
+
+def _remove_incomplete_package(package_dir: Path, staging_root: Path) -> None:
+    resolved_package = package_dir.resolve()
+    resolved_root = staging_root.resolve()
+    if resolved_package.parent != resolved_root:
+        raise RuntimeError('Refusing to remove a restore package outside its staging root.')
+    if resolved_package.exists():
+        shutil.rmtree(resolved_package)
+        _fsync_directory(resolved_root)
+
+
+def _mkdir_private(path: Path, *, parents: bool = True, exist_ok: bool = True) -> None:
+    path.mkdir(parents=parents, exist_ok=exist_ok)
+    _chmod_if_supported(path, 0o700)
+
+
+def _write_json_atomic(path: Path, payload: dict) -> None:
+    _mkdir_private(path.parent)
+    fd, temp_name = tempfile.mkstemp(prefix=f'.{path.name}.', dir=path.parent)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8', newline='\n') as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write('\n')
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        _chmod_if_supported(path, 0o600)
+        _fsync_directory(path.parent)
+    except BaseException:
+        try:
+            os.remove(temp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _append_journal(path: Path, event: str, **fields) -> None:
+    entry = {'at': _utc_iso(), 'event': event, **fields}
+    _mkdir_private(path.parent)
+    with path.open('a', encoding='utf-8', newline='\n') as handle:
+        _chmod_if_supported(path, 0o600)
+        handle.write(json.dumps(entry, sort_keys=True, default=str))
+        handle.write('\n')
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _sqlite_health(path: str) -> dict:
+    try:
+        conn = _read_only_connection(path)
+        try:
+            integrity = [row[0] for row in conn.execute('PRAGMA integrity_check')]
+            if integrity != ['ok']:
+                raise RestoreValidationError('Restore file failed SQLite integrity check.')
+            fk_violation = conn.execute('PRAGMA foreign_key_check').fetchone()
+            if fk_violation is not None:
+                raise RestoreValidationError('Restore file failed foreign key validation.')
+        finally:
+            conn.close()
+    except RestoreValidationError:
+        raise
+    except sqlite3.Error as exc:
+        raise RestoreValidationError(f'Restore file is not a readable SQLite database: {exc}') from exc
+    return {'integrity_check': 'ok', 'foreign_key_violations': 0}
+
+
+def _quote_sqlite_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _application_table_names(conn: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+        )
+    }
+
+
+def _application_table_structure(
+    conn: sqlite3.Connection,
+    table_names: set[str],
+) -> dict[str, dict]:
+    structure = {}
+    for table_name in sorted(table_names):
+        quoted_table = _quote_sqlite_identifier(table_name)
+        table_definition_row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        ).fetchone()
+        table_definition = (
+            table_definition_row[0] if table_definition_row else None
+        )
+        try:
+            table_columns = list(conn.execute(f'PRAGMA table_xinfo({quoted_table})'))
+        except sqlite3.DatabaseError:
+            table_columns = list(conn.execute(f'PRAGMA table_info({quoted_table})'))
+        columns = [
+            {
+                'name': str(row[1]),
+                'type': str(row[2] or '').strip().upper(),
+                'not_null': bool(row[3]),
+                'default': None if row[4] is None else str(row[4]),
+                'primary_key_position': int(row[5]),
+                'hidden': int(row[6]) if len(row) > 6 else 0,
+            }
+            for row in table_columns
+        ]
+        foreign_keys = sorted(
+            (
+                {
+                    'id': int(row[0]),
+                    'sequence': int(row[1]),
+                    'table': str(row[2]),
+                    'from': str(row[3]),
+                    'to': None if row[4] is None else str(row[4]),
+                    'on_update': str(row[5]).upper(),
+                    'on_delete': str(row[6]).upper(),
+                    'match': str(row[7]).upper(),
+                }
+                for row in conn.execute(f'PRAGMA foreign_key_list({quoted_table})')
+            ),
+            key=lambda item: (item['id'], item['sequence']),
+        )
+        indexes = []
+        for row in conn.execute(f'PRAGMA index_list({quoted_table})'):
+            index_name = str(row[1])
+            quoted_index = _quote_sqlite_identifier(index_name)
+            definition_row = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+                (index_name,),
+            ).fetchone()
+            definition = definition_row[0] if definition_row else None
+            index_columns = [
+                {
+                    'sequence': int(info[0]),
+                    'column_id': int(info[1]),
+                    'name': None if info[2] is None else str(info[2]),
+                }
+                for info in conn.execute(f'PRAGMA index_info({quoted_index})')
+            ]
+            indexes.append(
+                {
+                    'name': index_name,
+                    'unique': bool(row[2]),
+                    'origin': str(row[3]),
+                    'partial': bool(row[4]),
+                    'definition': (
+                        None if definition is None else ' '.join(str(definition).split())
+                    ),
+                    'columns': index_columns,
+                }
+            )
+        structure[table_name] = {
+            'definition': (
+                None
+                if table_definition is None
+                else ' '.join(str(table_definition).split())
+            ),
+            'columns': columns,
+            'foreign_keys': foreign_keys,
+            'indexes': sorted(indexes, key=lambda item: item['name']),
+            'triggers': [
+                {
+                    'name': str(row[0]),
+                    'definition': ' '.join(str(row[1]).split()),
+                }
+                for row in conn.execute(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE type = 'trigger' AND tbl_name = ? ORDER BY name",
+                    (table_name,),
+                )
+                if row[1] is not None
+            ],
+        }
+    return structure
+
+
+def _canonical_sha256(payload) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=True,
+    ).encode('utf-8')
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def sqlite_schema_info(path: str) -> dict:
-    conn = sqlite3.connect(path)
     try:
-        tables = {
-            row[0]
-            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        }
-        revision = None
-        if 'alembic_version' in tables:
-            row = conn.execute('SELECT version_num FROM alembic_version LIMIT 1').fetchone()
-            revision = row[0] if row else None
-        return {'tables': tables, 'revision': revision}
-    finally:
-        conn.close()
+        conn = _read_only_connection(path)
+        try:
+            tables = _application_table_names(conn)
+            revision = None
+            if 'alembic_version' in tables:
+                row = conn.execute('SELECT version_num FROM alembic_version LIMIT 1').fetchone()
+                revision = row[0] if row else None
+            required_structure = _application_table_structure(conn, tables)
+            return {
+                'tables': tables,
+                'revision': revision,
+                'required_structure': required_structure,
+                'required_structure_sha256': _canonical_sha256(required_structure),
+            }
+        finally:
+            conn.close()
+    except RestoreValidationError:
+        raise
+    except (sqlite3.Error, TypeError, ValueError) as exc:
+        raise RestoreValidationError(f'Could not inspect SQLite schema: {exc}') from exc
 
 
 def sqlite_db_path_from_uri(uri: str, instance_path: str) -> str:
@@ -30,29 +361,167 @@ def sqlite_db_path_from_uri(uri: str, instance_path: str) -> str:
     db_path = uri.replace('sqlite:///', '', 1)
     if not os.path.isabs(db_path):
         db_path = os.path.join(instance_path, db_path)
-    return db_path
+    return str(Path(db_path).resolve())
 
 
-def validate_sqlite_restore_file(upload_path: str, current_db_path: str) -> dict:
+def _tournament_identity(path: str, tournament_id: int) -> tuple[int, str, int] | None:
+    conn = _read_only_connection(path)
+    try:
+        row = conn.execute(
+            'SELECT id, name, year FROM tournaments WHERE id = ?',
+            (tournament_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return None
+    return int(row[0]), str(row[1]), int(row[2])
+
+
+def _database_identity(path: str) -> tuple[list[tuple[int, str, int]], str]:
+    conn = _read_only_connection(path)
+    try:
+        identities = [
+            (int(row[0]), str(row[1]), int(row[2]))
+            for row in conn.execute(
+                'SELECT id, name, year FROM tournaments ORDER BY id, name, year'
+            )
+        ]
+    except (sqlite3.Error, TypeError, ValueError) as exc:
+        raise RestoreValidationError(
+            f'Could not establish restore database identity: {exc}'
+        ) from exc
+    finally:
+        conn.close()
+    return identities, _canonical_sha256(identities)
+
+
+def sqlite_audit_chain_head(path: str) -> str | None:
+    """Hash audit rows in order without exposing row data outside this process."""
+    conn = _read_only_connection(path)
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        if 'audit_logs' not in tables:
+            return None
+        columns = [row[1] for row in conn.execute('PRAGMA table_info(audit_logs)')]
+        if not columns:
+            return None
+        quoted = ', '.join(f'"{column}"' for column in columns)
+        ordering = 'id' if 'id' in columns else 'rowid'
+        digest = hashlib.sha256()
+        for row in conn.execute(f'SELECT {quoted} FROM audit_logs ORDER BY {ordering}'):
+            digest.update(
+                json.dumps(row, separators=(',', ':'), default=str).encode('utf-8')
+            )
+            digest.update(b'\n')
+        return digest.hexdigest()
+    finally:
+        conn.close()
+
+
+def validate_sqlite_restore_file(
+    upload_path: str,
+    current_db_path: str,
+    *,
+    tournament_id: int | None = None,
+    expected_checksum: str | None = None,
+    expected_schema_sha256: str | None = None,
+    expected_database_identity_sha256: str | None = None,
+) -> dict:
     current_info = sqlite_schema_info(current_db_path)
     uploaded_info = sqlite_schema_info(upload_path)
-    missing_tables = sorted(REQUIRED_SQLITE_TABLES - set(uploaded_info['tables']))
-    if missing_tables:
-        raise RuntimeError(
-            f'Restore file is missing required tables: {", ".join(missing_tables)}'
+    health = _sqlite_health(upload_path)
+    current_tables = set(current_info['tables'])
+    uploaded_tables = set(uploaded_info['tables'])
+    missing_tables = sorted(current_tables - uploaded_tables)
+    unexpected_tables = sorted(uploaded_tables - current_tables)
+    if missing_tables or unexpected_tables:
+        details = []
+        if missing_tables:
+            details.append(f'missing: {", ".join(missing_tables)}')
+        if unexpected_tables:
+            details.append(f'unexpected: {", ".join(unexpected_tables)}')
+        raise RestoreValidationError(
+            'Restore file is missing required tables from the current application '
+            f'tables or contains unexpected application tables ({"; ".join(details)}).'
         )
     if not uploaded_info.get('revision'):
-        raise RuntimeError('Restore file is missing Alembic migration metadata.')
+        raise RestoreValidationError('Restore file is missing Alembic migration metadata.')
     if current_info.get('revision') and uploaded_info['revision'] != current_info['revision']:
-        raise RuntimeError(
+        raise RestoreValidationError(
             'Restore file schema revision does not match the current application schema. '
             f"Expected {current_info['revision']}, got {uploaded_info['revision']}."
         )
+
+    current_schema_sha = current_info['required_structure_sha256']
+    uploaded_schema_sha = uploaded_info['required_structure_sha256']
+    authoritative_schema_sha = expected_schema_sha256 or current_schema_sha
+    if not hmac.compare_digest(uploaded_schema_sha, authoritative_schema_sha):
+        raise RestoreValidationError(
+            'Restore file required-table structure does not match the authoritative '
+            'complete application-table structure.'
+        )
+    if expected_schema_sha256 and not hmac.compare_digest(
+        current_schema_sha, expected_schema_sha256,
+    ):
+        raise RestoreValidationError(
+            'Target database required-table structure no longer matches the staged '
+            'complete application-table structure.'
+        )
+
+    source_checksum = sha256_file(upload_path)
+    if expected_checksum and not hmac.compare_digest(source_checksum, expected_checksum):
+        raise RestoreValidationError('Restore package checksum does not match its staged manifest.')
+
+    identity_matches = tournament_id is None
+    if tournament_id is not None:
+        current_identity = _tournament_identity(current_db_path, tournament_id)
+        uploaded_identity = _tournament_identity(upload_path, tournament_id)
+        if current_identity is None:
+            raise RestoreValidationError('Target database does not contain the selected tournament.')
+        if uploaded_identity is None:
+            raise RestoreValidationError('Restore file does not contain the selected tournament.')
+        if uploaded_identity != current_identity:
+            raise RestoreValidationError(
+                'Restore file tournament identity does not match the selected tournament.'
+            )
+        identity_matches = True
+
+    _, current_identity_sha = _database_identity(current_db_path)
+    uploaded_identities, uploaded_identity_sha = _database_identity(upload_path)
+    authoritative_identity_sha = (
+        expected_database_identity_sha256 or current_identity_sha
+    )
+    if not hmac.compare_digest(uploaded_identity_sha, authoritative_identity_sha):
+        raise RestoreValidationError(
+            'Restore file database identity does not match the complete tournament '
+            'set in the authoritative database.'
+        )
+    if expected_database_identity_sha256 and not hmac.compare_digest(
+        current_identity_sha, expected_database_identity_sha256,
+    ):
+        raise RestoreValidationError(
+            'Target database identity no longer matches the staged restore package.'
+        )
+
     return {
-        'target_path': current_db_path,
+        'target_path': str(Path(current_db_path).resolve()),
         'current_revision': current_info.get('revision'),
         'uploaded_revision': uploaded_info.get('revision'),
         'tables': uploaded_info['tables'],
+        'integrity_check': health['integrity_check'],
+        'foreign_key_violations': health['foreign_key_violations'],
+        'tournament_identity_matches': identity_matches,
+        'database_identity_matches': True,
+        'database_identity_sha256': uploaded_identity_sha,
+        'database_identity_tournament_count': len(uploaded_identities),
+        'required_schema_matches': True,
+        'required_schema_sha256': uploaded_schema_sha,
+        'source_sha256': source_checksum,
+        'audit_chain_head': sqlite_audit_chain_head(upload_path),
     }
 
 
@@ -61,13 +530,938 @@ def prepare_sqlite_restore(
     upload_path: str,
     db_uri: str,
     instance_path: str,
+    tournament_id: int | None = None,
     malware_scan_enabled: bool = False,
     malware_scan_command: str = '',
 ) -> dict:
+    """Scan and validate a restore upload without changing the live database."""
     target_path = sqlite_db_path_from_uri(db_uri, instance_path)
     malware_scan(
         upload_path,
         enabled=malware_scan_enabled,
         command_template=malware_scan_command,
     )
-    return validate_sqlite_restore_file(upload_path, target_path)
+    return validate_sqlite_restore_file(
+        upload_path,
+        target_path,
+        tournament_id=tournament_id,
+    )
+
+
+def stage_sqlite_restore(
+    *,
+    upload_path: str,
+    db_uri: str,
+    instance_path: str,
+    tournament_id: int,
+    actor: str,
+    source_filename: str,
+    malware_scan_enabled: bool = False,
+    malware_scan_command: str = '',
+) -> dict:
+    """Validate an upload and create a same-volume offline restore package."""
+    target_path = Path(sqlite_db_path_from_uri(db_uri, instance_path)).resolve()
+    validation = prepare_sqlite_restore(
+        upload_path=upload_path,
+        db_uri=db_uri,
+        instance_path=instance_path,
+        tournament_id=tournament_id,
+        malware_scan_enabled=malware_scan_enabled,
+        malware_scan_command=malware_scan_command,
+    )
+
+    stage_id = uuid.uuid4().hex
+    staging_root = target_path.parent / STAGING_DIRNAME
+    _mkdir_private(staging_root)
+    package_dir = staging_root / stage_id
+    _mkdir_private(package_dir, parents=False, exist_ok=False)
+    staged_db = package_dir / 'restore.db'
+    journal = package_dir / 'restore-journal.jsonl'
+    try:
+        _restrict_restore_path(package_dir, 0o700)
+        _append_journal(
+            journal,
+            'phase_started',
+            phase='stage_copy',
+            actor=actor,
+            source_sha256=validation['source_sha256'],
+            audit_chain_head=validation['audit_chain_head'],
+        )
+        shutil.copyfile(upload_path, staged_db)
+        _restrict_restore_path(staged_db, 0o600)
+        _fsync_file(staged_db)
+        staged_validation = validate_sqlite_restore_file(
+            str(staged_db),
+            str(target_path),
+            tournament_id=tournament_id,
+            expected_checksum=validation['source_sha256'],
+            expected_schema_sha256=validation['required_schema_sha256'],
+            expected_database_identity_sha256=validation[
+                'database_identity_sha256'
+            ],
+        )
+        manifest = {
+            'package_version': PACKAGE_VERSION,
+            'stage_id': stage_id,
+            'status': 'staged',
+            'phase': 'staged',
+            'staged_at': _utc_iso(),
+            'actor': actor,
+            'source_filename': os.path.basename(source_filename),
+            'source_sha256': staged_validation['source_sha256'],
+            'source_size_bytes': staged_db.stat().st_size,
+            'source_audit_chain_head': staged_validation['audit_chain_head'],
+            'target_path': str(target_path),
+            'target_sha256_at_stage': sha256_file(str(target_path)),
+            'tournament_id': tournament_id,
+            'database_identity_sha256': staged_validation['database_identity_sha256'],
+            'database_identity_tournament_count': staged_validation[
+                'database_identity_tournament_count'
+            ],
+            'required_schema_sha256': staged_validation['required_schema_sha256'],
+            'schema_revision': staged_validation['uploaded_revision'],
+            'validation': {
+                'integrity_check': staged_validation['integrity_check'],
+                'foreign_key_violations': staged_validation['foreign_key_violations'],
+                'tournament_identity_matches': True,
+                'database_identity_matches': True,
+                'required_schema_matches': True,
+            },
+        }
+        _write_json_atomic(package_dir / 'manifest.json', manifest)
+        _append_journal(
+            journal,
+            'phase_completed',
+            phase='stage_copy',
+            actor=actor,
+            source_sha256=manifest['source_sha256'],
+            audit_chain_head=manifest['source_audit_chain_head'],
+            validation=manifest['validation'],
+        )
+        return {
+            'ok': True,
+            'stage_id': stage_id,
+            'package_dir': str(package_dir),
+            'manifest_path': str(package_dir / 'manifest.json'),
+            'source_sha256': manifest['source_sha256'],
+            'validation': manifest['validation'],
+        }
+    except BaseException as exc:
+        try:
+            _append_journal(
+                journal,
+                'phase_failed',
+                phase='stage_copy',
+                actor=actor,
+                error=type(exc).__name__,
+            )
+        finally:
+            _remove_incomplete_package(package_dir, staging_root)
+        raise
+
+
+class _FileFence:
+    def __init__(self, db_path: str, *, exclusive: bool):
+        self.path = Path(f'{Path(db_path).resolve()}.maintenance.lock')
+        self.exclusive = exclusive
+        self.handle = None
+        self.acquired = False
+
+    def acquire(self, timeout: float) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.handle = self.path.open('a+b')
+        self.handle.seek(0, os.SEEK_END)
+        if self.handle.tell() == 0:
+            self.handle.write(b'0')
+            self.handle.flush()
+            os.fsync(self.handle.fileno())
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            try:
+                self.handle.seek(0)
+                if os.name == 'nt':
+                    import msvcrt
+
+                    mode = msvcrt.LK_NBLCK if self.exclusive else msvcrt.LK_NBRLCK
+                    msvcrt.locking(self.handle.fileno(), mode, 1)
+                else:
+                    import fcntl
+
+                    mode = fcntl.LOCK_EX if self.exclusive else fcntl.LOCK_SH
+                    fcntl.flock(self.handle.fileno(), mode | fcntl.LOCK_NB)
+                self.acquired = True
+                return
+            except OSError as exc:
+                if time.monotonic() >= deadline:
+                    self.close()
+                    raise MaintenanceFenceBusy(str(self.path)) from exc
+                time.sleep(0.05)
+
+    def release(self) -> None:
+        if not self.acquired or self.handle is None:
+            return
+        try:
+            self.handle.seek(0)
+            if os.name == 'nt':
+                import msvcrt
+
+                msvcrt.locking(self.handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self.handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self.acquired = False
+
+    def close(self) -> None:
+        try:
+            self.release()
+        finally:
+            if self.handle is not None:
+                self.handle.close()
+                self.handle = None
+
+
+@contextmanager
+def database_activity_fence(db_path: str, *, exclusive: bool, timeout: float = 0):
+    fence = _FileFence(db_path, exclusive=exclusive)
+    fence.acquire(timeout)
+    try:
+        yield fence
+    finally:
+        fence.close()
+
+
+def configure_sqlite_process_fence(app) -> None:
+    """Hold a shared fence for the life of a SQLite web process."""
+    uri = app.config.get('SQLALCHEMY_DATABASE_URI', '')
+    if not uri.startswith('sqlite:///'):
+        return
+    if app.extensions.get('sqlite_process_fence') is not None:
+        return
+    db_path = sqlite_db_path_from_uri(uri, app.instance_path)
+    fence_key = str(Path(db_path).resolve())
+    with _PROCESS_FENCES_LOCK:
+        entry = _PROCESS_FENCES.get(fence_key)
+        if entry is None:
+            fence = _FileFence(db_path, exclusive=False)
+            try:
+                fence.acquire(0)
+            except MaintenanceFenceBusy as exc:
+                raise RuntimeError(
+                    'SQLite offline maintenance is active; web startup is blocked.'
+                ) from exc
+            entry = {'fence': fence, 'references': 0}
+            _PROCESS_FENCES[fence_key] = entry
+        entry['references'] = int(entry['references']) + 1
+        fence = entry['fence']
+    app.extensions['sqlite_process_fence'] = fence
+    app.extensions['sqlite_process_fence_finalizer'] = weakref.finalize(
+        app,
+        _release_sqlite_process_fence,
+        fence_key,
+    )
+
+
+def _release_sqlite_process_fence(fence_key: str) -> None:
+    with _PROCESS_FENCES_LOCK:
+        entry = _PROCESS_FENCES.get(fence_key)
+        if entry is None:
+            return
+        references = int(entry['references']) - 1
+        if references > 0:
+            entry['references'] = references
+            return
+        fence = entry['fence']
+        del _PROCESS_FENCES[fence_key]
+        fence.close()
+
+
+def _load_manifest(package_dir: Path) -> dict:
+    try:
+        manifest = json.loads((package_dir / 'manifest.json').read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RestoreValidationError('Restore package manifest is missing or invalid.') from exc
+    if manifest.get('package_version') != PACKAGE_VERSION:
+        raise RestoreValidationError('Restore package version is not supported.')
+    return manifest
+
+
+def _validate_package_paths(package_dir: Path, manifest: dict) -> tuple[Path, Path]:
+    target_path = Path(manifest.get('target_path', '')).resolve()
+    expected_root = (target_path.parent / STAGING_DIRNAME).resolve()
+    if package_dir.parent.resolve() != expected_root:
+        raise RestoreValidationError('Restore package is not on the target database volume.')
+    staged_db = (package_dir / 'restore.db').resolve()
+    if staged_db.parent != package_dir or not staged_db.is_file():
+        raise RestoreValidationError('Restore package database is missing.')
+    return target_path, staged_db
+
+
+def _active_jobs(path: Path) -> int:
+    conn = _read_only_connection(str(path))
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        if 'background_jobs' not in tables:
+            return 0
+        placeholders = ','.join('?' for _ in ACTIVE_JOB_STATUSES)
+        row = conn.execute(
+            f'SELECT COUNT(*) FROM background_jobs WHERE status IN ({placeholders})',
+            ACTIVE_JOB_STATUSES,
+        ).fetchone()
+        return int(row[0]) if row else 0
+    finally:
+        conn.close()
+
+
+def _probe_exclusive_sqlite_access(path: Path) -> None:
+    try:
+        conn = sqlite3.connect(str(path), timeout=0, isolation_level=None)
+        try:
+            conn.execute('PRAGMA busy_timeout=0')
+            conn.execute('BEGIN EXCLUSIVE')
+            conn.execute('ROLLBACK')
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        raise RuntimeError('Could not obtain exclusive SQLite database access.') from exc
+
+
+def _inject_failure(fail_at: str | None, checkpoint: str) -> None:
+    if fail_at == checkpoint:
+        raise RuntimeError(f'Injected restore failure at {checkpoint}')
+
+
+def _phase(journal: Path, name: str, actor: str, fn, *, fail_at: str | None):
+    _append_journal(journal, 'phase_started', phase=name, actor=actor)
+    _inject_failure(fail_at, f'before_{name}')
+    try:
+        result = fn()
+    except BaseException as exc:
+        _append_journal(
+            journal,
+            'phase_failed',
+            phase=name,
+            actor=actor,
+            error=type(exc).__name__,
+        )
+        raise
+    _append_journal(journal, 'phase_completed', phase=name, actor=actor)
+    _inject_failure(fail_at, f'after_{name}')
+    return result
+
+
+def _sidecar_quarantine_path(package_dir: Path, quarantine_name: str) -> Path:
+    if not quarantine_name or Path(quarantine_name).name != quarantine_name:
+        raise RestoreValidationError('SQLite sidecar quarantine name is unsafe.')
+    quarantine_dir = (package_dir / 'sidecar-quarantine').resolve()
+    quarantine_path = (quarantine_dir / quarantine_name).resolve()
+    if quarantine_path.parent != quarantine_dir:
+        raise RestoreValidationError('SQLite sidecar quarantine path is unsafe.')
+    return quarantine_path
+
+
+def _reconcile_pending_sidecar_quarantines(
+    *,
+    target_path: Path,
+    package_dir: Path,
+    manifest: dict,
+    journal: Path,
+    actor: str,
+    fail_at: str | None,
+) -> None:
+    """Finish recorded sidecar move intents before creating another attempt."""
+    quarantine_dir = package_dir / 'sidecar-quarantine'
+    _mkdir_private(quarantine_dir)
+    manifest_path = package_dir / 'manifest.json'
+
+    for record in manifest.get('sidecar_quarantines', []):
+        if record.get('status') == 'completed':
+            continue
+        attempt_id = str(record.get('attempt_id') or '')
+        purpose = str(record.get('purpose') or 'unknown')
+        for entry in record.get('entries', []):
+            if entry.get('status') in {'absent', 'quarantined'}:
+                continue
+            suffix = str(entry.get('suffix') or '')
+            if suffix not in SQLITE_SIDECAR_SUFFIXES:
+                raise RestoreValidationError('SQLite sidecar suffix is invalid.')
+            source_path = Path(f'{target_path}{suffix}')
+            quarantine_path = _sidecar_quarantine_path(
+                package_dir, str(entry.get('quarantine_name') or '')
+            )
+            if source_path.is_symlink() or (
+                source_path.exists() and not source_path.is_file()
+            ):
+                raise RestoreValidationError(
+                    f'SQLite sidecar has an unsafe file type: {source_path.name}'
+                )
+            if quarantine_path.is_symlink() or (
+                quarantine_path.exists() and not quarantine_path.is_file()
+            ):
+                raise RestoreValidationError(
+                    f'SQLite sidecar quarantine has an unsafe file type: '
+                    f'{quarantine_path.name}'
+                )
+            if source_path.is_file() and quarantine_path.is_file():
+                raise RestoreValidationError(
+                    f'SQLite sidecar exists in both live and quarantine locations: '
+                    f'{source_path.name}'
+                )
+
+            expected_sha = entry.get('source_sha256')
+            reconciled_move = False
+            if quarantine_path.is_file():
+                if not expected_sha or not hmac.compare_digest(
+                    sha256_file(str(quarantine_path)), str(expected_sha),
+                ):
+                    raise RestoreValidationError(
+                        f'Quarantined SQLite sidecar checksum is invalid: '
+                        f'{quarantine_path.name}'
+                    )
+                _chmod_if_supported(quarantine_path, 0o600)
+                entry['status'] = 'quarantined'
+                reconciled_move = True
+            elif source_path.is_file():
+                source_sha = sha256_file(str(source_path))
+                if expected_sha and not hmac.compare_digest(
+                    source_sha, str(expected_sha),
+                ):
+                    raise RestoreValidationError(
+                        f'SQLite sidecar changed after quarantine intent: '
+                        f'{source_path.name}'
+                    )
+                entry['source_sha256'] = source_sha
+                entry['status'] = 'move_pending'
+                _write_json_atomic(manifest_path, manifest)
+                _append_journal(
+                    journal,
+                    'sidecar_move_intent',
+                    actor=actor,
+                    purpose=purpose,
+                    attempt_id=attempt_id,
+                    suffix=suffix,
+                    source_sha256=source_sha,
+                    quarantine_name=quarantine_path.name,
+                )
+                os.replace(source_path, quarantine_path)
+                _chmod_if_supported(quarantine_path, 0o600)
+                _fsync_file(quarantine_path)
+                _fsync_directory(source_path.parent)
+                _fsync_directory(quarantine_dir)
+                _inject_failure(
+                    fail_at,
+                    f'after_sidecar_move_before_manifest_{suffix.removeprefix("-")}',
+                )
+                entry['status'] = 'quarantined'
+            elif expected_sha:
+                raise RestoreValidationError(
+                    f'Recorded SQLite sidecar is missing from live and quarantine '
+                    f'locations: {source_path.name}'
+                )
+            else:
+                entry['status'] = 'absent'
+
+            _write_json_atomic(manifest_path, manifest)
+            event = (
+                'sidecar_quarantine_reconciled'
+                if reconciled_move
+                else 'sidecar_quarantined'
+            )
+            _append_journal(
+                journal,
+                event,
+                actor=actor,
+                purpose=purpose,
+                attempt_id=attempt_id,
+                suffix=suffix,
+                status=entry['status'],
+                source_sha256=entry.get('source_sha256'),
+            )
+            _inject_failure(fail_at, f'after_quarantine_{suffix.removeprefix("-")}')
+
+        record['status'] = 'completed'
+        manifest['phase'] = f'{purpose}_sidecars_quarantined'
+        _write_json_atomic(manifest_path, manifest)
+        _append_journal(
+            journal,
+            'sidecar_quarantine_completed',
+            actor=actor,
+            purpose=purpose,
+            attempt_id=attempt_id,
+        )
+
+
+def _quarantine_sqlite_sidecars(
+    *,
+    target_path: Path,
+    package_dir: Path,
+    manifest: dict,
+    journal: Path,
+    actor: str,
+    purpose: str,
+    fail_at: str | None,
+) -> dict:
+    """Move target WAL/SHM files away so they cannot attach to a new main file."""
+    _reconcile_pending_sidecar_quarantines(
+        target_path=target_path,
+        package_dir=package_dir,
+        manifest=manifest,
+        journal=journal,
+        actor=actor,
+        fail_at=fail_at,
+    )
+    attempt_id = uuid.uuid4().hex
+    quarantine_dir = package_dir / 'sidecar-quarantine'
+    _mkdir_private(quarantine_dir)
+    record = {
+        'attempt_id': attempt_id,
+        'purpose': purpose,
+        'status': 'pending',
+        'entries': [],
+    }
+    for suffix in SQLITE_SIDECAR_SUFFIXES:
+        record['entries'].append(
+            {
+                'suffix': suffix,
+                'quarantine_name': f'{attempt_id}{suffix}',
+                'status': 'pending',
+            }
+        )
+    manifest.setdefault('sidecar_quarantines', []).append(record)
+    manifest['phase'] = f'{purpose}_sidecar_quarantine_pending'
+    _write_json_atomic(package_dir / 'manifest.json', manifest)
+    _append_journal(
+        journal,
+        'sidecar_quarantine_started',
+        actor=actor,
+        purpose=purpose,
+        attempt_id=attempt_id,
+    )
+    _reconcile_pending_sidecar_quarantines(
+        target_path=target_path,
+        package_dir=package_dir,
+        manifest=manifest,
+        journal=journal,
+        actor=actor,
+        fail_at=fail_at,
+    )
+    return record
+
+
+def _restore_safety_snapshot(
+    *,
+    package_dir: Path,
+    manifest: dict,
+    journal: Path,
+    actor: str,
+    safety_path: Path,
+    target_path: Path,
+    tournament_id: int,
+    expected_checksum: str,
+) -> None:
+    if not safety_path.is_file() or not hmac.compare_digest(
+        sha256_file(str(safety_path)), expected_checksum,
+    ):
+        raise RuntimeError('Safety snapshot is missing or has changed; rollback is blocked.')
+    rollback_copy = safety_path.with_name(f'.rollback-{uuid.uuid4().hex}.db')
+    try:
+        shutil.copyfile(safety_path, rollback_copy)
+        _chmod_if_supported(rollback_copy, 0o600)
+        _fsync_file(rollback_copy)
+        _quarantine_sqlite_sidecars(
+            target_path=target_path,
+            package_dir=package_dir,
+            manifest=manifest,
+            journal=journal,
+            actor=actor,
+            purpose='rollback',
+            fail_at=None,
+        )
+        os.replace(rollback_copy, target_path)
+        _fsync_file(target_path)
+        _fsync_directory(target_path.parent)
+        validate_sqlite_restore_file(
+            str(target_path),
+            str(target_path),
+            tournament_id=tournament_id,
+            expected_checksum=expected_checksum,
+            expected_schema_sha256=manifest['required_schema_sha256'],
+            expected_database_identity_sha256=manifest['database_identity_sha256'],
+        )
+    finally:
+        try:
+            rollback_copy.unlink()
+        except OSError:
+            pass
+
+
+def _recover_interrupted_attempt(
+    *,
+    package_dir: Path,
+    manifest: dict,
+    target_path: Path,
+    journal: Path,
+    actor: str,
+) -> dict | None:
+    if manifest.get('status') == 'completed':
+        validation = validate_sqlite_restore_file(
+            str(target_path),
+            str(target_path),
+            tournament_id=int(manifest['tournament_id']),
+            expected_checksum=manifest['source_sha256'],
+            expected_schema_sha256=manifest['required_schema_sha256'],
+            expected_database_identity_sha256=manifest['database_identity_sha256'],
+        )
+        return {
+            'ok': True,
+            'status': 'completed',
+            'stage_id': manifest['stage_id'],
+            'target_path': str(target_path),
+            'source_sha256': validation['source_sha256'],
+            'recovered': False,
+        }
+    if manifest.get('status') != 'applying':
+        return None
+
+    _quarantine_sqlite_sidecars(
+        target_path=target_path,
+        package_dir=package_dir,
+        manifest=manifest,
+        journal=journal,
+        actor=actor,
+        purpose='recovery',
+        fail_at=None,
+    )
+
+    source_sha = manifest['source_sha256']
+    if target_path.is_file() and hmac.compare_digest(sha256_file(str(target_path)), source_sha):
+        validation = validate_sqlite_restore_file(
+            str(target_path),
+            str(target_path),
+            tournament_id=int(manifest['tournament_id']),
+            expected_checksum=source_sha,
+            expected_schema_sha256=manifest['required_schema_sha256'],
+            expected_database_identity_sha256=manifest['database_identity_sha256'],
+        )
+        manifest.update(status='completed', phase='recovered_validation', completed_at=_utc_iso())
+        _write_json_atomic(package_dir / 'manifest.json', manifest)
+        _append_journal(
+            journal,
+            'restore_recovered',
+            actor=actor,
+            source_sha256=source_sha,
+            audit_chain_head=validation['audit_chain_head'],
+        )
+        return {
+            'ok': True,
+            'status': 'completed',
+            'stage_id': manifest['stage_id'],
+            'target_path': str(target_path),
+            'source_sha256': source_sha,
+            'recovered': True,
+        }
+
+    safety_path = package_dir / 'safety.db'
+    safety_sha = manifest.get('safety_sha256')
+    if safety_sha:
+        _append_journal(journal, 'rollback_started', actor=actor, reason='interrupted_apply')
+        _restore_safety_snapshot(
+            package_dir=package_dir,
+            manifest=manifest,
+            journal=journal,
+            actor=actor,
+            safety_path=safety_path,
+            target_path=target_path,
+            tournament_id=int(manifest['tournament_id']),
+            expected_checksum=safety_sha,
+        )
+        _append_journal(
+            journal,
+            'rollback_completed',
+            actor=actor,
+            safety_sha256=safety_sha,
+        )
+        manifest.update(status='staged', phase='recovered_rollback')
+        _write_json_atomic(package_dir / 'manifest.json', manifest)
+        return None
+    raise RuntimeError('Interrupted restore has no verifiable safety snapshot.')
+
+
+def apply_staged_sqlite_restore(
+    package_path: str,
+    *,
+    actor: str,
+    fence_timeout: float = 0,
+    fail_at: str | None = None,
+) -> dict:
+    """Apply a staged package while the web process is provably offline."""
+    package_dir = Path(package_path).resolve()
+    manifest = _load_manifest(package_dir)
+    target_path, staged_db = _validate_package_paths(package_dir, manifest)
+    journal = package_dir / 'restore-journal.jsonl'
+    tournament_id = int(manifest['tournament_id'])
+
+    try:
+        with database_activity_fence(
+            str(target_path), exclusive=True, timeout=fence_timeout,
+        ):
+            recovered = _recover_interrupted_attempt(
+                package_dir=package_dir,
+                manifest=manifest,
+                target_path=target_path,
+                journal=journal,
+                actor=actor,
+            )
+            if recovered is not None:
+                return recovered
+
+            if _active_jobs(target_path):
+                raise RuntimeError(
+                    'Queued or running background jobs must be drained before restore.'
+                )
+
+            validation = _phase(
+                journal,
+                'pre_validation',
+                actor,
+                lambda: validate_sqlite_restore_file(
+                    str(staged_db),
+                    str(target_path),
+                    tournament_id=tournament_id,
+                    expected_checksum=manifest['source_sha256'],
+                    expected_schema_sha256=manifest['required_schema_sha256'],
+                    expected_database_identity_sha256=manifest[
+                        'database_identity_sha256'
+                    ],
+                ),
+                fail_at=fail_at,
+            )
+            _phase(
+                journal,
+                'exclusive_access',
+                actor,
+                lambda: _probe_exclusive_sqlite_access(target_path),
+                fail_at=fail_at,
+            )
+
+            safety_path = package_dir / 'safety.db'
+            if safety_path.exists():
+                safety_path.unlink()
+            try:
+                safety = _phase(
+                    journal,
+                    'safety_snapshot',
+                    actor,
+                    lambda: create_sqlite_snapshot(str(target_path), str(safety_path)),
+                    fail_at=fail_at,
+                )
+                _chmod_if_supported(safety_path, 0o600)
+            except BaseException as exc:
+                safety_sha = sha256_file(str(safety_path)) if safety_path.is_file() else None
+                _append_journal(
+                    journal,
+                    'restore_failed',
+                    actor=actor,
+                    phase='safety_snapshot',
+                    error=type(exc).__name__,
+                )
+                _append_journal(
+                    journal,
+                    'rollback_not_required',
+                    actor=actor,
+                    safety_sha256=safety_sha,
+                )
+                manifest.update(
+                    status='failed',
+                    phase='safety_snapshot',
+                    failed_at=_utc_iso(),
+                    safety_sha256=safety_sha,
+                )
+                _write_json_atomic(package_dir / 'manifest.json', manifest)
+                raise
+            manifest.update(
+                status='applying',
+                phase='safety_ready',
+                maintenance_actor=actor,
+                apply_started_at=_utc_iso(),
+                safety_sha256=safety['sha256'],
+                safety_audit_chain_head=sqlite_audit_chain_head(str(safety_path)),
+            )
+            _write_json_atomic(package_dir / 'manifest.json', manifest)
+
+            replacement_copy = package_dir / f'.replacement-{uuid.uuid4().hex}.db'
+            replaced = False
+            target_mutated = False
+            try:
+                def _replace():
+                    nonlocal replaced, target_mutated
+                    shutil.copyfile(staged_db, replacement_copy)
+                    _chmod_if_supported(replacement_copy, 0o600)
+                    _fsync_file(replacement_copy)
+                    manifest.update(phase='replacement_pending')
+                    _write_json_atomic(package_dir / 'manifest.json', manifest)
+                    target_mutated = True
+                    _phase(
+                        journal,
+                        'sidecar_quarantine',
+                        actor,
+                        lambda: _quarantine_sqlite_sidecars(
+                            target_path=target_path,
+                            package_dir=package_dir,
+                            manifest=manifest,
+                            journal=journal,
+                            actor=actor,
+                            purpose='replace',
+                            fail_at=fail_at,
+                        ),
+                        fail_at=fail_at,
+                    )
+                    os.replace(replacement_copy, target_path)
+                    replaced = True
+                    _fsync_file(target_path)
+                    _fsync_directory(target_path.parent)
+                    manifest.update(phase='replaced')
+                    _write_json_atomic(package_dir / 'manifest.json', manifest)
+
+                _phase(
+                    journal,
+                    'replace',
+                    actor,
+                    _replace,
+                    fail_at=fail_at,
+                )
+                _phase(
+                    journal,
+                    'reopen',
+                    actor,
+                    lambda: sqlite_schema_info(str(target_path)),
+                    fail_at=fail_at,
+                )
+                post_validation = _phase(
+                    journal,
+                    'post_validation',
+                    actor,
+                    lambda: validate_sqlite_restore_file(
+                        str(target_path),
+                        str(target_path),
+                        tournament_id=tournament_id,
+                        expected_checksum=manifest['source_sha256'],
+                        expected_schema_sha256=manifest['required_schema_sha256'],
+                        expected_database_identity_sha256=manifest[
+                            'database_identity_sha256'
+                        ],
+                    ),
+                    fail_at=fail_at,
+                )
+            except BaseException as exc:
+                _append_journal(
+                    journal,
+                    'restore_failed',
+                    actor=actor,
+                    phase=manifest.get('phase'),
+                    error=type(exc).__name__,
+                )
+                if replaced or target_mutated:
+                    _append_journal(
+                        journal,
+                        'rollback_started',
+                        actor=actor,
+                        source_sha256=manifest['source_sha256'],
+                        safety_sha256=safety['sha256'],
+                    )
+                    _restore_safety_snapshot(
+                        package_dir=package_dir,
+                        manifest=manifest,
+                        journal=journal,
+                        actor=actor,
+                        safety_path=safety_path,
+                        target_path=target_path,
+                        tournament_id=tournament_id,
+                        expected_checksum=safety['sha256'],
+                    )
+                    _append_journal(
+                        journal,
+                        'rollback_completed',
+                        actor=actor,
+                        safety_sha256=safety['sha256'],
+                    )
+                    manifest.update(status='rolled_back', phase='rollback_completed')
+                else:
+                    _append_journal(
+                        journal,
+                        'rollback_not_required',
+                        actor=actor,
+                        safety_sha256=safety['sha256'],
+                    )
+                    manifest.update(status='failed', phase='before_replacement')
+                manifest['failed_at'] = _utc_iso()
+                _write_json_atomic(package_dir / 'manifest.json', manifest)
+                raise
+            finally:
+                try:
+                    replacement_copy.unlink()
+                except OSError:
+                    pass
+
+            manifest.update(status='completed', phase='completed', completed_at=_utc_iso())
+            _write_json_atomic(package_dir / 'manifest.json', manifest)
+            _append_journal(
+                journal,
+                'restore_completed',
+                actor=actor,
+                source_sha256=manifest['source_sha256'],
+                safety_sha256=safety['sha256'],
+                audit_chain_head=post_validation['audit_chain_head'],
+                validation={
+                    'integrity_check': post_validation['integrity_check'],
+                    'foreign_key_violations': post_validation['foreign_key_violations'],
+                    'tournament_identity_matches': True,
+                },
+            )
+            return {
+                'ok': True,
+                'status': 'completed',
+                'stage_id': manifest['stage_id'],
+                'target_path': str(target_path),
+                'source_sha256': manifest['source_sha256'],
+                'safety_sha256': safety['sha256'],
+                'validation': validation,
+                'recovered': False,
+            }
+    except MaintenanceFenceBusy as exc:
+        raise RuntimeError(
+            'The application is still running. Stop it before applying a restore.'
+        ) from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description='Missoula Pro-Am offline maintenance')
+    subparsers = parser.add_subparsers(dest='command', required=True)
+    apply_parser = subparsers.add_parser('apply', help='apply a staged SQLite restore')
+    apply_parser.add_argument('package_path')
+    apply_parser.add_argument('--actor', required=True)
+    apply_parser.add_argument('--wait-seconds', type=float, default=0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = apply_staged_sqlite_restore(
+            args.package_path,
+            actor=args.actor,
+            fence_timeout=max(0.0, args.wait_seconds),
+        )
+    except Exception as exc:
+        print(f'Restore failed: {exc}', file=sys.stderr)
+        return 2
+    print(json.dumps(result, sort_keys=True, default=str))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/services/scoring_workflow.py
+++ b/services/scoring_workflow.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 from datetime import datetime, timezone
 from typing import Mapping
+from uuid import UUID
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import StaleDataError
@@ -10,7 +13,7 @@ from sqlalchemy.orm.exc import StaleDataError
 import services.scoring_engine as engine
 import strings as text
 from database import db
-from models import Event, EventResult, Heat
+from models import AuditLog, Event, EventResult, Heat, ScoreSubmissionReceipt, User
 from models.competitor import CollegeCompetitor, ProCompetitor
 from services.audit import log_action
 from services.cache_invalidation import invalidate_tournament_caches
@@ -20,6 +23,338 @@ from services.flight_builder import (
 )
 
 logger = logging.getLogger(__name__)
+
+_PAYLOAD_TRANSPORT_FIELDS = frozenset({
+    'csrf_token',
+    'replay_token',
+    'payload_sha256',
+    'tournament_id',
+    'heat_id',
+})
+
+
+def _form_pairs(form_data: Mapping[str, object]) -> list[tuple[str, str]]:
+    """Return stable string pairs without losing MultiDict repeated values."""
+    pairs: list[tuple[str, str]] = []
+    if hasattr(form_data, 'lists'):
+        for raw_key, raw_values in form_data.lists():
+            key = str(raw_key)
+            for raw_value in raw_values:
+                pairs.append((key, str(raw_value or '')))
+        return pairs
+    for raw_key, raw_value in form_data.items():
+        key = str(raw_key)
+        if isinstance(raw_value, (list, tuple)):
+            pairs.extend((key, str(value or '')) for value in raw_value)
+        else:
+            pairs.append((key, str(raw_value or '')))
+    return pairs
+
+
+def canonical_score_payload_sha256(
+    form_data: Mapping[str, object],
+    *,
+    tournament_id: int,
+    heat_id: int,
+) -> str:
+    """Hash the complete score payload while excluding transport credentials."""
+    pairs = [
+        (key, value)
+        for key, value in _form_pairs(form_data)
+        if key not in _PAYLOAD_TRANSPORT_FIELDS
+    ]
+    pairs.extend((
+        ('heat_id', str(int(heat_id))),
+        ('tournament_id', str(int(tournament_id))),
+    ))
+    canonical = json.dumps(
+        sorted(pairs),
+        ensure_ascii=False,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+
+def heat_submission_identity(heat: Heat) -> str:
+    """Return a lock-independent identity for one generated heat instance."""
+    payload = {
+        'event_id': heat.event_id,
+        'flight_id': heat.flight_id,
+        'flight_position': heat.flight_position,
+        'heat_id': heat.id,
+        'heat_number': heat.heat_number,
+        'roster': heat.get_competitors(),
+        'run_number': heat.run_number,
+        'stands': heat.get_stand_assignments(),
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+
+def heat_scoring_state_digest(
+    heat: Heat,
+    event: Event,
+    results: object | None = None,
+) -> str:
+    """Hash score-relevant state without including the transient judge lock."""
+    competitor_ids = _normalize_competitor_ids(heat.get_competitors())
+    if results is None:
+        rows = EventResult.query.filter(
+            EventResult.event_id == event.id,
+            EventResult.competitor_id.in_(competitor_ids),
+            EventResult.competitor_type == event.event_type,
+        ).all()
+    else:
+        rows = list(results)
+
+    result_fields = (
+        'id',
+        'competitor_id',
+        'competitor_type',
+        'version_id',
+        'result_value',
+        'result_unit',
+        'run1_value',
+        'run2_value',
+        'run3_value',
+        'best_run',
+        'tiebreak_value',
+        't1_run1',
+        't2_run1',
+        't1_run2',
+        't2_run2',
+        'status',
+        'status_reason',
+        'is_flagged',
+        'throwoff_pending',
+    )
+
+    def _stable_value(value: object) -> object:
+        if value is None or isinstance(value, (bool, int, str)):
+            return value
+        return str(value)
+
+    payload = {
+        'heat_identity': heat_submission_identity(heat),
+        'heat_status': heat.status,
+        'results': [
+            {
+                field: _stable_value(getattr(result, field))
+                for field in result_fields
+            }
+            for result in sorted(
+                rows,
+                key=lambda result: (result.competitor_id, result.id or 0),
+            )
+        ],
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    return hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+
+def _normalized_request_id(form_data: Mapping[str, object]) -> str | None:
+    raw = str(form_data.get('request_id') or '').strip()
+    if not raw:
+        return None
+    try:
+        return str(UUID(raw))
+    except (TypeError, ValueError, AttributeError):
+        return ''
+
+
+def _receipt_public(receipt: ScoreSubmissionReceipt) -> dict:
+    return {
+        'request_id': receipt.request_id,
+        'tournament_id': receipt.tournament_id,
+        'heat_id': receipt.heat_id,
+        'issuing_user_id': receipt.issuing_user_id,
+        'payload_sha256': receipt.canonical_payload_sha256,
+        'accepted': True,
+    }
+
+
+def _receipt_conflict(
+    *,
+    event_id: int,
+    heat_id: int,
+    code: str,
+    message: str,
+) -> dict:
+    return {
+        'ok': False,
+        'category': 'error',
+        'message': message,
+        'error_code': code,
+        'redirect_kind': 'heat_entry',
+        'redirect_event_id': event_id,
+        'redirect_heat_id': heat_id,
+        'status_code': 409,
+    }
+
+
+def _outcome_from_receipt(
+    receipt: ScoreSubmissionReceipt,
+    *,
+    tournament_id: int,
+    heat_id: int,
+    event_id: int,
+    judge_user_id: int | None,
+    payload_sha256: str,
+) -> dict:
+    if receipt.issuing_user_id is None:
+        return _receipt_conflict(
+            event_id=event_id,
+            heat_id=heat_id,
+            code='request_id_issuer_deleted',
+            message=(
+                'The account that issued this score request no longer exists. '
+                'The retained request ID cannot be replayed.'
+            ),
+        )
+    if (
+        receipt.tournament_id != tournament_id
+        or receipt.heat_id != heat_id
+        or receipt.issuing_user_id != judge_user_id
+    ):
+        return _receipt_conflict(
+            event_id=event_id,
+            heat_id=heat_id,
+            code='request_id_binding_mismatch',
+            message=(
+                'This score request ID is already bound to another user, '
+                'tournament, or heat. The queued entry was not applied.'
+            ),
+        )
+    if receipt.canonical_payload_sha256 != payload_sha256:
+        return _receipt_conflict(
+            event_id=event_id,
+            heat_id=heat_id,
+            code='request_id_payload_mismatch',
+            message=(
+                'This score request ID was already used with different values. '
+                'The queued entry was not applied.'
+            ),
+        )
+    outcome = dict(receipt.accepted_outcome_json or {})
+    if outcome.get('receipt_revoked') is True:
+        return _receipt_conflict(
+            event_id=event_id,
+            heat_id=heat_id,
+            code='request_id_revoked',
+            message=(
+                'This score request was superseded by a heat undo. '
+                'Reload the heat before entering a new score.'
+            ),
+        )
+    outcome['receipt'] = _receipt_public(receipt)
+    outcome['receipt_replayed'] = True
+    return outcome
+
+
+def _add_scoring_audit(
+    action: str,
+    entity_type: str,
+    entity_id: int | None,
+    *,
+    judge_user_id: int | None,
+    details: dict,
+) -> None:
+    """Add score audit evidence to the score transaction itself."""
+    actor_user_id = judge_user_id
+    if actor_user_id is not None and db.session.get(User, actor_user_id) is None:
+        actor_user_id = None
+    db.session.add(AuditLog(
+        actor_user_id=actor_user_id,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        details_json=json.dumps(details, sort_keys=True),
+    ))
+
+
+def _create_submission_receipt(
+    *,
+    request_id: str,
+    tournament_id: int,
+    heat_id: int,
+    judge_user_id: int,
+    payload_sha256: str,
+    outcome: dict,
+) -> ScoreSubmissionReceipt:
+    receipt = ScoreSubmissionReceipt(
+        request_id=request_id,
+        tournament_id=tournament_id,
+        heat_id=heat_id,
+        issuing_user_id=judge_user_id,
+        canonical_payload_sha256=payload_sha256,
+        accepted_outcome_json=outcome,
+    )
+    db.session.add(receipt)
+    return receipt
+
+
+def revoke_heat_submission_receipts_for_undo(
+    *,
+    tournament_id: int,
+    heat_id: int,
+    event_id: int,
+    judge_user_id: int | None,
+) -> list[str]:
+    """Supersede accepted request IDs in the same transaction as a heat undo."""
+    receipts = (
+        ScoreSubmissionReceipt.query
+        .filter_by(tournament_id=tournament_id, heat_id=heat_id)
+        .with_for_update()
+        .all()
+    )
+    revoked_at = datetime.now(timezone.utc).isoformat()
+    revoked_request_ids: list[str] = []
+    for receipt in receipts:
+        accepted_outcome = dict(receipt.accepted_outcome_json or {})
+        if accepted_outcome.get('receipt_revoked') is True:
+            continue
+        receipt.accepted_outcome_json = {
+            'receipt_revoked': True,
+            'reason': 'heat_undo',
+            'revoked_at': revoked_at,
+            'superseded_outcome': accepted_outcome,
+        }
+        revoked_request_ids.append(receipt.request_id)
+
+    if revoked_request_ids:
+        _add_scoring_audit(
+            'score_submission_receipts_revoked',
+            'heat',
+            heat_id,
+            judge_user_id=judge_user_id,
+            details={
+                'event_id': event_id,
+                'request_ids': sorted(revoked_request_ids),
+                'reason': 'heat_undo',
+            },
+        )
+    _add_scoring_audit(
+        'heat_undo',
+        'heat',
+        heat_id,
+        judge_user_id=judge_user_id,
+        details={
+            'event_id': event_id,
+            'judge_user_id': judge_user_id,
+            'revoked_request_ids': sorted(revoked_request_ids),
+        },
+    )
+    return revoked_request_ids
 
 
 def _capture_shadow_outcomes(event: Event, judge_user_id: int | None) -> None:
@@ -201,7 +536,83 @@ def save_heat_results_submission(
     # clearing the placement while the judge is saving it.
     original_heat_id = heat.id
     original_event_id = event.id
+    request_id = _normalized_request_id(form_data)
+    if request_id == '':
+        return {
+            'ok': False,
+            'category': 'error',
+            'message': 'Score request ID must be a valid UUID.',
+            'error_code': 'request_id_invalid',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': original_event_id,
+            'redirect_heat_id': original_heat_id,
+            'status_code': 400,
+        }
+    if request_id and judge_user_id is None:
+        return {
+            'ok': False,
+            'category': 'error',
+            'message': 'Login is required to submit an offline score request.',
+            'error_code': 'session_required',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': original_event_id,
+            'redirect_heat_id': original_heat_id,
+            'status_code': 401,
+        }
+    posted_issuer = _form_int(form_data, 'issuer_user_id')
+    payload_sha256 = canonical_score_payload_sha256(
+        form_data,
+        tournament_id=tournament_id,
+        heat_id=original_heat_id,
+    )
+    posted_payload_sha256 = str(form_data.get('payload_sha256') or '').strip()
+    if posted_payload_sha256 and posted_payload_sha256 != payload_sha256:
+        return _receipt_conflict(
+            event_id=original_event_id,
+            heat_id=original_heat_id,
+            code='payload_fingerprint_mismatch',
+            message='The queued score payload fingerprint does not match its values.',
+        )
+
+    if request_id:
+        existing_receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+        if existing_receipt is not None:
+            return _outcome_from_receipt(
+                existing_receipt,
+                tournament_id=tournament_id,
+                heat_id=original_heat_id,
+                event_id=original_event_id,
+                judge_user_id=judge_user_id,
+                payload_sha256=payload_sha256,
+            )
+    if posted_issuer is not None and posted_issuer != judge_user_id:
+        return {
+            'ok': False,
+            'category': 'error',
+            'message': 'This queued score belongs to another user.',
+            'error_code': 'authorization_denied',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': original_event_id,
+            'redirect_heat_id': original_heat_id,
+            'status_code': 403,
+        }
+
     lock_tournament_schedule(tournament_id)
+    # A matching request can commit while this transaction waits for the
+    # tournament writer lock. Recheck after acquiring the lock so the waiting
+    # duplicate receives the durable outcome instead of a transient stale-form
+    # conflict caused by the first request's heat update.
+    if request_id:
+        committed_receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+        if committed_receipt is not None:
+            return _outcome_from_receipt(
+                committed_receipt,
+                tournament_id=tournament_id,
+                heat_id=original_heat_id,
+                event_id=original_event_id,
+                judge_user_id=judge_user_id,
+                payload_sha256=payload_sha256,
+            )
     heat = (
         Heat.query
         .filter_by(id=original_heat_id)
@@ -230,11 +641,29 @@ def save_heat_results_submission(
             'status_code': 409,
         }
 
+    if heat.is_locked() and heat.locked_by_user_id != (judge_user_id or -1):
+        lock_owner = db.session.get(User, heat.locked_by_user_id)
+        owner_name = (
+            lock_owner.username
+            if lock_owner is not None
+            else f'User #{heat.locked_by_user_id}'
+        )
+        return {
+            'ok': False,
+            'category': 'warning',
+            'message': (
+                f'Heat is currently being edited by {owner_name}. '
+                'Your submission was not saved.'
+            ),
+            'error_code': 'heat_locked',
+            'redirect_kind': 'heat_entry',
+            'redirect_event_id': event.id,
+            'redirect_heat_id': heat.id,
+            'status_code': 423,
+        }
+
     posted_identity = form_data.get('heat_identity')
-    current_identity = (
-        heat.locked_at.isoformat(timespec='microseconds')
-        if heat.locked_at is not None else None
-    )
+    current_identity = heat_submission_identity(heat)
     if posted_identity is not None or not _testing_mode_enabled():
         if not posted_identity or posted_identity != current_identity:
             return {
@@ -250,17 +679,37 @@ def save_heat_results_submission(
                 'status_code': 409,
             }
     competitor_ids = _normalize_competitor_ids(heat.get_competitors())
-    posted_version = _form_int(form_data, 'heat_version')
-    if posted_version is None or posted_version != heat.version_id:
-        return {
-            'ok': False,
-            'category': 'error',
-            'message': 'This heat changed in another session. Reload and re-enter results.',
-            'redirect_kind': 'heat_entry',
-            'redirect_event_id': event.id,
-            'redirect_heat_id': heat.id,
-            'status_code': 409,
-        }
+    posted_state_digest = str(form_data.get('scoring_state_digest') or '')
+    if posted_state_digest or not _testing_mode_enabled():
+        if posted_state_digest != heat_scoring_state_digest(heat, event):
+            return {
+                'ok': False,
+                'category': 'error',
+                'message': (
+                    'This heat or its scores changed in another session. '
+                    'Reload and reconcile before saving.'
+                ),
+                'error_code': 'scoring_state_changed',
+                'redirect_kind': 'heat_entry',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 409,
+            }
+    else:
+        posted_version = _form_int(form_data, 'heat_version')
+        if posted_version is None or posted_version != heat.version_id:
+            return {
+                'ok': False,
+                'category': 'error',
+                'message': (
+                    'This heat changed in another session. '
+                    'Reload and re-enter results.'
+                ),
+                'redirect_kind': 'heat_entry',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 409,
+            }
 
     result_by_comp = existing_results_for_event(event, competitor_ids)
     comp_lookup = competitor_lookup_for_event(event, competitor_ids)
@@ -445,11 +894,12 @@ def save_heat_results_submission(
                 result.status_reason = None
 
             if result.id:
-                log_action(
+                _add_scoring_audit(
                     'score_edited',
                     'event_result',
                     result.id,
-                    {
+                    judge_user_id=judge_user_id,
+                    details={
                         'event_id': event.id,
                         'heat_id': heat.id,
                         'new_value': result.result_value,
@@ -518,16 +968,103 @@ def save_heat_results_submission(
                 event.status = 'in_progress'
                 finalize_failed = True
 
-        log_action(
+        _add_scoring_audit(
             'heat_results_saved',
             'heat',
             heat.id,
-            {
+            judge_user_id=judge_user_id,
+            details={
                 'event_id': event.id,
                 'result_updates': changes,
                 'judge_user_id': judge_user_id,
             },
         )
+
+        undo_token = {
+            'heat_id': heat.id,
+            'event_id': event.id,
+            'heat_version': heat.version_id,
+            'result_versions': {
+                str(result.id): result.version_id
+                for result in EventResult.query.filter(
+                    EventResult.event_id == event.id,
+                    EventResult.competitor_id.in_(competitor_ids),
+                    EventResult.competitor_type == event.event_type,
+                ).all()
+            },
+            'saved_at': datetime.now(timezone.utc).isoformat(),
+        }
+
+        if finalize_failed:
+            outcome = {
+                'ok': True,
+                'category': 'warning',
+                'message': ('Heat saved, but auto-finalization failed. The event '
+                            'results page will let you retry - your timer values '
+                            'are safe.'),
+                'redirect_kind': 'event_results',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 200,
+                'undo_heat_id': heat.id,
+                'undo_token': undo_token,
+            }
+        elif finalize_deferred:
+            shown = ', '.join(partial_names[:5])
+            more = (f' (+{len(partial_names) - 5} more)'
+                    if len(partial_names) > 5 else '')
+            extra = (f' {len(invalid)} invalid value(s) were also skipped.'
+                     if invalid else '')
+            outcome = {
+                'ok': True,
+                'category': 'warning',
+                'message': (f'Heat saved. The event was NOT finalized because '
+                            f'{len(partial_names)} result(s) still have only one '
+                            f'timer entered: {shown}{more}. Enter the second timer '
+                            f'and save again to finalize, or set them to DNF if '
+                            f'the time is gone.{extra}'),
+                'redirect_kind': 'event_results',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 200,
+                'undo_heat_id': heat.id,
+                'undo_token': undo_token,
+            }
+        elif invalid:
+            outcome = {
+                'ok': True,
+                'category': 'warning',
+                'message': f'Heat saved with {len(invalid)} invalid value(s) skipped.',
+                'redirect_kind': 'event_results',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 200,
+                'undo_heat_id': heat.id,
+                'undo_token': undo_token,
+            }
+        else:
+            outcome = {
+                'ok': True,
+                'category': 'success',
+                'message': text.FLASH['heat_saved'],
+                'redirect_kind': 'event_results',
+                'redirect_event_id': event.id,
+                'redirect_heat_id': heat.id,
+                'status_code': 200,
+                'undo_heat_id': heat.id,
+                'undo_token': undo_token,
+            }
+
+        receipt = None
+        if request_id:
+            receipt = _create_submission_receipt(
+                request_id=request_id,
+                tournament_id=tournament_id,
+                heat_id=heat.id,
+                judge_user_id=judge_user_id,
+                payload_sha256=payload_sha256,
+                outcome=outcome,
+            )
         db.session.commit()
 
     except StaleDataError:
@@ -544,6 +1081,17 @@ def save_heat_results_submission(
         }
     except IntegrityError:
         db.session.rollback()
+        if request_id:
+            raced_receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+            if raced_receipt is not None:
+                return _outcome_from_receipt(
+                    raced_receipt,
+                    tournament_id=tournament_id,
+                    heat_id=original_heat_id,
+                    event_id=original_event_id,
+                    judge_user_id=judge_user_id,
+                    payload_sha256=payload_sha256,
+                )
         return {
             'ok': False,
             'category': 'error',
@@ -556,82 +1104,10 @@ def save_heat_results_submission(
         }
 
     invalidate_tournament_caches(tournament_id)
-    undo_token = {
-        'heat_id': heat.id,
-        'event_id': event.id,
-        'heat_version': heat.version_id,
-        'result_versions': {
-            str(result.id): result.version_id
-            for result in EventResult.query.filter(
-                EventResult.event_id == event.id,
-                EventResult.competitor_id.in_(competitor_ids),
-                EventResult.competitor_type == event.event_type,
-            ).all()
-        },
-        'saved_at': datetime.now(timezone.utc).isoformat(),
-    }
-
-    if finalize_failed:
-        return {
-            'ok': True,
-            'category': 'warning',
-            'message': ('Heat saved, but auto-finalization failed. The event '
-                        'results page will let you retry - your timer values '
-                        'are safe.'),
-            'redirect_kind': 'event_results',
-            'redirect_event_id': event.id,
-            'redirect_heat_id': heat.id,
-            'status_code': 200,
-            'undo_heat_id': heat.id,
-            'undo_token': undo_token,
-        }
-
-    if finalize_deferred:
-        shown = ', '.join(partial_names[:5])
-        more = (f' (+{len(partial_names) - 5} more)'
-                if len(partial_names) > 5 else '')
-        extra = (f' {len(invalid)} invalid value(s) were also skipped.'
-                 if invalid else '')
-        return {
-            'ok': True,
-            'category': 'warning',
-            'message': (f'Heat saved. The event was NOT finalized because '
-                        f'{len(partial_names)} result(s) still have only one '
-                        f'timer entered: {shown}{more}. Enter the second timer '
-                        f'and save again to finalize, or set them to DNF if '
-                        f'the time is gone.{extra}'),
-            'redirect_kind': 'event_results',
-            'redirect_event_id': event.id,
-            'redirect_heat_id': heat.id,
-            'status_code': 200,
-            'undo_heat_id': heat.id,
-            'undo_token': undo_token,
-        }
-
-    if invalid:
-        return {
-            'ok': True,
-            'category': 'warning',
-            'message': f'Heat saved with {len(invalid)} invalid value(s) skipped.',
-            'redirect_kind': 'event_results',
-            'redirect_event_id': event.id,
-            'redirect_heat_id': heat.id,
-            'status_code': 200,
-            'undo_heat_id': heat.id,
-            'undo_token': undo_token,
-        }
-
-    return {
-        'ok': True,
-        'category': 'success',
-        'message': text.FLASH['heat_saved'],
-        'redirect_kind': 'event_results',
-        'redirect_event_id': event.id,
-        'redirect_heat_id': heat.id,
-        'status_code': 200,
-        'undo_heat_id': heat.id,
-        'undo_token': undo_token,
-    }
+    if receipt is not None:
+        outcome['receipt'] = _receipt_public(receipt)
+        outcome['receipt_replayed'] = False
+    return outcome
 
 
 def finalize_event_results(

--- a/services/scratch_cascade.py
+++ b/services/scratch_cascade.py
@@ -8,10 +8,13 @@ scratch operation.  No DB writes are performed here.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
 from dataclasses import dataclass, field
 from datetime import timedelta
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import OperationalError
@@ -39,6 +42,182 @@ class CascadeEffect:
     affected_entity_id: int  # PK of the affected row
     affected_entity_type: str  # 'event_result' | 'competitor' | 'event'
     metadata: dict = field(default_factory=dict)
+
+
+def scratch_effect_digest(competitor, effects) -> str:
+    """Bind a scratch confirmation to the exact effects the judge reviewed."""
+    from models.competitor import CollegeCompetitor
+
+    canonical_effects = [
+        {
+            'effect_type': effect.effect_type,
+            'description': effect.description,
+            'affected_entity_id': effect.affected_entity_id,
+            'affected_entity_type': effect.affected_entity_type,
+            'metadata': effect.metadata,
+        }
+        for effect in effects
+    ]
+    canonical_effects.sort(key=lambda effect: (
+        effect['effect_type'],
+        effect['affected_entity_type'],
+        effect['affected_entity_id'],
+        effect['description'],
+    ))
+    payload = {
+        'competitor_id': competitor.id,
+        'competitor_type': (
+            'college' if isinstance(competitor, CollegeCompetitor) else 'pro'
+        ),
+        'competitor_status': competitor.status,
+        'effects': canonical_effects,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=True,
+        default=str,
+    ).encode('ascii')
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonical_json_value(raw_value):
+    if not isinstance(raw_value, str):
+        return raw_value
+    try:
+        return json.loads(raw_value)
+    except (json.JSONDecodeError, TypeError):
+        return raw_value
+
+
+def _stable_number(raw_value):
+    if raw_value is None:
+        return None
+    try:
+        return format(Decimal(str(raw_value)).normalize(), "f")
+    except (InvalidOperation, TypeError, ValueError):
+        return str(raw_value)
+
+
+def _scratch_post_state_sha256(competitor, snapshot: dict) -> str:
+    """Fingerprint state that reverse_cascade would otherwise overwrite."""
+    from database import db
+    from models.competitor import CollegeCompetitor
+    from models.event import EventResult
+    from models.heat import Heat
+
+    result_state = []
+    for result_snapshot in sorted(
+        snapshot.get("results", []), key=lambda item: item.get("id") or 0,
+    ):
+        result = db.session.get(EventResult, result_snapshot.get("id"))
+        if result is None:
+            result_state.append(None)
+            continue
+        result_state.append({
+            "id": result.id,
+            "version_id": result.version_id,
+            "status": result.status,
+            "status_reason": result.status_reason,
+            "result_value": _stable_number(result.result_value),
+            "run1_value": _stable_number(result.run1_value),
+            "run2_value": _stable_number(result.run2_value),
+            "run3_value": _stable_number(result.run3_value),
+            "best_run": _stable_number(result.best_run),
+            "t1_run1": _stable_number(result.t1_run1),
+            "t2_run1": _stable_number(result.t2_run1),
+            "t1_run2": _stable_number(result.t1_run2),
+            "t2_run2": _stable_number(result.t2_run2),
+            "tiebreak_value": _stable_number(result.tiebreak_value),
+            "points_awarded": _stable_number(result.points_awarded),
+            "payout_amount": _stable_number(result.payout_amount),
+            "payout_settled": result.payout_settled,
+            "final_position": result.final_position,
+        })
+
+    heat_state = []
+    for heat_snapshot in sorted(
+        snapshot.get("heats", []), key=lambda item: item.get("heat_id") or 0,
+    ):
+        heat = db.session.get(Heat, heat_snapshot.get("heat_id"))
+        if heat is None:
+            heat_state.append(None)
+            continue
+        heat_state.append({
+            "id": heat.id,
+            "version_id": heat.version_id,
+            "status": heat.status,
+            "competitors": heat.get_competitors(),
+            "stand_assignments": heat.get_stand_assignments(),
+        })
+
+    payload = {
+        "competitor": {
+            "id": competitor.id,
+            "type": (
+                "college" if isinstance(competitor, CollegeCompetitor) else "pro"
+            ),
+            "status": competitor.status,
+            "partners": _canonical_json_value(competitor.partners),
+            "total_earnings": (
+                None
+                if isinstance(competitor, CollegeCompetitor)
+                else _stable_number(competitor.total_earnings)
+            ),
+        },
+        "results": result_state,
+        "heats": heat_state,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _scratch_audit_details(audit_entry) -> dict:
+    try:
+        details = json.loads(audit_entry.details_json or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return details if isinstance(details, dict) else {}
+
+
+def scratch_undo_token(audit_entry) -> str | None:
+    """Return the exact capability for one fingerprinted scratch audit row."""
+    details = _scratch_audit_details(audit_entry)
+    state_sha256 = details.get("scratch_post_state_sha256")
+    if not isinstance(state_sha256, str) or len(state_sha256) != 64:
+        return None
+    encoded = f"{audit_entry.id}:{state_sha256}".encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _append_scratch_audit(
+    *, action: str, competitor_id: int, judge_user_id: int | None, details: dict,
+):
+    """Append scratch evidence to the caller's transaction."""
+    from database import db
+    from models.audit_log import AuditLog
+    from models.user import User
+
+    actor_user_id = judge_user_id
+    if actor_user_id is not None and db.session.get(User, actor_user_id) is None:
+        actor_user_id = None
+    entry = AuditLog(
+        actor_user_id=actor_user_id,
+        action=action,
+        entity_type="competitor",
+        entity_id=competitor_id,
+        details_json=json.dumps(details, sort_keys=True, default=str),
+    )
+    db.session.add(entry)
+    db.session.flush()
+    return entry
 
 
 def _lock_cascade_rows(
@@ -440,7 +619,6 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
     from database import db
     from models.competitor import CollegeCompetitor, ProCompetitor
     from models.event import Event, EventResult
-    from services.audit import log_action
     from services.flight_builder import lock_tournament_schedule
     from services.proam_relay import ProAmRelay
     from services.scoring_engine import _rebuild_individual_points
@@ -766,21 +944,26 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
                 }
 
         # --- Audit log -------------------------------------------------------
-        log_action(
-            "competitor_scratched",
-            entity_type="competitor",
-            entity_id=competitor.id,
+        db.session.flush()
+        scratch_post_state_sha256 = _scratch_post_state_sha256(competitor, snapshot)
+        audit_entry = _append_scratch_audit(
+            action="competitor_scratched",
+            competitor_id=competitor.id,
+            judge_user_id=judge_user_id,
             details={
                 "judge_id": judge_user_id,
                 "effects": [e.description for e in effects],
                 "scratch_snapshot": snapshot,
+                "scratch_post_state_sha256": scratch_post_state_sha256,
             },
         )
+        undo_token = scratch_undo_token(audit_entry)
 
     return {
         "success": True,
         "message": f"Competitor scratched. {effects_applied} effect(s) applied.",
         "effects_applied": effects_applied,
+        "undo_token": undo_token,
         # Reported, not folded into "message": scratch_confirm discards
         # message entirely and builds its own flash, so anything written
         # there would never reach the operator.  The heats-page scratch
@@ -807,6 +990,17 @@ def _snapshot_competitor_type(audit_entry) -> str:
     return snapshot.get("competitor_type", "pro")
 
 
+def _consumed_scratch_ids(entries) -> set[int]:
+    consumed: set[int] = set()
+    for entry in entries:
+        restored_from = _scratch_audit_details(entry).get("restored_from")
+        try:
+            consumed.add(int(restored_from))
+        except (TypeError, ValueError):
+            continue
+    return consumed
+
+
 def find_undoable_scratch(competitor_id: int, competitor_type: str | None = None):
     """Return the AuditLog row an undo would restore from, or None.
 
@@ -823,7 +1017,7 @@ def find_undoable_scratch(competitor_id: int, competitor_type: str | None = None
     from models.audit_log import AuditLog
 
     cutoff = utc_now_naive() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
-    return next(
+    scratch_entry = next(
         (
             entry
             for entry in AuditLog.query.filter(
@@ -838,6 +1032,15 @@ def find_undoable_scratch(competitor_id: int, competitor_type: str | None = None
         ),
         None,
     )
+    if scratch_entry is None or scratch_undo_token(scratch_entry) is None:
+        return None
+    undo_entries = AuditLog.query.filter(
+        AuditLog.action == "scratch_undone",
+        AuditLog.entity_id == competitor_id,
+    ).all()
+    if scratch_entry.id in _consumed_scratch_ids(undo_entries):
+        return None
+    return scratch_entry
 
 
 def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) -> set:
@@ -858,20 +1061,47 @@ def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) 
         return set()
 
     cutoff = utc_now_naive() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
-    return {
-        entry.entity_id
-        for entry in AuditLog.query.filter(
+    scratch_entries = (
+        AuditLog.query.filter(
             AuditLog.action == "competitor_scratched",
             AuditLog.entity_id.in_(ids),
             AuditLog.created_at >= cutoff,
+        )
+        .order_by(AuditLog.id.desc())
+        .all()
+    )
+    latest_by_competitor = {}
+    for entry in scratch_entries:
+        if (
+            entry.entity_id in latest_by_competitor
+            or (
+                competitor_type is not None
+                and _snapshot_competitor_type(entry) != competitor_type
+            )
+        ):
+            continue
+        latest_by_competitor[entry.entity_id] = entry
+
+    consumed = _consumed_scratch_ids(
+        AuditLog.query.filter(
+            AuditLog.action == "scratch_undone",
+            AuditLog.entity_id.in_(ids),
         ).all()
-        if competitor_type is None
-        or _snapshot_competitor_type(entry) == competitor_type
+    )
+    return {
+        competitor_id
+        for competitor_id, entry in latest_by_competitor.items()
+        if entry.id not in consumed and scratch_undo_token(entry) is not None
     }
 
 
-def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
-                    competitor_type: str | None = None) -> dict:
+def reverse_cascade(
+    competitor_id: int,
+    judge_user_id: int,
+    tournament,
+    competitor_type: str | None = None,
+    expected_undo_token: str | None = None,
+) -> dict:
     """Reverse a scratch cascade by restoring from the audit log snapshot.
 
     Only works within SCRATCH_UNDO_WINDOW_MINUTES of the original scratch.
@@ -893,7 +1123,6 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
     from models.audit_log import AuditLog
     from models.competitor import CollegeCompetitor, ProCompetitor
     from models.event import Event, EventResult
-    from services.audit import log_action
     from services.flight_builder import lock_tournament_schedule
 
     tournament = lock_tournament_schedule(tournament)
@@ -917,19 +1146,48 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
                     AuditLog.action == "competitor_scratched",
                     AuditLog.entity_id == competitor_id,
                 )
+                .order_by(AuditLog.id.desc())
                 .all()
                 if _matches_type(entry)
             ),
             None,
         )
         if any_entry is not None:
-            return {"success": False, "message": "Undo window expired"}
-        return {"success": False, "message": "No scratch to undo"}
+            cutoff = utc_now_naive() - timedelta(
+                minutes=SCRATCH_UNDO_WINDOW_MINUTES
+            )
+            if any_entry.created_at < cutoff:
+                return {
+                    "success": False,
+                    "message": "Undo window expired",
+                    "status_code": 409,
+                }
+            return {
+                "success": False,
+                "message": "Scratch is no longer undoable",
+                "status_code": 409,
+            }
+        return {
+            "success": False,
+            "message": "No scratch to undo",
+            "status_code": 409,
+        }
 
-    try:
-        details = json.loads(audit_entry.details_json or "{}")
-    except (json.JSONDecodeError, TypeError):
-        return {"success": False, "message": "Audit entry corrupt; cannot undo"}
+    details = _scratch_audit_details(audit_entry)
+    current_undo_token = scratch_undo_token(audit_entry)
+    if (
+        not expected_undo_token
+        or current_undo_token is None
+        or not hmac.compare_digest(expected_undo_token, current_undo_token)
+    ):
+        return {
+            "success": False,
+            "message": (
+                "Scratch undo review is missing or stale. Review the current "
+                "scratch state before trying again."
+            ),
+            "status_code": 409,
+        }
 
     snapshot = details.get("scratch_snapshot", {})
 
@@ -988,6 +1246,21 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
             and relay_snapshot.get("relay_team_id") is not None
         },
     )
+
+    expected_post_state = details.get("scratch_post_state_sha256")
+    current_post_state = _scratch_post_state_sha256(comp, snapshot)
+    if (
+        not isinstance(expected_post_state, str)
+        or not hmac.compare_digest(expected_post_state, current_post_state)
+    ):
+        return {
+            "success": False,
+            "message": (
+                "Scoring or schedule state changed after this scratch. "
+                "The scratch was not reversed."
+            ),
+            "status_code": 409,
+        }
 
     with db.session.begin_nested():
         # --- Restore competitor status ---------------------------------------
@@ -1230,10 +1503,10 @@ def reverse_cascade(competitor_id: int, judge_user_id: int, tournament,
             _rebuild_individual_points(list(affected_college_competitor_ids))
 
         # --- Audit log the undo ---------------------------------------------
-        log_action(
-            "scratch_undone",
-            entity_type="competitor",
-            entity_id=competitor_id,
+        _append_scratch_audit(
+            action="scratch_undone",
+            competitor_id=competitor_id,
+            judge_user_id=judge_user_id,
             details={
                 "judge_id": judge_user_id,
                 "restored_from": audit_entry.id,

--- a/static/js/offline_queue_shared.js
+++ b/static/js/offline_queue_shared.js
@@ -1,8 +1,47 @@
-/* Shared client-side queue helpers for offline scoring pages. */
+/* Shared exactly-once queue helpers for offline scoring pages. */
 (function () {
     'use strict';
 
     var KEY = 'proam_heat_score_queue_v1';
+    var LOCK_PREFIX = KEY + '_mutation_participant_v1:';
+    var LOCK_NAME = KEY + '_mutation';
+    var SCHEMA_VERSION = 2;
+    var MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+    var LOCK_WAIT_MS = 5000;
+    var LOCK_LEASE_MS = 10000;
+    var MAX_MUTATION_ATTEMPTS = 5;
+    var TRANSPORT_FIELDS = {
+        csrf_token: true,
+        replay_token: true,
+        payload_sha256: true,
+        tournament_id: true,
+        heat_id: true
+    };
+
+    function QueueError(code, message, httpStatus, data) {
+        this.name = 'QueueError';
+        this.code = code;
+        this.message = message || code;
+        this.httpStatus = httpStatus || 0;
+        this.data = data || null;
+    }
+    QueueError.prototype = Object.create(Error.prototype);
+    QueueError.prototype.constructor = QueueError;
+
+    function uuid() {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return window.crypto.randomUUID();
+        }
+        var bytes = new Uint8Array(16);
+        window.crypto.getRandomValues(bytes);
+        bytes[6] = (bytes[6] & 15) | 64;
+        bytes[8] = (bytes[8] & 63) | 128;
+        var hex = Array.prototype.map.call(bytes, function (value) {
+            return value.toString(16).padStart(2, '0');
+        }).join('');
+        return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16),
+            hex.slice(16, 20), hex.slice(20)].join('-');
+    }
 
     function read() {
         try {
@@ -13,47 +52,529 @@
         }
     }
 
-    function write(queue) {
+    function writeRaw(queue) {
         localStorage.setItem(KEY, JSON.stringify(queue));
     }
 
-    function upsert(entry) {
-        var queue = read().filter(function (item) {
-            return !(item.heat_id === entry.heat_id && item.url === entry.url);
+    function wait(milliseconds) {
+        return new Promise(function (resolve) {
+            setTimeout(resolve, milliseconds);
         });
-        queue.push(entry);
-        write(queue);
-        return queue;
+    }
+
+    function storageParticipants() {
+        var participants = [];
+        var expired = [];
+        for (var index = 0; index < localStorage.length; index += 1) {
+            var key = localStorage.key(index);
+            if (!key || key.indexOf(LOCK_PREFIX) !== 0) continue;
+            try {
+                var participant = JSON.parse(localStorage.getItem(key) || 'null');
+                if (!participant || Number(participant.expires_at || 0) <= Date.now()) {
+                    expired.push(key);
+                } else {
+                    participants.push(participant);
+                }
+            } catch (_error) {
+                expired.push(key);
+            }
+        }
+        expired.forEach(function (key) { localStorage.removeItem(key); });
+        return participants;
+    }
+
+    async function withStorageTicketLock(callback) {
+        var owner = uuid();
+        var participantKey = LOCK_PREFIX + owner;
+        var deadline = Date.now() + LOCK_WAIT_MS;
+        localStorage.setItem(participantKey, JSON.stringify({
+            owner: owner,
+            choosing: true,
+            ticket: 0,
+            expires_at: Date.now() + LOCK_LEASE_MS
+        }));
+        var ticket = storageParticipants().reduce(function (highest, participant) {
+            return Math.max(highest, Number(participant.ticket || 0));
+        }, 0) + 1;
+        localStorage.setItem(participantKey, JSON.stringify({
+            owner: owner,
+            choosing: false,
+            ticket: ticket,
+            expires_at: Date.now() + LOCK_LEASE_MS
+        }));
+        try {
+            while (Date.now() < deadline) {
+                var blocked = storageParticipants().some(function (participant) {
+                    if (participant.owner === owner) return false;
+                    if (participant.choosing) return true;
+                    var otherTicket = Number(participant.ticket || 0);
+                    return otherTicket < ticket ||
+                        (otherTicket === ticket && String(participant.owner) < owner);
+                });
+                if (!blocked) return await callback();
+                await wait(20 + Math.floor(Math.random() * 30));
+            }
+            throw new QueueError(
+                'queue_lock_timeout',
+                'Another tab is updating the offline queue. Try again.'
+            );
+        } finally {
+            localStorage.removeItem(participantKey);
+        }
+    }
+
+    function withQueueLock(callback) {
+        if (navigator.locks && typeof navigator.locks.request === 'function') {
+            return navigator.locks.request(
+                LOCK_NAME,
+                {mode: 'exclusive'},
+                callback
+            );
+        }
+        return withStorageTicketLock(callback);
+    }
+
+    function entryKey(entry, index) {
+        if (entry && entry.request_id) return 'request:' + String(entry.request_id);
+        return [
+            'legacy',
+            String((entry && entry.url) || ''),
+            String((entry && entry.heat_id) || ''),
+            String((entry && (entry.queued_at || entry.saved_at)) || ''),
+            String(index || 0)
+        ].join(':');
+    }
+
+    function normalizeQueue(queue) {
+        var normalized = [];
+        var positions = {};
+        (Array.isArray(queue) ? queue : []).forEach(function (entry, index) {
+            var key = entryKey(entry, index);
+            if (Object.prototype.hasOwnProperty.call(positions, key)) {
+                normalized[positions[key]] = entry;
+            } else {
+                positions[key] = normalized.length;
+                normalized.push(entry);
+            }
+        });
+        return normalized;
+    }
+
+    function sameEntry(left, right) {
+        return JSON.stringify(left) === JSON.stringify(right);
+    }
+
+    function containsExpected(queue, expected) {
+        return expected.every(function (entry, index) {
+            var key = entryKey(entry, index);
+            return queue.some(function (candidate, candidateIndex) {
+                return entryKey(candidate, candidateIndex) === key &&
+                    sameEntry(candidate, entry);
+            });
+        });
+    }
+
+    async function mutateQueue(mutator, verifier) {
+        return withQueueLock(async function () {
+            for (var attempt = 0; attempt < MAX_MUTATION_ATTEMPTS; attempt += 1) {
+                var next = normalizeQueue(mutator(read().slice()));
+                writeRaw(next);
+                var committed = read();
+                if (containsExpected(committed, next) && verifier(committed, next)) {
+                    return committed;
+                }
+                await wait(0);
+            }
+            throw new QueueError(
+                'queue_write_conflict',
+                'Another tab changed the offline queue before this update was verified.'
+            );
+        });
+    }
+
+    function canonicalPairs(payload, tournamentId, heatId) {
+        var pairs = [];
+        Object.keys(payload || {}).forEach(function (key) {
+            if (TRANSPORT_FIELDS[key]) return;
+            var value = payload[key];
+            if (Array.isArray(value)) {
+                value.forEach(function (item) {
+                    pairs.push([String(key), String(item || '')]);
+                });
+            } else {
+                pairs.push([String(key), String(value || '')]);
+            }
+        });
+        pairs.push(['heat_id', String(Number(heatId))]);
+        pairs.push(['tournament_id', String(Number(tournamentId))]);
+        pairs.sort(function (left, right) {
+            if (left[0] < right[0]) return -1;
+            if (left[0] > right[0]) return 1;
+            if (left[1] < right[1]) return -1;
+            if (left[1] > right[1]) return 1;
+            return 0;
+        });
+        return pairs;
+    }
+
+    async function sha256(value) {
+        var encoded = new TextEncoder().encode(value);
+        var digest = await window.crypto.subtle.digest('SHA-256', encoded);
+        return Array.prototype.map.call(new Uint8Array(digest), function (byte) {
+            return byte.toString(16).padStart(2, '0');
+        }).join('');
+    }
+
+    async function payloadFingerprint(payload, tournamentId, heatId) {
+        return sha256(JSON.stringify(canonicalPairs(payload, tournamentId, heatId)));
+    }
+
+    async function prepareEntry(entry, context) {
+        var prepared = Object.assign({}, entry || {});
+        var sourcePayload = Object.assign({}, prepared.payload || {});
+        prepared.schema_version = SCHEMA_VERSION;
+        // A cached offline page contains the request ID minted when the package
+        // was prepared. Treat that hidden value as a no-JS fallback only: each
+        // new JS submission is a new action. A queued retry already carries
+        // request_id on the entry itself and therefore preserves its receipt
+        // identity across reconnects and lost responses.
+        prepared.request_id = prepared.request_id || uuid();
+        prepared.tournament_id = Number(
+            prepared.tournament_id || sourcePayload.tournament_id || context.tournament_id
+        );
+        prepared.heat_id = Number(prepared.heat_id || sourcePayload.heat_id || 0);
+        prepared.issuer_user_id = Number(
+            prepared.issuer_user_id || sourcePayload.issuer_user_id || context.issuer_user_id
+        );
+        prepared.issuer_role = prepared.issuer_role || sourcePayload.issuer_role ||
+            context.issuer_role;
+        prepared.schedule_fingerprint = prepared.schedule_fingerprint ||
+            sourcePayload.schedule_fingerprint || context.schedule_fingerprint;
+        prepared.application_build = prepared.application_build ||
+            sourcePayload.application_build || context.application_build;
+        prepared.queued_at = prepared.queued_at || sourcePayload.queued_at ||
+            new Date().toISOString();
+        prepared.payload = sourcePayload;
+        prepared.payload.request_id = prepared.request_id;
+        prepared.payload.tournament_id = String(prepared.tournament_id);
+        prepared.payload.heat_id = String(prepared.heat_id);
+        prepared.payload.issuer_user_id = String(prepared.issuer_user_id);
+        prepared.payload.issuer_role = prepared.issuer_role;
+        prepared.payload.schedule_fingerprint = prepared.schedule_fingerprint;
+        prepared.payload.application_build = prepared.application_build;
+        prepared.payload.queued_at = prepared.queued_at;
+        prepared.payload_sha256 = await payloadFingerprint(
+            prepared.payload,
+            prepared.tournament_id,
+            prepared.heat_id
+        );
+        prepared.payload.payload_sha256 = prepared.payload_sha256;
+        return prepared;
+    }
+
+    function upsert(entry) {
+        return mutateQueue(function (queue) {
+            queue = queue.filter(function (item) {
+                return String(item.request_id || '') !== String(entry.request_id || '');
+            });
+            queue.push(entry);
+            return queue;
+        }, function (committed) {
+            return committed.some(function (item) {
+                return String(item.request_id || '') === String(entry.request_id || '') &&
+                    sameEntry(item, entry);
+            });
+        });
     }
 
     function remove(url, heatId) {
-        var queue = read().filter(function (item) {
-            return !(String(item.url || '') === String(url || '') && Number(item.heat_id || 0) === Number(heatId || 0));
+        return mutateQueue(function (queue) {
+            return queue.filter(function (item) {
+                return !(
+                    String(item.url || '') === String(url || '') &&
+                    Number(item.heat_id || 0) === Number(heatId || 0)
+                );
+            });
+        }, function (committed) {
+            return !committed.some(function (item) {
+                return String(item.url || '') === String(url || '') &&
+                    Number(item.heat_id || 0) === Number(heatId || 0);
+            });
         });
-        write(queue);
-        return queue;
+    }
+
+    function removeByRequestId(requestId) {
+        return mutateQueue(function (queue) {
+            return queue.filter(function (item) {
+                return String(item.request_id || '') !== String(requestId || '');
+            });
+        }, function (committed) {
+            return !committed.some(function (item) {
+                return String(item.request_id || '') === String(requestId || '');
+            });
+        });
+    }
+
+    function removeTournament(tournamentId) {
+        return mutateQueue(function (queue) {
+            return queue.filter(function (item) {
+                return Number(item.tournament_id || 0) !== Number(tournamentId || 0);
+            });
+        }, function (committed) {
+            return !committed.some(function (item) {
+                return Number(item.tournament_id || 0) === Number(tournamentId || 0);
+            });
+        });
+    }
+
+    function merge(entries) {
+        return mutateQueue(function (queue) {
+            var known = {};
+            queue.forEach(function (item, index) {
+                known[entryKey(item, index)] = true;
+            });
+            (Array.isArray(entries) ? entries : []).forEach(function (entry, index) {
+                var key = entryKey(entry, index);
+                if (!known[key]) {
+                    known[key] = true;
+                    queue.push(entry);
+                }
+            });
+            return queue;
+        }, function (committed) {
+            return (Array.isArray(entries) ? entries : []).every(function (entry, index) {
+                var key = entryKey(entry, index);
+                return committed.some(function (candidate, candidateIndex) {
+                    return entryKey(candidate, candidateIndex) === key;
+                });
+            });
+        });
     }
 
     function find(url, heatId) {
         return read().find(function (item) {
-            return String(item.url || '') === String(url || '') && Number(item.heat_id || 0) === Number(heatId || 0);
+            return String(item.url || '') === String(url || '') &&
+                Number(item.heat_id || 0) === Number(heatId || 0);
+        });
+    }
+
+    function findByRequestId(requestId) {
+        return read().find(function (item) {
+            return String(item.request_id || '') === String(requestId || '');
         });
     }
 
     function byTournament(tournamentId) {
-        var marker = '/scoring/' + tournamentId + '/';
         return read().filter(function (item) {
-            return String(item.url || '').indexOf(marker) !== -1;
+            return Number(item.tournament_id || 0) === Number(tournamentId || 0);
         });
+    }
+
+    function ageState(entry, now) {
+        var queuedAt = Date.parse(entry.queued_at || '');
+        if (!Number.isFinite(queuedAt)) return 'queued_at_invalid';
+        if ((now || Date.now()) - queuedAt > MAX_AGE_MS) {
+            return 'manual_reconciliation_required';
+        }
+        return 'ready';
+    }
+
+    function bindingState(entry, context) {
+        if (!entry.issuer_user_id || !entry.issuer_role || !entry.schedule_fingerprint) {
+            return 'legacy_unbound';
+        }
+        if (Number(entry.tournament_id) !== Number(context.tournament_id)) {
+            return 'tournament_mismatch';
+        }
+        if (Number(entry.issuer_user_id) !== Number(context.issuer_user_id)) {
+            return 'issuer_mismatch';
+        }
+        if (String(entry.issuer_role) !== String(context.issuer_role)) {
+            return 'role_mismatch';
+        }
+        if (String(entry.schedule_fingerprint) !== String(context.schedule_fingerprint)) {
+            return 'stale_manifest';
+        }
+        return 'ready';
+    }
+
+    function verifyReceipt(entry, receipt) {
+        return Boolean(
+            receipt && receipt.accepted === true &&
+            String(receipt.request_id || '') === String(entry.request_id || '') &&
+            Number(receipt.tournament_id || 0) === Number(entry.tournament_id || 0) &&
+            Number(receipt.heat_id || 0) === Number(entry.heat_id || 0) &&
+            Number(receipt.issuing_user_id || 0) === Number(entry.issuer_user_id || 0) &&
+            String(receipt.payload_sha256 || '') === String(entry.payload_sha256 || '')
+        );
+    }
+
+    async function removeVerified(entry, receipt) {
+        if (!verifyReceipt(entry, receipt)) {
+            throw new QueueError(
+                'receipt_mismatch',
+                'The server receipt does not match this queued score.'
+            );
+        }
+        return removeByRequestId(entry.request_id);
+    }
+
+    function responseCode(data, fallback) {
+        return data && data.error && data.error.code ? data.error.code : fallback;
+    }
+
+    async function verifiedJson(response, entry) {
+        if (response.redirected) {
+            throw new QueueError(
+                'session_required',
+                'Sign in as the queue issuer before syncing.',
+                response.status
+            );
+        }
+        var contentType = response.headers.get('Content-Type') || '';
+        if (contentType.toLowerCase().indexOf('application/json') === -1) {
+            throw new QueueError(
+                'unexpected_response',
+                'The server returned HTML instead of a score receipt.',
+                response.status
+            );
+        }
+        var data;
+        try {
+            data = await response.json();
+        } catch (_error) {
+            throw new QueueError(
+                'invalid_json',
+                'The server response was not valid JSON.',
+                response.status
+            );
+        }
+        if (!response.ok || !data.ok) {
+            throw new QueueError(
+                responseCode(data, 'server_rejected_' + response.status),
+                data.message || 'The server rejected this queued score.',
+                response.status,
+                data
+            );
+        }
+        if (!verifyReceipt(entry, data.receipt)) {
+            throw new QueueError(
+                'receipt_mismatch',
+                'The server accepted a different score request.',
+                response.status,
+                data
+            );
+        }
+        return data;
+    }
+
+    function formBody(payload) {
+        var body = new FormData();
+        Object.keys(payload || {}).forEach(function (key) {
+            body.append(key, payload[key]);
+        });
+        return body;
+    }
+
+    async function post(url, payload) {
+        return fetch(url, {
+            method: 'POST',
+            body: formBody(payload),
+            headers: {
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            credentials: 'same-origin',
+            redirect: 'follow'
+        });
+    }
+
+    async function renewReplayToken(entry, context) {
+        if (bindingState(entry, context) !== 'ready') {
+            throw new QueueError(
+                'authorization_denied',
+                'Only the original authorized user can renew replay authority.'
+            );
+        }
+        var response = await fetch('/scoring/api/replay-token', {
+            headers: {'Accept': 'application/json'},
+            credentials: 'same-origin'
+        });
+        if (response.redirected ||
+                (response.headers.get('Content-Type') || '').indexOf('application/json') === -1) {
+            throw new QueueError('session_required', 'Sign in before syncing.', response.status);
+        }
+        var data = await response.json();
+        if (!response.ok || !data.ok ||
+                Number(data.issuer_user_id) !== Number(entry.issuer_user_id) ||
+                String(data.issuer_role) !== String(entry.issuer_role)) {
+            throw new QueueError(
+                responseCode(data, 'authorization_denied'),
+                data.message || 'Replay authority could not be renewed.',
+                response.status,
+                data
+            );
+        }
+        entry.payload.replay_token = data.replay_token;
+        await upsert(entry);
+        return entry;
+    }
+
+    async function replay(entry, context) {
+        if (!entry.payload.replay_token) await renewReplayToken(entry, context);
+        var response = await post('/scoring/api/replay', entry.payload);
+        try {
+            return await verifiedJson(response, entry);
+        } catch (error) {
+            if (error.code !== 'replay_token_expired' &&
+                    error.code !== 'replay_token_required') throw error;
+            await renewReplayToken(entry, context);
+            response = await post('/scoring/api/replay', entry.payload);
+            return verifiedJson(response, entry);
+        }
+    }
+
+    async function syncEntry(rawEntry, context) {
+        var age = ageState(rawEntry);
+        if (age !== 'ready') {
+            throw new QueueError(age, 'This queued score requires manual reconciliation.');
+        }
+        var binding = bindingState(rawEntry, context);
+        if (binding !== 'ready') {
+            throw new QueueError(binding, 'This queued score cannot sync in the current context.');
+        }
+        var entry = await prepareEntry(rawEntry, context);
+        await upsert(entry);
+        var response = await post(entry.url, entry.payload);
+        try {
+            return {entry: entry, data: await verifiedJson(response, entry)};
+        } catch (error) {
+            if (error.code !== 'csrf_expired') throw error;
+            return {entry: entry, data: await replay(entry, context)};
+        }
     }
 
     window.ProAmOfflineQueue = {
         key: KEY,
+        schemaVersion: SCHEMA_VERSION,
+        maxAgeMs: MAX_AGE_MS,
         read: read,
-        write: write,
         upsert: upsert,
+        merge: merge,
         remove: remove,
+        removeByRequestId: removeByRequestId,
+        removeTournament: removeTournament,
+        removeVerified: removeVerified,
         find: find,
-        byTournament: byTournament
+        findByRequestId: findByRequestId,
+        byTournament: byTournament,
+        ageState: ageState,
+        bindingState: bindingState,
+        prepareEntry: prepareEntry,
+        payloadFingerprint: payloadFingerprint,
+        verifyReceipt: verifyReceipt,
+        mutateQueue: mutateQueue,
+        syncEntry: syncEntry,
+        QueueError: QueueError
     };
-})();
+}());

--- a/static/offline_queue.js
+++ b/static/offline_queue.js
@@ -1,44 +1,55 @@
-/**
- * Offline Queue Client
- * - Registers the service worker
- * - Shows/hides the offline status banner
- * - Handles sync-complete notifications from the SW
- * - Intercepts the score entry form to display offline feedback
- */
+/** Global service-worker registration and offline state surface. */
 (function () {
     'use strict';
 
-    // ── Service Worker Registration ──────────────────────────────────────────
+    function controllerMessage(message) {
+        if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage(message);
+        }
+    }
+
+    function validatePreparedPackage() {
+        if (!window.ProAmOfflineContext) return;
+        controllerMessage({
+            type: 'validate-prepared-package',
+            context: window.ProAmOfflineContext
+        });
+    }
+
     function registerSW() {
         if (!('serviceWorker' in navigator)) return;
-        navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(function (err) {
-            console.warn('[ProAm SW] Registration failed:', err);
+        navigator.serviceWorker.register('/sw.js', {scope: '/'}).then(function () {
+            return navigator.serviceWorker.ready;
+        }).then(function () {
+            validatePreparedPackage();
+            controllerMessage({type: 'legacy-queue-status'});
+        }).catch(function (error) {
+            console.warn('[ProAm SW] Registration failed:', error);
         });
 
-        // Listen for sync messages from the SW
+        navigator.serviceWorker.addEventListener('controllerchange', function () {
+            validatePreparedPackage();
+        });
         navigator.serviceWorker.addEventListener('message', function (event) {
-            if (!event.data) return;
-            if (event.data.type === 'sync-complete') {
-                if (event.data.success > 0) {
-                    showSyncBanner(event.data.success || event.data.count || 0);
-                }
+            var data = event.data || {};
+            if (data.type === 'legacy-sync-complete' && data.success > 0) {
+                showSyncBanner(data.success);
             }
-            if (event.data.type === 'replay-failed') {
-                showReplayFailedBanner(event.data.count || 0, event.data.reasons || []);
+            if (data.type === 'legacy-sync-complete' && data.failed > 0) {
+                showReplayFailedBanner(data.failed, data.reasons || []);
             }
         });
     }
 
-    // ── Offline Banner ───────────────────────────────────────────────────────
-    function createBanner(id, html, bg, color) {
+    function createBanner(id, html, background, color) {
         var banner = document.createElement('div');
         banner.id = id;
         banner.innerHTML = html;
         banner.style.cssText = [
             'position:fixed', 'top:0', 'left:0', 'right:0',
-            'z-index:9999', 'background:' + bg, 'color:' + color,
+            'z-index:9999', 'background:' + background, 'color:' + color,
             'text-align:center', 'padding:8px 16px', 'font-size:14px',
-            'font-weight:600', 'box-shadow:0 2px 8px rgba(0,0,0,.3)',
+            'font-weight:600', 'box-shadow:0 2px 8px rgba(0,0,0,.3)'
         ].join(';');
         return banner;
     }
@@ -47,11 +58,11 @@
         if (document.getElementById('proam-offline-banner')) return;
         var banner = createBanner(
             'proam-offline-banner',
-            '<i class="bi bi-wifi-off"></i> &nbsp;Offline mode — scores will be queued and synced when connection restores.',
-            '#e89012', '#000'
+            '<i class="bi bi-wifi-off"></i> &nbsp;Offline mode - score submissions stay on this device until verified.',
+            '#e89012',
+            '#000'
         );
         document.body.insertBefore(banner, document.body.firstChild);
-        // Push content down so the banner doesn't cover the nav
         document.body.style.paddingTop = (
             parseInt(document.body.style.paddingTop || '0', 10) + 40
         ) + 'px';
@@ -59,129 +70,47 @@
 
     function hideOfflineBanner() {
         var banner = document.getElementById('proam-offline-banner');
-        if (banner) {
-            banner.remove();
-            document.body.style.paddingTop = Math.max(
-                0,
-                parseInt(document.body.style.paddingTop || '0', 10) - 40
-            ) + 'px';
-        }
+        if (!banner) return;
+        banner.remove();
+        document.body.style.paddingTop = Math.max(
+            0,
+            parseInt(document.body.style.paddingTop || '0', 10) - 40
+        ) + 'px';
     }
 
     function showSyncBanner(count) {
-        var msg = count === 1
-            ? '1 queued score has been synced successfully.'
-            : count + ' queued scores have been synced successfully.';
+        var message = count === 1 ?
+            '1 legacy queued score was verified and removed.' :
+            count + ' legacy queued scores were verified and removed.';
         var flash = document.createElement('div');
         flash.className = 'alert alert-success position-fixed shadow';
-        flash.style.cssText = 'top:70px;right:20px;z-index:9998;max-width:320px;';
-        flash.innerHTML = '<i class="bi bi-check-circle-fill"></i> ' + msg;
+        flash.style.cssText = 'top:70px;right:20px;z-index:9998;max-width:360px;';
+        flash.innerHTML = '<i class="bi bi-check-circle-fill"></i> ' + message;
         document.body.appendChild(flash);
         setTimeout(function () { flash.remove(); }, 6000);
     }
 
     function showReplayFailedBanner(count, reasons) {
-        // Remove any existing failure banner
         var existing = document.getElementById('proam-replay-failed-banner');
         if (existing) existing.remove();
-
-        var reasonText = '';
-        if (reasons.indexOf('csrf_expired') >= 0) {
-            reasonText = 'Session expired while offline. ';
-        }
-        if (reasons.indexOf('version_conflict') >= 0) {
-            reasonText += 'Another judge updated the same heat. ';
-        }
-
-        var msg = count === 1
-            ? '1 queued score failed to sync. '
-            : count + ' queued scores failed to sync. ';
-
+        var needsManual = reasons.indexOf('manual_reconciliation_required') >= 0;
+        var message = count === 1 ?
+            '1 legacy queued score remains on this device.' :
+            count + ' legacy queued scores remain on this device.';
+        if (needsManual) message += ' An old entry requires manual reconciliation.';
         var banner = document.createElement('div');
         banner.id = 'proam-replay-failed-banner';
-        banner.className = 'alert alert-danger position-fixed shadow';
-        banner.style.cssText = 'top:70px;right:20px;z-index:9998;max-width:400px;';
-        banner.innerHTML =
-            '<i class="bi bi-exclamation-triangle-fill"></i> ' + msg + reasonText +
-            '<br><button class="btn btn-sm btn-outline-light mt-2" id="proam-retry-sync">' +
-            '<i class="bi bi-arrow-clockwise"></i> Retry Sync</button>' +
-            '<button class="btn btn-sm btn-outline-secondary mt-2 ms-2" onclick="this.parentElement.remove()">' +
-            'Dismiss</button>';
+        banner.className = 'alert alert-warning position-fixed shadow';
+        banner.style.cssText = 'top:70px;right:20px;z-index:9998;max-width:420px;';
+        banner.innerHTML = '<i class="bi bi-exclamation-triangle-fill"></i> ' + message;
         document.body.appendChild(banner);
-
-        // Wire up retry button
-        var retryBtn = document.getElementById('proam-retry-sync');
-        if (retryBtn) {
-            retryBtn.addEventListener('click', function () {
-                if (navigator.serviceWorker && navigator.serviceWorker.controller) {
-                    navigator.serviceWorker.controller.postMessage({ type: 'manual-sync' });
-                }
-                banner.remove();
-            });
-        }
     }
 
-    // ── Score-entry form feedback when offline ───────────────────────────────
-    function patchScoreForm() {
-        // Only applies on the heat entry page
-        if (!/\/scoring\/\d+\/heat\/\d+\/enter/.test(window.location.pathname)) return;
-
-        document.addEventListener('submit', function (e) {
-            var form = e.target;
-            if (form.method && form.method.toLowerCase() !== 'post') return;
-            if (!/\/scoring\/\d+\/heat\/\d+\/enter/.test(form.action)) return;
-
-            if (!navigator.onLine) {
-                // Let the SW handle it; intercept the response to show feedback
-                e.preventDefault();
-                var data = new URLSearchParams(new FormData(form)).toString();
-                fetch(form.action, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                    body: data,
-                }).then(function (resp) {
-                    return resp.json();
-                }).then(function (json) {
-                    if (json.offline) {
-                        showOfflineQueuedAlert(json.message || 'Score queued for sync.');
-                    }
-                }).catch(function () {
-                    showOfflineQueuedAlert('Score queued for sync when connection restores.');
-                });
-            }
-        }, true);
-    }
-
-    function showOfflineQueuedAlert(msg) {
-        var existing = document.getElementById('proam-offline-queued');
-        if (existing) existing.remove();
-        var alert = document.createElement('div');
-        alert.id = 'proam-offline-queued';
-        alert.className = 'alert alert-warning mt-3';
-        alert.innerHTML = '<i class="bi bi-clock-history"></i> ' + msg;
-        var container = document.querySelector('.container-fluid, .container, main');
-        if (container) {
-            container.insertBefore(alert, container.firstChild);
-        } else {
-            document.body.insertBefore(alert, document.body.firstChild);
-        }
-    }
-
-    // ── Init ─────────────────────────────────────────────────────────────────
     if (!navigator.onLine) showOfflineBanner();
     window.addEventListener('online', function () {
         hideOfflineBanner();
-        // Trigger manual replay in case Background Sync isn't supported
-        if (navigator.serviceWorker && navigator.serviceWorker.controller) {
-            navigator.serviceWorker.controller.postMessage({ type: 'manual-sync' });
-        }
+        validatePreparedPackage();
     });
     window.addEventListener('offline', showOfflineBanner);
-
     registerSW();
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', patchScoreForm);
-    } else {
-        patchScoreForm();
-    }
-})();
+}());

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,15 +1,17 @@
-/**
- * Missoula Pro-Am Service Worker
- * Caches scoring entry pages and queues POST submissions when offline.
- * Replays the queue via Background Sync when connectivity is restored.
- */
+/** Missoula Pro-Am prepared offline cache and legacy queue drain. */
 
 const CACHE_PREFIX = 'proam-scoring-';
 const CACHE_NAME = 'proam-scoring-v2';
 const OFFLINE_FALLBACK = '/static/offline.html';
 const SCORE_ENTRY_PATTERN = /\/scoring\/\d+\/heat\/\d+\/enter/;
+const LOGOUT_PATTERN = /\/auth\/logout\/?$/;
+const PREPARED_CACHE_PREFIX = 'proam-prepared-pages-v2-';
+const PREPARED_META_CACHE = 'proam-prepared-meta-v2';
+const PREPARED_META_URL = '/__proam_prepared_manifest__';
+const LEGACY_DB_NAME = 'proam-offline-queue';
+const LEGACY_STORE_NAME = 'queue';
+const MAX_REPLAY_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
-// ── Install: cache the offline fallback ─────────────────────────────────────
 self.addEventListener('install', (event) => {
     event.waitUntil(
         caches.open(CACHE_NAME).then(cache =>
@@ -19,87 +21,20 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-    event.waitUntil(
-        caches.keys()
-            .then(keys => Promise.all(
-                keys
-                    .filter(key => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME)
-                    .map(key => caches.delete(key))
-            ))
-            .then(() => self.clients.claim())
-    );
+    event.waitUntil((async () => {
+        const names = await caches.keys();
+        await Promise.all(names.filter((name) =>
+            (name.startsWith(CACHE_PREFIX) && name !== CACHE_NAME) ||
+            name.startsWith('proam-prepared-pages-v1-') ||
+            name === 'proam-prepared-meta-v1'
+        ).map((name) => caches.delete(name)));
+        await self.clients.claim();
+    })());
 });
 
-// ── IndexedDB helpers ────────────────────────────────────────────────────────
-function openDB() {
-    return new Promise((resolve, reject) => {
-        const req = indexedDB.open('proam-offline-queue', 1);
-        req.onupgradeneeded = (e) => {
-            e.target.result.createObjectStore('queue', { keyPath: 'id', autoIncrement: true });
-        };
-        req.onsuccess = (e) => resolve(e.target.result);
-        req.onerror = (e) => reject(e.target.error);
-    });
+function sameOrigin(url) {
+    return new URL(url, self.location.origin).origin === self.location.origin;
 }
-
-function enqueue(db, entry) {
-    return new Promise((resolve, reject) => {
-        const tx = db.transaction('queue', 'readwrite');
-        tx.objectStore('queue').add(entry);
-        tx.oncomplete = resolve;
-        tx.onerror = (e) => reject(e.target.error);
-    });
-}
-
-function dequeueAll(db) {
-    return new Promise((resolve, reject) => {
-        const tx = db.transaction('queue', 'readonly');
-        const req = tx.objectStore('queue').getAll();
-        req.onsuccess = (e) => resolve(e.target.result);
-        req.onerror = (e) => reject(e.target.error);
-    });
-}
-
-function removeEntry(db, id) {
-    return new Promise((resolve, reject) => {
-        const tx = db.transaction('queue', 'readwrite');
-        tx.objectStore('queue').delete(id);
-        tx.oncomplete = resolve;
-        tx.onerror = (e) => reject(e.target.error);
-    });
-}
-
-function isSameOriginScoreEntryUrl(rawUrl) {
-    try {
-        const url = new URL(rawUrl, self.location.origin);
-        return url.origin === self.location.origin
-            && SCORE_ENTRY_PATTERN.test(url.pathname);
-    } catch (_invalidUrl) {
-        return false;
-    }
-}
-
-function isScoreEntryRequest(request) {
-    return isSameOriginScoreEntryUrl(request.url);
-}
-
-// ── Fetch handler ────────────────────────────────────────────────────────────
-self.addEventListener('fetch', (event) => {
-    const req = event.request;
-
-    // Intercept POST to score entry when offline
-    if (req.method === 'POST' && isScoreEntryRequest(req)) {
-        event.respondWith(handleScorePost(req));
-        return;
-    }
-
-    // Network-first for GET score entry pages (cache for offline fallback)
-    if (req.method === 'GET' && isScoreEntryRequest(req)) {
-        event.respondWith(loadScorePage(req));
-        return;
-    }
-    // All other requests: default browser handling
-});
 
 function isCacheableScorePage(response, request) {
     const contentType = response.headers.get('content-type') || '';
@@ -109,106 +44,508 @@ function isCacheableScorePage(response, request) {
         && contentType.includes('text/html');
 }
 
-async function loadScorePage(req) {
+self.addEventListener('fetch', (event) => {
+    const request = event.request;
+    if (request.method === 'POST' && LOGOUT_PATTERN.test(request.url)) {
+        event.respondWith(handleLogout(request));
+        return;
+    }
+    if (request.method !== 'GET' || !sameOrigin(request.url)) return;
+    event.respondWith(networkFirstPreparedFallback(request));
+});
+
+async function handleLogout(request) {
+    const response = await fetch(request);
+    if (response.ok || response.redirected) await clearPreparedPackage();
+    return response;
+}
+
+async function networkFirstPreparedFallback(request) {
     try {
-        const resp = await fetch(req);
-        if (isCacheableScorePage(resp, req)) {
+        const response = await fetch(request);
+        if (SCORE_ENTRY_PATTERN.test(request.url) &&
+                isCacheableScorePage(response, request)) {
             try {
                 const cache = await caches.open(CACHE_NAME);
-                await cache.put(req, resp.clone());
+                await cache.put(request, response.clone());
             } catch (_cacheErr) {
                 // A quota/cache failure must never replace a valid live page.
             }
         }
-        return resp;
-    } catch (_networkErr) {
-        try {
-            const cache = await caches.open(CACHE_NAME);
-            const cachedPage = await cache.match(req);
-            if (cachedPage) return cachedPage;
-
-            const fallback = await cache.match(OFFLINE_FALLBACK);
-            if (fallback) return fallback;
-        } catch (_cacheReadErr) {
-            // Fall through to an explicit bounded response.
+        return response;
+    } catch (networkError) {
+        const manifest = await readPreparedManifest();
+        if (manifest && manifest.cache_name) {
+            const preparedCache = await caches.open(manifest.cache_name);
+            const prepared = await preparedCache.match(request, {ignoreSearch: false});
+            if (prepared) return prepared;
         }
 
-        return new Response('Offline score page unavailable', {
-            status: 503,
-            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
-        });
-    }
-}
+        if (SCORE_ENTRY_PATTERN.test(request.url)) {
+            try {
+                const cache = await caches.open(CACHE_NAME);
+                const cachedPage = await cache.match(request);
+                if (cachedPage) return cachedPage;
 
-async function handleScorePost(request) {
-    // Try network first
-    try {
-        return await fetch(request.clone());
-    } catch (_networkErr) {
-        // Offline — queue the submission with a replay token
-        const body = await request.text();
-        const replay_token = new URLSearchParams(body).get('replay_token') || '';
-        // Extract tournament_id and heat_id from the URL pattern:
-        // /scoring/{tournament_id}/heat/{heat_id}/enter
-        const urlMatch = new URL(request.url).pathname.match(
-            /\/scoring\/(\d+)\/heat\/(\d+)\/enter/
-        );
-        const tournament_id = urlMatch ? urlMatch[1] : '';
-        const heat_id = urlMatch ? urlMatch[2] : '';
-        const db = await openDB();
-        await enqueue(db, {
-            url: request.url,
-            method: 'POST',
-            body,
-            replay_token,
-            tournament_id,
-            heat_id,
-            timestamp: Date.now(),
-        });
-
-        // Register Background Sync to replay when back online
-        try {
-            await self.registration.sync.register('score-sync');
-        } catch (_syncErr) {
-            // Background Sync API not supported — queue will be replayed on next page load
-        }
-
-        return new Response(
-            JSON.stringify({
-                ok: false,
-                offline: true,
-                category: 'warning',
-                message: 'You are offline. Score queued — it will sync automatically when connection restores.',
-            }),
-            {
-                status: 202,
-                headers: { 'Content-Type': 'application/json' },
+                const fallback = await cache.match(OFFLINE_FALLBACK);
+                if (fallback) return fallback;
+            } catch (_cacheReadErr) {
+                // Fall through to an explicit bounded response.
             }
-        );
+
+            return new Response('Offline score page unavailable', {
+                status: 503,
+                headers: {'Content-Type': 'text/plain; charset=utf-8'}
+            });
+        }
+        throw networkError;
     }
 }
 
-// ── Manual sync trigger (fallback for browsers without Background Sync) ──────
-self.addEventListener('message', (event) => {
-    if (event.data && event.data.type === 'manual-sync') {
-        replayQueue().catch(() => {});
+async function sha256Bytes(value) {
+    const digest = await crypto.subtle.digest('SHA-256', value);
+    return Array.from(new Uint8Array(digest), (byte) =>
+        byte.toString(16).padStart(2, '0')
+    ).join('');
+}
+
+async function sha256(value) {
+    return sha256Bytes(new TextEncoder().encode(value));
+}
+
+function contextMatches(manifest, context) {
+    return Boolean(manifest && context &&
+        Number(manifest.schema_version) === Number(context.schema_version) &&
+        String(manifest.application_build) === String(context.application_build) &&
+        String(manifest.schedule_fingerprint) === String(context.schedule_fingerprint) &&
+        Number(manifest.tournament_id) === Number(context.tournament_id) &&
+        Number(manifest.issuer_user_id) === Number(context.issuer_user_id) &&
+        String(manifest.issuer_role) === String(context.issuer_role));
+}
+
+async function readPreparedManifest() {
+    const cache = await caches.open(PREPARED_META_CACHE);
+    const response = await cache.match(PREPARED_META_URL);
+    if (!response) return null;
+    try {
+        return await response.json();
+    } catch (_error) {
+        return null;
     }
-});
+}
 
-// ── Background Sync ──────────────────────────────────────────────────────────
-self.addEventListener('sync', (event) => {
-    if (event.tag === 'score-sync') {
-        event.waitUntil(replayQueue());
+async function writePreparedManifest(manifest) {
+    const cache = await caches.open(PREPARED_META_CACHE);
+    await cache.put(PREPARED_META_URL, new Response(JSON.stringify(manifest), {
+        headers: {'Content-Type': 'application/json'}
+    }));
+}
+
+async function clearPreparedPackage() {
+    const names = await caches.keys();
+    await Promise.all(names.filter((name) =>
+        name.startsWith(PREPARED_CACHE_PREFIX)
+    ).map((name) => caches.delete(name)));
+    await caches.delete(PREPARED_META_CACHE);
+}
+
+async function verifyManifestRows(manifest) {
+    const rows = [].concat(manifest.pages || [], manifest.assets || []);
+    for (const row of rows) {
+        if (!row.url || !sameOrigin(row.url)) return false;
+        if (row.kind === 'asset' &&
+                !/^[a-f0-9]{64}$/.test(String(row.content_sha256 || ''))) return false;
+        if (row.kind === 'page' &&
+                (!row.fetch_url || !sameOrigin(row.fetch_url))) return false;
+        if (row.kind !== 'asset' && row.kind !== 'page') return false;
     }
-});
+    return rows.length > 0;
+}
 
-async function replayQueue() {
-    const db = await openDB();
-    const entries = await dequeueAll(db);
-    let successCount = 0;
-    let failedCount = 0;
-    const failReasons = [];
+async function verifyFetchedRow(manifest, row, response) {
+    const contentDigest = await sha256Bytes(await response.clone().arrayBuffer());
+    if (row.kind === 'asset') {
+        if (contentDigest !== String(row.content_sha256)) {
+            const error = new Error('content_digest_mismatch');
+            error.code = 'content_digest_mismatch';
+            throw error;
+        }
+        return contentDigest;
+    }
 
+    const expectedHeaders = {
+        'X-ProAm-Offline-Build': String(manifest.application_build),
+        'X-ProAm-Offline-Schedule': String(manifest.schedule_fingerprint),
+        'X-ProAm-Offline-Tournament': String(manifest.tournament_id),
+        'X-ProAm-Offline-Issuer': String(manifest.issuer_user_id),
+        'X-ProAm-Offline-Role': String(manifest.issuer_role)
+    };
+    for (const [name, expected] of Object.entries(expectedHeaders)) {
+        if (String(response.headers.get(name) || '') !== expected) {
+            const error = new Error('prepared_context_mismatch');
+            error.code = 'prepared_context_mismatch';
+            throw error;
+        }
+    }
+    if (String(response.headers.get('X-ProAm-Offline-Content-SHA256') || '') !==
+            contentDigest) {
+        const error = new Error('content_digest_mismatch');
+        error.code = 'content_digest_mismatch';
+        throw error;
+    }
+    return contentDigest;
+}
+
+async function verifyPreparedCache(manifest) {
+    if (!manifest || !manifest.cache_name || !manifest.cached_content_digests) {
+        return false;
+    }
+    const cache = await caches.open(manifest.cache_name);
+    const rows = [].concat(manifest.assets || [], manifest.pages || []);
+    for (const row of rows) {
+        const response = await cache.match(new Request(row.url, {method: 'GET'}), {
+            ignoreSearch: false
+        });
+        const expected = manifest.cached_content_digests[row.url];
+        if (!response || !expected) return false;
+        const actual = await sha256Bytes(await response.arrayBuffer());
+        if (actual !== expected) return false;
+    }
+    return true;
+}
+
+function cacheNameFor(manifest) {
+    return PREPARED_CACHE_PREFIX + [
+        manifest.tournament_id,
+        manifest.issuer_user_id,
+        String(manifest.application_build).slice(0, 16),
+        String(manifest.schedule_fingerprint).slice(0, 16)
+    ].join('-').replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+async function prepareOfflinePackage(manifest, source) {
+    if (!manifest || Number(manifest.schema_version) !== 2 ||
+            !Array.isArray(manifest.pages) || !Array.isArray(manifest.assets) ||
+            !await verifyManifestRows(manifest)) {
+        throw new Error('Invalid prepared-offline manifest.');
+    }
+
+    const previous = await readPreparedManifest();
+    if (previous && !contextMatches(previous, manifest)) {
+        await clearPreparedPackage();
+    }
+
+    const cacheName = cacheNameFor(manifest);
+    await caches.delete(cacheName);
+    const cache = await caches.open(cacheName);
+    const rows = [].concat(manifest.assets, manifest.pages);
+    const failures = [];
+    const cachedContentDigests = {};
+    let completed = 0;
+
+    for (const row of rows) {
+        try {
+            const response = await fetch(row.fetch_url || row.url, {
+                credentials: 'include',
+                redirect: 'follow',
+                cache: 'no-store',
+                headers: {'X-Offline-Prepare': '1'}
+            });
+            const contentType = response.headers.get('Content-Type') || '';
+            const isPage = row.kind === 'page';
+            if (!response.ok || response.redirected ||
+                    (isPage && contentType.indexOf('text/html') === -1)) {
+                throw new Error('HTTP ' + response.status);
+            }
+            cachedContentDigests[row.url] = await verifyFetchedRow(
+                manifest, row, response
+            );
+            await cache.put(new Request(row.url, {method: 'GET'}), response.clone());
+            completed += 1;
+        } catch (error) {
+            failures.push({url: row.url, error: String(error.message || error)});
+        }
+        if (source) {
+            source.postMessage({
+                type: 'prepare-offline-progress',
+                completed: completed,
+                attempted: completed + failures.length,
+                total: rows.length,
+                failures: failures.slice()
+            });
+        }
+    }
+
+    if (failures.length) {
+        await caches.delete(cacheName);
+        return {
+            state: 'incomplete',
+            completed: completed,
+            total: rows.length,
+            failures: failures
+        };
+    }
+
+    const names = await caches.keys();
+    await Promise.all(names.filter((name) =>
+        name.startsWith(PREPARED_CACHE_PREFIX) && name !== cacheName
+    ).map((name) => caches.delete(name)));
+    const stored = Object.assign({}, manifest, {
+        cache_name: cacheName,
+        prepared_at: new Date().toISOString(),
+        completed: completed,
+        total: rows.length,
+        cached_content_digests: cachedContentDigests
+    });
+    await writePreparedManifest(stored);
+    return Object.assign({state: 'ready'}, stored);
+}
+
+async function preparedStatus(context) {
+    const manifest = await readPreparedManifest();
+    if (!manifest) return {state: 'not_prepared'};
+    if (!contextMatches(manifest, context)) {
+        await clearPreparedPackage();
+        return {state: 'invalidated'};
+    }
+    if (!await verifyPreparedCache(manifest)) {
+        await clearPreparedPackage();
+        return {state: 'invalidated'};
+    }
+    return Object.assign({state: 'ready'}, manifest);
+}
+
+function openLegacyDB() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(LEGACY_DB_NAME, 1);
+        request.onupgradeneeded = (event) => {
+            const database = event.target.result;
+            if (!database.objectStoreNames.contains(LEGACY_STORE_NAME)) {
+                database.createObjectStore(LEGACY_STORE_NAME, {
+                    keyPath: 'id', autoIncrement: true
+                });
+            }
+        };
+        request.onsuccess = (event) => resolve(event.target.result);
+        request.onerror = (event) => reject(event.target.error);
+    });
+}
+
+function legacyEntries(database) {
+    return new Promise((resolve, reject) => {
+        const transaction = database.transaction(LEGACY_STORE_NAME, 'readonly');
+        const request = transaction.objectStore(LEGACY_STORE_NAME).getAll();
+        request.onsuccess = (event) => resolve(event.target.result);
+        request.onerror = (event) => reject(event.target.error);
+    });
+}
+
+function updateLegacyEntry(database, entry) {
+    return new Promise((resolve, reject) => {
+        const transaction = database.transaction(LEGACY_STORE_NAME, 'readwrite');
+        transaction.objectStore(LEGACY_STORE_NAME).put(entry);
+        transaction.oncomplete = resolve;
+        transaction.onerror = (event) => reject(event.target.error);
+    });
+}
+
+function removeLegacyEntry(database, id) {
+    return new Promise((resolve, reject) => {
+        const transaction = database.transaction(LEGACY_STORE_NAME, 'readwrite');
+        transaction.objectStore(LEGACY_STORE_NAME).delete(id);
+        transaction.oncomplete = resolve;
+        transaction.onerror = (event) => reject(event.target.error);
+    });
+}
+
+function legacyUuid() {
+    if (crypto.randomUUID) return crypto.randomUUID();
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 15) | 64;
+    bytes[8] = (bytes[8] & 63) | 128;
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    return [hex.slice(0, 8), hex.slice(8, 12), hex.slice(12, 16),
+        hex.slice(16, 20), hex.slice(20)].join('-');
+}
+
+async function canonicalLegacyFingerprint(params, tournamentId, heatId) {
+    const ignored = new Set([
+        'csrf_token', 'replay_token', 'payload_sha256', 'tournament_id', 'heat_id'
+    ]);
+    const pairs = [];
+    params.forEach((value, key) => {
+        if (!ignored.has(key)) pairs.push([String(key), String(value || '')]);
+    });
+    pairs.push(['heat_id', String(Number(heatId))]);
+    pairs.push(['tournament_id', String(Number(tournamentId))]);
+    pairs.sort((left, right) =>
+        left[0].localeCompare(right[0]) || left[1].localeCompare(right[1])
+    );
+    return sha256(JSON.stringify(pairs));
+}
+
+async function prepareLegacyEntry(database, entry) {
+    const params = new URLSearchParams(entry.body || '');
+    const match = String(entry.url || '').match(/\/scoring\/(\d+)\/heat\/(\d+)\/enter/);
+    const tournamentId = Number(entry.tournament_id || (match && match[1]) || 0);
+    const heatId = Number(entry.heat_id || (match && match[2]) || 0);
+    const issuerUserId = Number(
+        entry.issuer_user_id || params.get('issuer_user_id') || 0
+    );
+    const issuerRole = String(
+        entry.issuer_role || params.get('issuer_role') || ''
+    ).trim();
+    const hasBoundIssuer = Number.isInteger(issuerUserId) &&
+        issuerUserId > 0 && Boolean(issuerRole);
+    if (!params.get('request_id')) params.set('request_id', legacyUuid());
+    if (!params.get('queued_at')) {
+        params.set('queued_at', new Date(entry.timestamp || Date.now()).toISOString());
+    }
+    params.set('tournament_id', String(tournamentId));
+    params.set('heat_id', String(heatId));
+    if (hasBoundIssuer) {
+        params.set('issuer_user_id', String(issuerUserId));
+        params.set('issuer_role', issuerRole);
+    }
+    const fingerprint = await canonicalLegacyFingerprint(params, tournamentId, heatId);
+    params.set('payload_sha256', fingerprint);
+    entry.body = params.toString();
+    entry.request_id = params.get('request_id');
+    entry.payload_sha256 = fingerprint;
+    entry.tournament_id = tournamentId;
+    entry.heat_id = heatId;
+    entry.issuer_user_id = hasBoundIssuer ? issuerUserId : null;
+    entry.issuer_role = hasBoundIssuer ? issuerRole : null;
+    entry.auto_replay = hasBoundIssuer;
+    entry.reconciliation_state = hasBoundIssuer ? null : 'legacy_unbound_issuer';
+    entry.timestamp = entry.timestamp || Date.now();
+    await updateLegacyEntry(database, entry);
+    return {entry, params, replayable: hasBoundIssuer};
+}
+
+async function legacyJson(response) {
+    if (response.redirected) throw new Error('session_required');
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.indexOf('application/json') === -1) {
+        throw new Error('unexpected_response');
+    }
+    const data = await response.json();
+    if (!response.ok || !data.ok) {
+        const code = data && data.error && data.error.code;
+        const error = new Error(code || 'server_rejected_' + response.status);
+        error.code = code;
+        throw error;
+    }
+    return data;
+}
+
+function matchingLegacyReceipt(entry, receipt) {
+    return Boolean(receipt && receipt.accepted === true &&
+        String(receipt.request_id) === String(entry.request_id) &&
+        Number(receipt.tournament_id) === Number(entry.tournament_id) &&
+        Number(receipt.heat_id) === Number(entry.heat_id) &&
+        Number(receipt.issuing_user_id) === Number(entry.issuer_user_id) &&
+        String(receipt.payload_sha256) === String(entry.payload_sha256));
+}
+
+async function postLegacy(url, params) {
+    return fetch(url, {
+        method: 'POST',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'X-Requested-With': 'XMLHttpRequest'
+        },
+        credentials: 'same-origin',
+        redirect: 'follow',
+        body: params.toString()
+    });
+}
+
+async function renewLegacyReplayToken(database, entry, params) {
+    const response = await fetch('/scoring/api/replay-token', {
+        method: 'GET',
+        headers: {'Accept': 'application/json'},
+        credentials: 'same-origin',
+        redirect: 'follow',
+        cache: 'no-store'
+    });
+    const data = await legacyJson(response);
+    if (Number(data.issuer_user_id) !== Number(entry.issuer_user_id) ||
+            String(data.issuer_role) !== String(entry.issuer_role)) {
+        const error = new Error('legacy_issuer_session_mismatch');
+        error.code = 'legacy_issuer_session_mismatch';
+        throw error;
+    }
+    params.set('replay_token', String(data.replay_token || ''));
+    if (!params.get('replay_token')) throw new Error('replay_token_required');
+    entry.body = params.toString();
+    await updateLegacyEntry(database, entry);
+    return data.replay_token;
+}
+
+async function replayLegacyEntry(database, rawEntry) {
+    const prepared = await prepareLegacyEntry(database, rawEntry);
+    const entry = prepared.entry;
+    const params = prepared.params;
+    if (!prepared.replayable) {
+        const error = new Error('legacy_unbound_issuer');
+        error.code = 'manual_reconciliation_required';
+        throw error;
+    }
+    if (Date.now() - Number(entry.timestamp || 0) > MAX_REPLAY_AGE_MS) {
+        throw new Error('manual_reconciliation_required');
+    }
+
+    let response = await postLegacy(entry.url, params);
+    let data;
+    try {
+        data = await legacyJson(response);
+    } catch (error) {
+        if (error.code !== 'csrf_expired') throw error;
+        if (!params.get('replay_token')) {
+            await renewLegacyReplayToken(database, entry, params);
+        }
+        response = await postLegacy('/scoring/api/replay', params);
+        try {
+            data = await legacyJson(response);
+        } catch (replayError) {
+            if (replayError.code !== 'replay_token_expired') throw replayError;
+            await renewLegacyReplayToken(database, entry, params);
+            response = await postLegacy('/scoring/api/replay', params);
+            data = await legacyJson(response);
+        }
+    }
+    if (!matchingLegacyReceipt(entry, data.receipt)) {
+        throw new Error('receipt_mismatch');
+    }
+    await removeLegacyEntry(database, entry.id);
+    return true;
+}
+
+async function legacyQueueStatus() {
+    const database = await openLegacyDB();
+    const entries = await legacyEntries(database);
+    const prepared = [];
+    for (const entry of entries) {
+        prepared.push((await prepareLegacyEntry(database, entry)).entry);
+    }
+    database.close();
+    return {
+        count: prepared.length,
+        manual_reconciliation_required: prepared.filter((entry) =>
+            entry.reconciliation_state === 'legacy_unbound_issuer' ||
+            Date.now() - Number(entry.timestamp || 0) > MAX_REPLAY_AGE_MS
+        ).length
+    };
+}
+
+async function replayLegacyQueue() {
+    const database = await openLegacyDB();
+    const entries = await legacyEntries(database);
+    let success = 0;
+    const reasons = [];
     for (const entry of entries) {
         if (!isSameOriginScoreEntryUrl(entry.url)) {
             failedCount++;
@@ -216,80 +553,54 @@ async function replayQueue() {
             continue;
         }
         try {
-            const resp = await fetch(entry.url, {
-                method: entry.method,
-                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: entry.body,
-            });
-
-            if (resp.status >= 200 && resp.status < 300) {
-                // 2xx — server accepted the score. Safe to dequeue.
-                await removeEntry(db, entry.id);
-                successCount++;
-            } else if (resp.status === 400 || resp.status === 403) {
-                // CSRF token expired or session invalid.
-                // Try the CSRF-exempt replay endpoint. The HMAC replay_token is
-                // already embedded in entry.body (from the form hidden input
-                // populated via /scoring/api/replay-token on page load — CSO #6).
-                if (entry.replay_token) {
-                    const replayBody = entry.body
-                        + '&tournament_id=' + encodeURIComponent(entry.tournament_id || '')
-                        + '&heat_id=' + encodeURIComponent(entry.heat_id || '');
-                    const replayResp = await fetch('/scoring/api/replay', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                        body: replayBody,
-                    });
-                    if (replayResp.status >= 200 && replayResp.status < 300) {
-                        await removeEntry(db, entry.id);
-                        successCount++;
-                    } else {
-                        // Replay endpoint also rejected — keep in queue
-                        failedCount++;
-                        failReasons.push('csrf_expired');
-                    }
-                } else {
-                    // No replay token — keep in queue, notify user
-                    failedCount++;
-                    failReasons.push('csrf_expired');
-                }
-            } else if (resp.status === 409) {
-                // Version conflict — another judge already updated this heat.
-                // KEEP in queue — do NOT dequeue. User must resolve manually.
-                failedCount++;
-                failReasons.push('version_conflict');
-            } else if (resp.status >= 500) {
-                // Server error — transient, retry later. Keep in queue.
-                // Do not increment failedCount — this is retryable.
-            } else {
-                // Other 4xx (404, 422, etc.) — keep in queue, flag as failed
-                failedCount++;
-                failReasons.push('server_rejected_' + resp.status);
-            }
-        } catch (_) {
-            // Network error — still offline. Leave in queue for next attempt.
+            await replayLegacyEntry(database, entry);
+            success += 1;
+        } catch (error) {
+            reasons.push(String(error.code || error.message || error));
         }
     }
-
-    // Notify all open windows of results
-    const clients = await self.clients.matchAll({ type: 'window' });
-    if (successCount > 0 || failedCount > 0) {
-        clients.forEach(client =>
-            client.postMessage({
-                type: 'sync-complete',
-                success: successCount,
-                failed: failedCount,
-                reasons: failReasons,
-            })
-        );
-    }
-    if (failedCount > 0) {
-        clients.forEach(client =>
-            client.postMessage({
-                type: 'replay-failed',
-                count: failedCount,
-                reasons: failReasons,
-            })
-        );
-    }
+    database.close();
+    const clients = await self.clients.matchAll({type: 'window'});
+    clients.forEach((client) => client.postMessage({
+        type: 'legacy-sync-complete',
+        success: success,
+        failed: reasons.length,
+        reasons: reasons
+    }));
+    return {success, failed: reasons.length, reasons};
 }
+
+self.addEventListener('message', (event) => {
+    const data = event.data || {};
+    if (data.type === 'prepare-offline-package') {
+        event.waitUntil(prepareOfflinePackage(data.manifest, event.source)
+            .then((result) => event.source && event.source.postMessage({
+                type: 'prepare-offline-complete', result: result
+            }))
+            .catch((error) => event.source && event.source.postMessage({
+                type: 'prepare-offline-complete',
+                result: {state: 'failed', error: String(error.message || error)}
+            })));
+    } else if (data.type === 'validate-prepared-package' ||
+            data.type === 'prepared-package-status') {
+        event.waitUntil(preparedStatus(data.context).then((result) =>
+            event.source && event.source.postMessage({
+                type: 'prepared-package-status', result: result
+            })
+        ));
+    } else if (data.type === 'clear-prepared-package') {
+        event.waitUntil(clearPreparedPackage().then(() =>
+            event.source && event.source.postMessage({
+                type: 'prepared-package-status', result: {state: 'not_prepared'}
+            })
+        ));
+    } else if (data.type === 'legacy-queue-status') {
+        event.waitUntil(legacyQueueStatus().then((result) =>
+            event.source && event.source.postMessage({
+                type: 'legacy-queue-status', result: result
+            })
+        ));
+    } else if (data.type === 'drain-legacy-queue') {
+        event.waitUntil(replayLegacyQueue());
+    }
+});

--- a/templates/ops_dashboard.html
+++ b/templates/ops_dashboard.html
@@ -403,6 +403,8 @@
                                     <td>
                                         {% if job.status == 'failed' %}
                                             <span class="badge bg-danger">failed</span>
+                                        {% elif job.status == 'interrupted' %}
+                                            <span class="badge bg-warning text-dark">interrupted</span>
                                         {% elif job.status == 'running' %}
                                             <span class="badge bg-primary">running</span>
                                         {% elif job.status == 'queued' %}

--- a/templates/pro/flights.html
+++ b/templates/pro/flights.html
@@ -362,6 +362,7 @@
             <form method="post"
                   action="{{ url_for('scheduling.start_flight', tournament_id=tournament.id, flight_id=flight.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="expected_status" value="pending">
                 <button type="submit" class="btn btn-warning btn-sm"
                         data-confirm="Start Flight {{ flight.flight_number }}? This will notify opted-in competitors.">
                     <i class="bi bi-play-fill"></i> Start Flight
@@ -371,6 +372,7 @@
             <form method="post"
                   action="{{ url_for('scheduling.complete_flight', tournament_id=tournament.id, flight_id=flight.id) }}">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="expected_status" value="in_progress">
                 <button type="submit" class="btn btn-success btn-sm">
                     <i class="bi bi-check-lg"></i> Mark Complete
                 </button>
@@ -379,7 +381,7 @@
         </div>
 
         {# Heat tiles grid — drag-drop: within-flight reorder + cross-flight move #}
-        <div class="heat-grid flight-drag-grid" data-flight-id="{{ flight.id }}">
+        <div class="heat-grid flight-drag-grid" data-flight-id="{{ flight.id }}" data-order-digest="{{ fd.order_digest }}">
             {% for row in fd.heats %}
             {% set is_college = row.event.event_type == 'college' %}
             {% set is_relay = row.event.name == 'Pro-Am Relay' %}
@@ -519,9 +521,23 @@
             var fid = parseInt(grid.dataset.flightId, 10);
             var ids = Array.from(grid.querySelectorAll('[data-heat-id]'))
                 .map(function (el) { return parseInt(el.dataset.heatId, 10); });
-            out.push({flight_id: fid, heat_ids: ids});
+            out.push({
+                flight_id: fid,
+                heat_ids: ids,
+                expected_digest: grid.dataset.orderDigest
+            });
         });
         return out;
+    }
+
+    function applyOrderDigests(orderDigests) {
+        if (!orderDigests) return;
+        document.querySelectorAll('.flight-drag-grid').forEach(function (grid) {
+            var flightId = grid.dataset.flightId;
+            if (Object.prototype.hasOwnProperty.call(orderDigests, flightId)) {
+                grid.dataset.orderDigest = orderDigests[flightId];
+            }
+        });
     }
 
     function persistChange() {
@@ -537,7 +553,9 @@
                 var msg = (data && data.error) || 'unknown error';
                 alert('Move failed: ' + msg + '. The page will refresh to show the saved order.');
                 window.location.reload();
+                return;
             }
+            applyOrderDigests(data.order_digests);
         }).catch(function () {
             alert('Move request failed. Check your connection and refresh.');
             window.location.reload();

--- a/templates/proam_relay/configure_payouts.html
+++ b/templates/proam_relay/configure_payouts.html
@@ -33,6 +33,7 @@
 
           <form method="POST" id="relayPayoutForm">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="expected_payout_digest" value="{{ expected_payout_digest }}">
 
             <div class="table-responsive">
               <table class="table table-sm align-middle">

--- a/templates/proam_relay/dashboard.html
+++ b/templates/proam_relay/dashboard.html
@@ -84,6 +84,7 @@
                     </ul>
                     <form action="{{ url_for('proam_relay.draw_lottery', tournament_id=tournament.id) }}" method="POST">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                        <input type="hidden" name="expected_relay_digest" value="{{ relay_state_digest }}">
                         <div class="mb-3">
                             <label class="form-label">Number of Teams</label>
                             {% set default_teams = [2, capacity.max_teams]|min %}
@@ -171,6 +172,7 @@
                         <form action="{{ url_for('proam_relay.redraw_lottery', tournament_id=tournament.id) }}" method="POST"
                               data-confirm="This will clear all teams and results. Are you sure?">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="hidden" name="expected_relay_digest" value="{{ relay_state_digest }}">
                             {% if capacity.max_teams > 0 %}
                             {% set default_redraw_n = [teams|length, capacity.max_teams]|min %}
                             <div class="mb-2">

--- a/templates/proam_relay/manual_teams.html
+++ b/templates/proam_relay/manual_teams.html
@@ -210,6 +210,7 @@
     <form id="saveForm" method="POST"
           action="{{ url_for('proam_relay.save_manual_teams', tournament_id=tournament.id) }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" name="expected_relay_digest" value="{{ relay_state_digest }}">
         <input type="hidden" name="teams_json" id="teamsJsonInput" value="[]">
     </form>
 </div>

--- a/templates/proam_relay/results.html
+++ b/templates/proam_relay/results.html
@@ -42,6 +42,7 @@
                     <form action="{{ url_for('proam_relay.enter_results', tournament_id=tournament.id) }}" method="POST">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <input type="hidden" name="team_number" value="{{ team.team_number }}">
+                        <input type="hidden" name="expected_relay_digest" value="{{ team_state_digests[team.team_number] }}">
                         <div class="input-group">
                             <input type="text" name="time_seconds" class="form-control form-control-lg"
                                    placeholder="e.g., 45.67 or 1:23.45"

--- a/templates/proam_relay/teams.html
+++ b/templates/proam_relay/teams.html
@@ -60,11 +60,32 @@
                             </h6>
                             <ul class="list-group">
                                 {% for member in team.pro_members %}
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    <span>{{ member.name }}</span>
-                                    <span class="badge {% if member.gender == 'M' %}bg-primary{% else %}bg-info{% endif %}">
-                                        {{ member.gender }}
-                                    </span>
+                                {% set choices = replacement_options['pro'].get(member.gender, []) %}
+                                <li class="list-group-item">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <span>{{ member.name }}</span>
+                                        <span class="badge {% if member.gender == 'M' %}bg-primary{% else %}bg-info{% endif %}">
+                                            {{ member.gender }}
+                                        </span>
+                                    </div>
+                                    {% if choices %}
+                                    <form action="{{ url_for('proam_relay.replace_competitor', tournament_id=tournament.id) }}" method="post" class="d-flex gap-2 mt-2">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="team_number" value="{{ team.team_number }}">
+                                        <input type="hidden" name="old_competitor_id" value="{{ member.id }}">
+                                        <input type="hidden" name="competitor_type" value="pro">
+                                        <input type="hidden" name="expected_relay_digest" value="{{ team_state_digests[team.team_number] }}">
+                                        <select class="form-select form-select-sm" name="new_competitor_id" aria-label="Replacement for {{ member.name }}" required>
+                                            <option value="" selected disabled>Replacement</option>
+                                            {% for candidate in choices %}
+                                            <option value="{{ candidate.id }}">{{ candidate.name }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary flex-shrink-0" title="Replace {{ member.name }}" aria-label="Replace {{ member.name }}">
+                                            <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
+                                        </button>
+                                    </form>
+                                    {% endif %}
                                 </li>
                                 {% endfor %}
                             </ul>
@@ -77,11 +98,32 @@
                             </h6>
                             <ul class="list-group">
                                 {% for member in team.college_members %}
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    <span>{{ member.name }}</span>
-                                    <span class="badge {% if member.gender == 'M' %}bg-primary{% else %}bg-info{% endif %}">
-                                        {{ member.gender }}
-                                    </span>
+                                {% set choices = replacement_options['college'].get(member.gender, []) %}
+                                <li class="list-group-item">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <span>{{ member.name }}</span>
+                                        <span class="badge {% if member.gender == 'M' %}bg-primary{% else %}bg-info{% endif %}">
+                                            {{ member.gender }}
+                                        </span>
+                                    </div>
+                                    {% if choices %}
+                                    <form action="{{ url_for('proam_relay.replace_competitor', tournament_id=tournament.id) }}" method="post" class="d-flex gap-2 mt-2">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <input type="hidden" name="team_number" value="{{ team.team_number }}">
+                                        <input type="hidden" name="old_competitor_id" value="{{ member.id }}">
+                                        <input type="hidden" name="competitor_type" value="college">
+                                        <input type="hidden" name="expected_relay_digest" value="{{ team_state_digests[team.team_number] }}">
+                                        <select class="form-select form-select-sm" name="new_competitor_id" aria-label="Replacement for {{ member.name }}" required>
+                                            <option value="" selected disabled>Replacement</option>
+                                            {% for candidate in choices %}
+                                            <option value="{{ candidate.id }}">{{ candidate.name }}</option>
+                                            {% endfor %}
+                                        </select>
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary flex-shrink-0" title="Replace {{ member.name }}" aria-label="Replace {{ member.name }}">
+                                            <i class="bi bi-arrow-repeat" aria-hidden="true"></i>
+                                        </button>
+                                    </form>
+                                    {% endif %}
                                 </li>
                                 {% endfor %}
                             </ul>

--- a/templates/scheduling/birling_manage.html
+++ b/templates/scheduling/birling_manage.html
@@ -324,6 +324,7 @@
                                 <form method="POST" action="{{ url_for('scheduling.birling_record_fall', tournament_id=tournament.id, event_id=event.id) }}" class="d-grid">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <input type="hidden" name="match_id" value="{{ match.match_id }}">
+                                    <input type="hidden" name="expected_fall_digest" value="{{ match.fall_digest }}">
                                     <button type="submit" name="fall_winner_id" value="{{ match.competitor1 }}"
                                             class="btn btn-outline-primary btn-sm text-start">
                                         Fall to {{ name1 }}
@@ -332,6 +333,7 @@
                                 <form method="POST" action="{{ url_for('scheduling.birling_record_fall', tournament_id=tournament.id, event_id=event.id) }}" class="d-grid">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <input type="hidden" name="match_id" value="{{ match.match_id }}">
+                                    <input type="hidden" name="expected_fall_digest" value="{{ match.fall_digest }}">
                                     <button type="submit" name="fall_winner_id" value="{{ match.competitor2 }}"
                                             class="btn btn-outline-primary btn-sm text-start">
                                         Fall to {{ name2 }}
@@ -346,6 +348,7 @@
                                 <form method="POST" action="{{ url_for('scheduling.birling_record_match', tournament_id=tournament.id, event_id=event.id) }}">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                     <input type="hidden" name="match_id" value="{{ match.match_id }}">
+                                    <input type="hidden" name="expected_fall_digest" value="{{ match.fall_digest }}">
                                     <div class="d-grid gap-1">
                                         <button type="submit" name="winner_id" value="{{ match.competitor1 }}"
                                                 class="btn btn-outline-success btn-sm text-start">
@@ -415,6 +418,7 @@
                             <form method="POST" action="{{ url_for('scheduling.birling_undo_match', tournament_id=tournament.id, event_id=event.id) }}" style="display:inline">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <input type="hidden" name="match_id" value="{{ match.match_id }}">
+                                <input type="hidden" name="expected_undo_digest" value="{{ undo_match_digests.get(match.match_id, '') }}">
                                 <button type="submit" class="btn btn-link btn-sm p-0 text-muted"
                                         style="font-size:0.65rem; text-decoration:none"
                                         data-confirm="Undo this match result? Both competitors will be returned to this match."
@@ -556,6 +560,7 @@
         </a>
         <form method="POST" action="{{ url_for('scheduling.birling_reset', tournament_id=tournament.id, event_id=event.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="expected_bracket_digest" value="{{ bracket_state_digest }}">
             <button type="submit" class="btn btn-outline-danger btn-sm"
                     data-confirm="Reset the entire bracket? All match results will be lost.">
                 <i class="bi bi-arrow-counterclockwise me-1"></i> Reset Bracket

--- a/templates/scheduling/heat_sheets_print.html
+++ b/templates/scheduling/heat_sheets_print.html
@@ -285,7 +285,7 @@
         {% endif %}
 
         {# Screen view: Bootstrap grid + drag handles #}
-        <div class="row no-print flight-screen-grid" data-flight-id="{{ fd.flight.id }}">
+        <div class="row no-print flight-screen-grid" data-flight-id="{{ fd.flight.id }}" data-expected-order="{% for row in fd.heats %}{{ row.heat.id }}{{ ',' if not loop.last }}{% endfor %}">
             {% for row in fd.heats %}
             <div class="col-md-6 col-lg-4 mb-0" data-heat-id="{{ row.heat.id }}">
                 <div class="heat-card">
@@ -644,7 +644,9 @@ function filterFlights(filter, btn) {
 // ── Drag-and-drop reorder ────────────────────────────────────────────────
 {% if flight_data %}
 document.querySelectorAll('.flight-screen-grid').forEach(function(grid) {
-    var flightId = grid.dataset.flightId;
+            var flightId = grid.dataset.flightId;
+            var expectedHeatIds = (grid.dataset.expectedOrder || '').split(',')
+                .filter(Boolean).map(function(id) { return parseInt(id, 10); });
     new Sortable(grid, {
         animation: 150,
         handle: '.heat-drag-handle',
@@ -660,7 +662,10 @@ document.querySelectorAll('.flight-screen-grid').forEach(function(grid) {
                     'Content-Type': 'application/json',
                     'X-CSRFToken': csrfToken,
                 },
-                body: JSON.stringify({heat_ids: heatIds})
+                body: JSON.stringify({
+                    heat_ids: heatIds,
+                    expected_heat_ids: expectedHeatIds
+                })
             }).then(function(r) { return r.json(); }).then(function(data) {
                 if (!data.ok) {
                     alert('Reorder failed: ' + (data.error || 'unknown error') + '. Refresh to see current order.');

--- a/templates/scheduling/partner_queue.html
+++ b/templates/scheduling/partner_queue.html
@@ -57,22 +57,31 @@
             {% if partner_repairs_locked %}
             <span class="text-muted">Locked after scoring</span>
             {% else %}
+            {% set default_partner = repair.suggested_partner or (available|first) %}
+            {% if default_partner %}
             <form method="POST" action="{{ url_for('scheduling.reassign_partner', tid=tournament.id, eid=event.id) }}" class="d-flex gap-2">
               <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <input type="hidden" name="orphan_id" value="{{ repair.competitor.id }}">
               <input type="hidden" name="orphan_type" value="{{ repair.competitor_type }}">
               <input type="hidden" name="new_partner_type" value="{{ repair.competitor_type }}">
-              <select name="new_partner_id" class="form-select form-select-sm" required>
+              <input type="hidden" name="new_partner_id" value="{{ default_partner.id }}">
+              <input type="hidden" name="expected_claim_digest" value="{{ claim_digests[(repair.competitor.id, default_partner.id)] }}">
+              <select name="partner_claim" class="form-select form-select-sm partner-choice" required>
                 <option value="">Select partner...</option>
                 {% if repair.suggested_partner %}
-                <option value="{{ repair.suggested_partner.id }}" selected>{{ repair.suggested_partner.name }} ({{ repair.suggested_partner.gender }})</option>
+                <option value="{{ repair.suggested_partner.id }}:{{ claim_digests[(repair.competitor.id, repair.suggested_partner.id)] }}" selected>{{ repair.suggested_partner.name }} ({{ repair.suggested_partner.gender }})</option>
                 {% endif %}
                 {% for a in available %}
-                <option value="{{ a.id }}">{{ a.name }} ({{ a.gender }})</option>
+                {% if not repair.suggested_partner or a.id != repair.suggested_partner.id %}
+                <option value="{{ a.id }}:{{ claim_digests[(repair.competitor.id, a.id)] }}" {% if not repair.suggested_partner and loop.first %}selected{% endif %}>{{ a.name }} ({{ a.gender }})</option>
+                {% endif %}
                 {% endfor %}
               </select>
               <button type="submit" class="btn btn-sm btn-primary">Reassign</button>
             </form>
+            {% else %}
+            <span class="text-muted">No eligible partners</span>
+            {% endif %}
             {% endif %}
           </td>
           <td></td>
@@ -87,4 +96,18 @@
   </div>
   {% endif %}
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+document.querySelectorAll('.partner-choice').forEach(function (select) {
+  function syncExpectedDigest() {
+    var claim = select.value.split(':');
+    select.form.querySelector('[name="new_partner_id"]').value = claim.shift() || '';
+    select.form.querySelector('[name="expected_claim_digest"]').value = claim.join(':');
+  }
+  select.addEventListener('change', syncExpectedDigest);
+  syncExpectedDigest();
+});
+</script>
 {% endblock %}

--- a/templates/scoring/enter_heat.html
+++ b/templates/scoring/enter_heat.html
@@ -238,9 +238,16 @@
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="heat_version" value="{{ heat_version }}">
             <input type="hidden" name="heat_identity" value="{{ heat_identity }}">
-            {# SECURITY (CSO #6): HMAC-bound replay token fetched on page load.
-               The offline queue captures the form body verbatim, so this hidden
-               input propagates automatically through IDB and the replay POST. #}
+            <input type="hidden" name="scoring_state_digest" value="{{ scoring_state_digest }}">
+            <input type="hidden" name="request_id" value="{{ score_request_id }}">
+            <input type="hidden" name="tournament_id" value="{{ tournament.id }}">
+            <input type="hidden" name="heat_id" value="{{ heat.id }}">
+            <input type="hidden" name="issuer_user_id" value="{{ offline_context.issuer_user_id }}">
+            <input type="hidden" name="issuer_role" value="{{ offline_context.issuer_role }}">
+            <input type="hidden" name="schedule_fingerprint" value="{{ offline_context.schedule_fingerprint }}">
+            <input type="hidden" name="application_build" value="{{ offline_context.application_build }}">
+            <input type="hidden" name="queued_at" value="">
+            <input type="hidden" name="payload_sha256" value="">
             <input type="hidden" name="replay_token" value="">
 
             <div class="table-responsive">
@@ -565,6 +572,7 @@
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/offline_queue_shared.js') }}"></script>
 <script>
+window.ProAmOfflineContext = {{ offline_context|tojson }};
 document.addEventListener('DOMContentLoaded', function () {
     /* ── Constants from server ───────────────────────────────────────────── */
     const postUrl          = {{ url_for('scoring.enter_heat_results', tournament_id=tournament.id, heat_id=heat.id)|tojson }};
@@ -583,12 +591,11 @@ document.addEventListener('DOMContentLoaded', function () {
         {{ comp.id }}: {{ comp.name|tojson }}{% if not loop.last %},{% endif %}
         {% endfor %}
     };
+    const offlineContext   = window.ProAmOfflineContext;
 
     if (lockBlocked) return; // read-only, no JS wiring needed
 
-    /* ── SECURITY FIX (CSO #6): fetch a real HMAC replay token ───────────── */
-    // The offline queue stashes the form body in IndexedDB at queue time, so
-    // the replay_token hidden input propagates automatically to the replay POST.
+    /* ── Fetch replay authority for a future CSRF-expired queue sync ─────── */
     (async function () {
         try {
             const r = await fetch('/scoring/api/replay-token', {credentials: 'same-origin'});
@@ -623,7 +630,6 @@ document.addEventListener('DOMContentLoaded', function () {
 
     /* ── Offline queue helpers ───────────────────────────────────────────── */
     const readQ  = () => window.ProAmOfflineQueue.read();
-    const writeQ = (q) => { window.ProAmOfflineQueue.write(q); refreshBanner(); };
 
     function setStatus(msg, type) {
         statusBox.classList.remove('d-none','alert-secondary','alert-info','alert-success','alert-warning','alert-danger');
@@ -653,21 +659,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     async function postEntry(entry) {
-        const body = new FormData();
-        Object.keys(entry.payload).forEach(k => body.append(k, entry.payload[k]));
-        const res = await fetch(entry.url, {
-            method: 'POST', body,
-            headers: {'X-Requested-With': 'XMLHttpRequest'},
-            credentials: 'same-origin'
-        });
-        const data = await res.json().catch(() => ({}));
-        if (!res.ok || !data.ok) {
-            const e = new Error(data.message || 'Error');
-            e.httpStatus = res.status;
-            e.serverMessage = data.message || null;  // surface for conflict modal
-            throw e;
-        }
-        return data;
+        const result = await window.ProAmOfflineQueue.syncEntry(entry, offlineContext);
+        await window.ProAmOfflineQueue.removeVerified(result.entry, result.data.receipt);
+        return result.data;
     }
 
     async function syncPending() {
@@ -678,10 +672,10 @@ document.addEventListener('DOMContentLoaded', function () {
         for (const entry of q) {
             try {
                 await postEntry(entry);
-                window.ProAmOfflineQueue.remove(entry.url, entry.heat_id);
                 synced++;
             } catch(err) {
-                if (err.httpStatus === 409) { setStatus('<i class="bi bi-exclamation-circle"></i> A queued heat is stale. Open and re-save.', 'alert-danger'); return false; }
+                if (err.httpStatus === 409 || err.code === 'stale_manifest') { setStatus('<i class="bi bi-exclamation-circle"></i> A queued heat needs reconciliation before it can sync.', 'alert-danger'); return false; }
+                if (err.code === 'session_required' || err.code === 'issuer_mismatch' || err.code === 'role_mismatch') { setStatus('<i class="bi bi-person-lock"></i> Sign in as the original queue issuer before syncing.', 'alert-warning'); return false; }
                 setStatus('<i class="bi bi-cloud-slash"></i> Connection issue — scores remain queued.', 'alert-warning'); return false;
             }
         }
@@ -971,7 +965,7 @@ document.addEventListener('DOMContentLoaded', function () {
         e.preventDefault();
         if (savingState) return;
         const autoAdvance = autoAdvTgl?.checked && saveNextBtn;
-        const entry = {
+        let entry = {
             url: postUrl, event_id: eventId, heat_id: heatId,
             scoring_order: scoringOrder, requires_dual_runs: requiresDualRuns,
             run_number: runNumber, competitor_names: competitorNames,
@@ -980,8 +974,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
         setSaving(true);
         try {
+            entry = await window.ProAmOfflineQueue.prepareEntry(entry, offlineContext);
+            form.querySelector('[name="request_id"]').value = entry.request_id;
+            form.querySelector('[name="queued_at"]').value = entry.queued_at;
+            form.querySelector('[name="payload_sha256"]').value = entry.payload_sha256;
+            await window.ProAmOfflineQueue.upsert(entry);
             const res = await postEntry(entry);
-            window.ProAmOfflineQueue.remove(postUrl, heatId);
             // Show undo toast
             showUndoToast(res.undo_heat_id, res.redirect_url || redirectUrl);
             const dest = nextHeatOverride || (autoAdvance ? saveNextBtn.dataset.nextUrl : null) || res.redirect_url || redirectUrl;
@@ -1004,8 +1002,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 } else {
                     setStatus('<i class="bi bi-exclamation-circle"></i> ' + msg, 'alert-danger');
                 }
+            } else if (err.code === 'session_required' || err.code === 'authorization_denied') {
+                setStatus('<i class="bi bi-person-lock"></i> Score retained. Sign in as the original issuer before syncing.', 'alert-warning');
             } else {
-                window.ProAmOfflineQueue.upsert(entry);
                 setStatus('<i class="bi bi-cloud-slash"></i> Saved locally — will sync when online.', 'alert-warning');
                 refreshBanner();
             }

--- a/templates/scoring/offline_ops.html
+++ b/templates/scoring/offline_ops.html
@@ -17,6 +17,41 @@
         </div>
     </div>
 
+    <div class="row mb-4">
+        <div class="col-lg-8 mb-3 mb-lg-0">
+            <div class="card h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h6 class="mb-0"><i class="bi bi-device-ssd"></i> Prepared scoring package</h6>
+                    <span class="badge bg-secondary" id="preparedStatus">Not prepared</span>
+                </div>
+                <div class="card-body d-flex flex-wrap align-items-center gap-3">
+                    <button class="btn btn-primary" id="prepareOfflineBtn">
+                        <i class="bi bi-download"></i> Prepare device
+                    </button>
+                    <div class="flex-grow-1">
+                        <div class="progress" role="progressbar" aria-label="Offline package preparation">
+                            <div class="progress-bar" id="prepareProgress" style="width:0%"></div>
+                        </div>
+                        <small class="text-muted" id="preparedDetail">0 of {{ offline_manifest.pages|length }} heat pages verified</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-4">
+            <div class="card h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h6 class="mb-0"><i class="bi bi-database-down"></i> Legacy drain</h6>
+                    <span class="badge bg-secondary" id="legacyQueueCount">0</span>
+                </div>
+                <div class="card-body">
+                    <button class="btn btn-outline-info w-100" id="drainLegacyBtn">
+                        <i class="bi bi-arrow-repeat"></i> Drain legacy queue
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div class="row mb-3">
         <div class="col-12 d-flex justify-content-between align-items-center">
             <div>
@@ -96,6 +131,7 @@
 {% block extra_js %}
 <script src="{{ url_for('static', filename='js/offline_queue_shared.js') }}"></script>
 <script>
+window.ProAmOfflineContext = {{ offline_context|tojson }};
 // SECURITY FIX (CSO #1): escape server-supplied strings before innerHTML
 function escapeHtml(s) {
     if (s === null || s === undefined) return '';
@@ -109,23 +145,25 @@ function escapeHtml(s) {
 document.addEventListener('DOMContentLoaded', function () {
     const TOURNAMENT_ID = {{ tournament.id }};
     const EVENT_DIRECTORY = {{ event_directory|tojson }};
+    const OFFLINE_MANIFEST = {{ offline_manifest|tojson }};
+    const OFFLINE_CONTEXT = window.ProAmOfflineContext;
     const queueBody = document.getElementById('queueBody');
     const queueCount = document.getElementById('queueCount');
     const statusBox = document.getElementById('opsStatus');
     const networkStatus = document.getElementById('networkStatus');
     const syncAllBtn = document.getElementById('syncAllBtn');
+    const prepareOfflineBtn = document.getElementById('prepareOfflineBtn');
+    const preparedStatus = document.getElementById('preparedStatus');
+    const preparedDetail = document.getElementById('preparedDetail');
+    const prepareProgress = document.getElementById('prepareProgress');
+    const legacyQueueCount = document.getElementById('legacyQueueCount');
 
     function readQueue() {
         return window.ProAmOfflineQueue.read();
     }
 
-    function writeQueue(queue) {
-        window.ProAmOfflineQueue.write(queue);
-    }
-
     function isForTournament(entry) {
-        const url = String(entry.url || '');
-        return url.indexOf('/scoring/' + TOURNAMENT_ID + '/') !== -1;
+        return Number(entry.tournament_id || 0) === Number(TOURNAMENT_ID);
     }
 
     function setStatus(message, type) {
@@ -172,16 +210,21 @@ document.addEventListener('DOMContentLoaded', function () {
             const timeLabel = queuedAt ? new Date(queuedAt).toLocaleString() : '-';
             const heatLabel = entry.heat_id ? ('Heat ' + entry.heat_id) : '-';
             const entries = resultFieldCount(entry.payload || {});
-            const key = encodeURIComponent((entry.url || '') + '|' + (entry.heat_id || ''));
+            const key = encodeURIComponent(entry.request_id || '');
+            const ageState = window.ProAmOfflineQueue.ageState(entry);
+            const bindingState = window.ProAmOfflineQueue.bindingState(entry, OFFLINE_CONTEXT);
+            const ready = ageState === 'ready' && bindingState === 'ready';
+            const stateLabel = ageState !== 'ready' ? 'Manual reconciliation' :
+                (bindingState !== 'ready' ? 'Blocked: ' + bindingState.replace(/_/g, ' ') : 'Pending');
             return '' +
                 '<tr>' +
                     '<td>' + escapeHtml(timeLabel) + '</td>' +
                     '<td>' + escapeHtml(eventLabel(entry)) + '</td>' +
                     '<td>' + escapeHtml(heatLabel) + '</td>' +
                     '<td>' + escapeHtml(entries) + '</td>' +
-                    '<td><span class="badge bg-warning text-dark">Pending</span></td>' +
+                    '<td><span class="badge ' + (ready ? 'bg-warning text-dark' : 'bg-danger') + '">' + escapeHtml(stateLabel) + '</span></td>' +
                     '<td class="d-flex gap-2">' +
-                        '<button class="btn btn-sm btn-outline-info sync-one" data-key="' + escapeHtml(key) + '"><i class="bi bi-arrow-repeat"></i> Sync</button>' +
+                        '<button class="btn btn-sm btn-outline-info sync-one" data-key="' + escapeHtml(key) + '" ' + (ready ? '' : 'disabled') + '><i class="bi bi-arrow-repeat"></i> Sync</button>' +
                         '<button class="btn btn-sm btn-outline-danger drop-one" data-key="' + escapeHtml(key) + '"><i class="bi bi-x-circle"></i> Remove</button>' +
                     '</td>' +
                 '</tr>';
@@ -189,47 +232,27 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function parseKey(key) {
-        const decoded = decodeURIComponent(key);
-        const sep = decoded.lastIndexOf('|');
-        return {
-            url: decoded.substring(0, sep),
-            heatId: Number(decoded.substring(sep + 1)),
-        };
+        return decodeURIComponent(key);
     }
 
-    function removeEntry(url, heatId) {
-        window.ProAmOfflineQueue.remove(url, heatId);
+    async function removeEntry(requestId) {
+        await window.ProAmOfflineQueue.removeByRequestId(requestId);
         renderQueue();
     }
 
     async function postEntry(entry) {
-        const body = new FormData();
-        Object.keys(entry.payload || {}).forEach(function (k) {
-            body.append(k, entry.payload[k]);
-        });
-        const response = await fetch(entry.url, {
-            method: 'POST',
-            body: body,
-            headers: { 'X-Requested-With': 'XMLHttpRequest' },
-            credentials: 'same-origin'
-        });
-        const data = await response.json().catch(function () { return {}; });
-        if (!response.ok || !data.ok) {
-            const err = new Error(data.message || 'Sync failed');
-            err.httpStatus = response.status;
-            throw err;
-        }
-        return data;
+        const result = await window.ProAmOfflineQueue.syncEntry(entry, OFFLINE_CONTEXT);
+        await window.ProAmOfflineQueue.removeVerified(result.entry, result.data.receipt);
+        return result.data;
     }
 
-    async function syncOne(url, heatId) {
+    async function syncOne(requestId) {
         const queue = readQueue();
         const entry = queue.find(function (row) {
-            return String(row.url || '') === String(url || '') && Number(row.heat_id || 0) === Number(heatId || 0);
+            return String(row.request_id || '') === String(requestId || '');
         });
         if (!entry) return true;
         await postEntry(entry);
-        removeEntry(url, heatId);
         return true;
     }
 
@@ -247,7 +270,7 @@ document.addEventListener('DOMContentLoaded', function () {
         let synced = 0;
         for (let i = 0; i < queue.length; i += 1) {
             try {
-                await syncOne(queue[i].url, queue[i].heat_id);
+                await syncOne(queue[i].request_id);
                 synced += 1;
             } catch (err) {
                 if (err.httpStatus === 409) {
@@ -290,22 +313,11 @@ document.addEventListener('DOMContentLoaded', function () {
         const file = e.target.files && e.target.files[0];
         if (!file) return;
         const reader = new FileReader();
-        reader.onload = function () {
+        reader.onload = async function () {
             try {
                 const imported = JSON.parse(String(reader.result || '[]'));
                 if (!Array.isArray(imported)) throw new Error('Invalid file format');
-
-                const current = readQueue();
-                const merged = current.slice();
-                imported.forEach(function (entry) {
-                    if (!isForTournament(entry)) return;
-                    const exists = merged.some(function (row) {
-                        return String(row.url || '') === String(entry.url || '') &&
-                               Number(row.heat_id || 0) === Number(entry.heat_id || 0);
-                    });
-                    if (!exists) merged.push(entry);
-                });
-                writeQueue(merged);
+                await window.ProAmOfflineQueue.merge(imported.filter(isForTournament));
                 renderQueue();
                 setStatus('<i class="bi bi-upload"></i> Imported queue file.', 'alert-success');
             } catch (err) {
@@ -317,16 +329,15 @@ document.addEventListener('DOMContentLoaded', function () {
         reader.readAsText(file);
     });
 
-    document.getElementById('clearBtn').addEventListener('click', function () {
+    document.getElementById('clearBtn').addEventListener('click', async function () {
         const queue = readQueue();
-        const keep = queue.filter(function (entry) { return !isForTournament(entry); });
-        const removed = queue.length - keep.length;
+        const removed = queue.filter(isForTournament).length;
         if (!removed) {
             setStatus('<i class="bi bi-info-circle"></i> No queued heats to clear for this tournament.', 'alert-info');
             return;
         }
         if (!window.confirm('Clear all queued heats for this tournament on this device?')) return;
-        writeQueue(keep);
+        await window.ProAmOfflineQueue.removeTournament(TOURNAMENT_ID);
         renderQueue();
         setStatus('<i class="bi bi-trash"></i> Cleared ' + removed + ' queued heat(s).', 'alert-warning');
     });
@@ -339,7 +350,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const parsed = parseKey(syncBtn.getAttribute('data-key'));
             syncBtn.disabled = true;
             try {
-                await syncOne(parsed.url, parsed.heatId);
+                await syncOne(parsed);
                 setStatus('<i class="bi bi-cloud-check"></i> Heat synced.', 'alert-success');
             } catch (err) {
                 if (err.httpStatus === 409) {
@@ -357,7 +368,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (dropBtn) {
             const parsed = parseKey(dropBtn.getAttribute('data-key'));
             if (!window.confirm('Remove this queued heat from local storage?')) return;
-            removeEntry(parsed.url, parsed.heatId);
+            await removeEntry(parsed);
             setStatus('<i class="bi bi-trash"></i> Queued heat removed.', 'alert-warning');
         }
     });
@@ -368,11 +379,61 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     window.addEventListener('offline', updateNetwork);
     window.addEventListener('storage', function (event) {
-        if (event.key === QUEUE_KEY) renderQueue();
+        if (event.key === window.ProAmOfflineQueue.key) renderQueue();
     });
+
+    function swMessage(message) {
+        if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+            navigator.serviceWorker.controller.postMessage(message);
+        }
+    }
+
+    function renderPrepared(result) {
+        const state = (result && result.state) || 'not_prepared';
+        const ready = state === 'ready';
+        preparedStatus.textContent = ready ? 'Ready' : state.replace(/_/g, ' ');
+        preparedStatus.className = 'badge ' + (ready ? 'bg-success' : state === 'incomplete' || state === 'failed' ? 'bg-danger' : 'bg-secondary');
+        const completed = Number(result && result.completed || 0);
+        const total = Number(result && result.total || OFFLINE_MANIFEST.pages.length + OFFLINE_MANIFEST.assets.length);
+        prepareProgress.style.width = (total ? Math.round(completed * 100 / total) : 0) + '%';
+        preparedDetail.textContent = completed + ' of ' + total + ' package items verified';
+    }
+
+    prepareOfflineBtn.addEventListener('click', function () {
+        prepareOfflineBtn.disabled = true;
+        renderPrepared({state: 'preparing', completed: 0, total: OFFLINE_MANIFEST.pages.length + OFFLINE_MANIFEST.assets.length});
+        swMessage({type: 'prepare-offline-package', manifest: OFFLINE_MANIFEST});
+    });
+    document.getElementById('drainLegacyBtn').addEventListener('click', function () {
+        swMessage({type: 'drain-legacy-queue'});
+    });
+    if (navigator.serviceWorker) {
+        navigator.serviceWorker.addEventListener('message', function (event) {
+            const data = event.data || {};
+            if (data.type === 'prepare-offline-progress') renderPrepared(Object.assign({state: 'preparing'}, data));
+            if (data.type === 'prepare-offline-complete') {
+                prepareOfflineBtn.disabled = false;
+                renderPrepared(data.result);
+            }
+            if (data.type === 'prepared-package-status') renderPrepared(data.result);
+            if (data.type === 'legacy-queue-status') {
+                legacyQueueCount.textContent = String(data.result.count || 0);
+                const manual = Number(data.result.manual_reconciliation_required || 0);
+                legacyQueueCount.className = 'badge ' + (manual ? 'bg-danger' : 'bg-secondary');
+                legacyQueueCount.title = manual ?
+                    (manual + ' entrie(s) require manual reconciliation') : '';
+            }
+            if (data.type === 'legacy-sync-complete') {
+                legacyQueueCount.textContent = String(data.failed || 0);
+                setStatus('<i class="bi bi-database-check"></i> Legacy drain verified ' + (data.success || 0) + ' entrie(s); ' + (data.failed || 0) + ' remain.', data.failed ? 'alert-warning' : 'alert-success');
+            }
+        });
+    }
 
     updateNetwork();
     renderQueue();
+    swMessage({type: 'prepared-package-status', context: OFFLINE_CONTEXT});
+    swMessage({type: 'legacy-queue-status'});
 });
 </script>
 {% endblock %}

--- a/templates/scoring/scratch_preview.html
+++ b/templates/scoring/scratch_preview.html
@@ -24,12 +24,16 @@
         <div class="card-header bg-warning text-dark">
           <h4 class="mb-0">
             <i class="bi bi-exclamation-triangle-fill me-2"></i>
-            Confirm Scratch: {{ competitor.name }}
+            {% if competitor.status == 'scratched' %}Scratch Active{% else %}Confirm Scratch{% endif %}: {{ competitor.name }}
           </h4>
         </div>
         <div class="card-body">
 
-          {% if effects %}
+          {% if competitor.status == 'scratched' %}
+          <span class="badge bg-warning text-dark">Scratched</span>
+          <a href="{{ cancel_url }}" class="btn btn-sm btn-outline-secondary ms-2">Back</a>
+
+          {% elif effects %}
           <p class="text-muted mb-3">
             The following changes will be applied. Uncheck any effect you want to skip.
           </p>
@@ -38,6 +42,7 @@
                 action="{{ url_for('scoring.scratch_confirm', tournament_id=tournament.id, competitor_id=competitor.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="competitor_type" value="{{ competitor_type }}">
+            <input type="hidden" name="expected_effect_digest" value="{{ effect_digest }}">
             {% if return_event_id %}<input type="hidden" name="return_event_id" value="{{ return_event_id }}">{% endif %}
             <input type="hidden" name="effect_count" value="{{ effects|length }}">
 
@@ -91,6 +96,7 @@
                 action="{{ url_for('scoring.scratch_confirm', tournament_id=tournament.id, competitor_id=competitor.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="competitor_type" value="{{ competitor_type }}">
+            <input type="hidden" name="expected_effect_digest" value="{{ effect_digest }}">
             {% if return_event_id %}<input type="hidden" name="return_event_id" value="{{ return_event_id }}">{% endif %}
             <input type="hidden" name="effect_count" value="0">
             <div class="d-flex gap-2">
@@ -110,6 +116,7 @@
                 action="{{ url_for('scoring.scratch_undo', tournament_id=tournament.id, competitor_id=competitor.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="competitor_type" value="{{ competitor_type }}">
+            <input type="hidden" name="expected_undo_token" value="{{ undo_token }}">
             <button type="submit" class="btn btn-sm btn-outline-secondary">
               <i class="bi bi-arrow-counterclockwise me-1"></i>Undo Last Scratch
             </button>

--- a/templates/tournament_detail.html
+++ b/templates/tournament_detail.html
@@ -758,8 +758,8 @@
                     <input class="form-control form-control-sm" type="file"
                            name="backup_file" accept=".db" required style="max-width:280px;">
                     <button class="btn btn-outline-danger btn-sm" type="submit"
-                            data-confirm="Restoring a backup will overwrite the current database. Continue?">
-                        <i class="bi bi-database-up"></i> Restore DB
+                            data-confirm="Validate and stage this backup for offline maintenance? The live database will not be changed.">
+                        <i class="bi bi-database-up"></i> Stage Restore
                     </button>
                 </form>
             </div>

--- a/tests/db_test_utils.py
+++ b/tests/db_test_utils.py
@@ -59,6 +59,9 @@ def _isolate_report_cache():
 
     with report_cache._lock:
         report_cache._cache.clear()
+        report_cache._prefix_generations.clear()
+        report_cache._generation_counter = 0
+    report_cache._read_state.misses = {}
     report_cache._shelf_path = None
     report_cache._shelf_resolved = True
 

--- a/tests/js/offline_queue_shared.test.js
+++ b/tests/js/offline_queue_shared.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const SOURCE = fs.readFileSync(
+    require('node:path').join(__dirname, '..', '..', 'static', 'js', 'offline_queue_shared.js'),
+    'utf8'
+);
+
+function sharedStorage() {
+    const values = new Map();
+    let afterSet = null;
+    return {
+        get length() {
+            return values.size;
+        },
+        key(index) {
+            return Array.from(values.keys())[index] || null;
+        },
+        getItem(key) {
+            return values.has(key) ? values.get(key) : null;
+        },
+        setItem(key, value) {
+            values.set(key, String(value));
+            if (afterSet) {
+                const hook = afterSet;
+                afterSet = null;
+                hook(key, values);
+            }
+        },
+        removeItem(key) {
+            values.delete(key);
+        },
+        interfereOnce(hook) {
+            afterSet = hook;
+        }
+    };
+}
+
+function lockManager() {
+    const tails = new Map();
+    return {
+        request(name, _options, callback) {
+            const prior = tails.get(name) || Promise.resolve();
+            const current = prior.then(callback, callback);
+            tails.set(name, current.catch(() => {}));
+            return current;
+        }
+    };
+}
+
+function loadTab(storage, locks) {
+    const window = {
+        crypto: {
+            randomUUID: () => `00000000-0000-4000-8000-${String(Math.random()).slice(2, 14).padEnd(12, '0')}`,
+            getRandomValues: (bytes) => bytes,
+            subtle: {digest: async () => new Uint8Array(32)}
+        }
+    };
+    const context = vm.createContext({
+        FormData: class FormData {},
+        TextEncoder,
+        URLSearchParams,
+        clearTimeout,
+        console,
+        fetch: async () => { throw new Error('unexpected fetch'); },
+        localStorage: storage,
+        navigator: {locks},
+        Promise,
+        setTimeout,
+        Uint8Array,
+        window
+    });
+    vm.runInContext(SOURCE, context, {filename: 'offline_queue_shared.js'});
+    return window.ProAmOfflineQueue;
+}
+
+function entry(id, heatId) {
+    return {
+        request_id: id,
+        tournament_id: 7,
+        heat_id: heatId,
+        issuer_user_id: 11,
+        payload_sha256: `sha-${id}`
+    };
+}
+
+function receipt(item) {
+    return {
+        accepted: true,
+        request_id: item.request_id,
+        tournament_id: item.tournament_id,
+        heat_id: item.heat_id,
+        issuing_user_id: item.issuer_user_id,
+        payload_sha256: item.payload_sha256
+    };
+}
+
+async function main() {
+    const storage = sharedStorage();
+    const locks = lockManager();
+    const firstTab = loadTab(storage, locks);
+    const secondTab = loadTab(storage, locks);
+    const alpha = entry('alpha', 1);
+    const beta = entry('beta', 2);
+
+    await Promise.all([firstTab.upsert(alpha), secondTab.upsert(beta)]);
+    assert.deepEqual(
+        Array.from(firstTab.read(), (row) => row.request_id).sort(),
+        ['alpha', 'beta']
+    );
+
+    const gamma = entry('gamma', 3);
+    await Promise.all([
+        firstTab.removeVerified(alpha, receipt(alpha)),
+        secondTab.upsert(gamma)
+    ]);
+    assert.deepEqual(
+        Array.from(firstTab.read(), (row) => row.request_id).sort(),
+        ['beta', 'gamma']
+    );
+
+    const delta = entry('delta', 4);
+    const external = entry('external', 5);
+    storage.interfereOnce((key, values) => {
+        if (key === firstTab.key) values.set(key, JSON.stringify([beta, gamma, external]));
+    });
+    await firstTab.upsert(delta);
+    assert.deepEqual(
+        Array.from(firstTab.read(), (row) => row.request_id).sort(),
+        ['beta', 'delta', 'external', 'gamma']
+    );
+
+    const late = entry('late', 8);
+    storage.interfereOnce((key, values) => {
+        if (key === firstTab.key) {
+            values.set(key, JSON.stringify([beta, delta, external, gamma, late]));
+        }
+    });
+    await firstTab.removeVerified(gamma, receipt(gamma));
+    assert.deepEqual(
+        Array.from(firstTab.read(), (row) => row.request_id).sort(),
+        ['beta', 'delta', 'external', 'late']
+    );
+
+    assert.equal(firstTab.verifyReceipt(delta, receipt(delta)), true);
+    assert.equal(
+        firstTab.verifyReceipt(delta, {...receipt(delta), issuing_user_id: 99}),
+        false
+    );
+
+    const context = {
+        tournament_id: 7,
+        issuer_user_id: 11,
+        issuer_role: 'admin',
+        schedule_fingerprint: 'schedule-1',
+        application_build: 'build-1'
+    };
+    const cachedFormPayload = {
+        request_id: '00000000-0000-4000-8000-cached000000',
+        heat_id: '9',
+        tournament_id: '7',
+        result_22: '14'
+    };
+    const firstAction = await firstTab.prepareEntry({
+        heat_id: 9,
+        payload: cachedFormPayload
+    }, context);
+    const secondAction = await firstTab.prepareEntry({
+        heat_id: 9,
+        payload: cachedFormPayload
+    }, context);
+    assert.notEqual(firstAction.request_id, cachedFormPayload.request_id);
+    assert.notEqual(firstAction.request_id, secondAction.request_id);
+    const retriedAction = await firstTab.prepareEntry(firstAction, context);
+    assert.equal(retriedAction.request_id, firstAction.request_id);
+
+    const fallbackStorage = sharedStorage();
+    const fallbackFirst = loadTab(fallbackStorage, undefined);
+    const fallbackSecond = loadTab(fallbackStorage, undefined);
+    await Promise.all([
+        fallbackFirst.upsert(entry('fallback-one', 6)),
+        fallbackSecond.upsert(entry('fallback-two', 7))
+    ]);
+    assert.deepEqual(
+        Array.from(fallbackFirst.read(), (row) => row.request_id).sort(),
+        ['fallback-one', 'fallback-two']
+    );
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/js/service_worker_offline.test.js
+++ b/tests/js/service_worker_offline.test.js
@@ -1,0 +1,251 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const {webcrypto} = require('crypto');
+
+const source = fs.readFileSync('static/sw.js', 'utf8') + `
+globalThis.__swTest = {
+    sha256Bytes,
+    verifyFetchedRow,
+    renewLegacyReplayToken,
+    replayLegacyEntry,
+    setHooks(hooks) {
+        if (hooks.prepareLegacyEntry) prepareLegacyEntry = hooks.prepareLegacyEntry;
+        if (hooks.postLegacy) postLegacy = hooks.postLegacy;
+        if (hooks.updateLegacyEntry) updateLegacyEntry = hooks.updateLegacyEntry;
+        if (hooks.removeLegacyEntry) removeLegacyEntry = hooks.removeLegacyEntry;
+    }
+};`;
+
+const context = vm.createContext({
+    URL,
+    URLSearchParams,
+    Request,
+    Response,
+    TextEncoder,
+    crypto: webcrypto,
+    console,
+    setTimeout,
+    clearTimeout,
+    self: {
+        location: {origin: 'https://proam.test'},
+        addEventListener() {},
+        skipWaiting: async () => {},
+        clients: {claim: async () => {}, matchAll: async () => []}
+    },
+    caches: {
+        delete: async () => true,
+        keys: async () => [],
+        open: async () => ({match: async () => null, put: async () => {}})
+    },
+    indexedDB: {}
+});
+context.globalThis = context;
+vm.runInContext(source, context, {filename: 'static/sw.js'});
+
+async function expectRejects(promise, expected) {
+    let error;
+    try {
+        await promise;
+    } catch (caught) {
+        error = caught;
+    }
+    assert(error, 'expected promise to reject');
+    assert.strictEqual(error.code || error.message, expected);
+}
+
+async function run() {
+    const api = context.__swTest;
+    const assetBody = 'verified asset bytes';
+    const assetDigest = await api.sha256Bytes(
+        new TextEncoder().encode(assetBody).buffer
+    );
+    const manifest = {
+        application_build: 'build-123',
+        schedule_fingerprint: 'schedule-456',
+        tournament_id: 9,
+        issuer_user_id: 7,
+        issuer_role: 'judge'
+    };
+    const asset = {
+        kind: 'asset',
+        url: '/static/app.js',
+        content_sha256: assetDigest
+    };
+    assert.strictEqual(
+        await api.verifyFetchedRow(manifest, asset, new Response(assetBody)),
+        assetDigest
+    );
+    await expectRejects(
+        api.verifyFetchedRow(
+            manifest,
+            {...asset, content_sha256: '0'.repeat(64)},
+            new Response(assetBody)
+        ),
+        'content_digest_mismatch'
+    );
+
+    const pageBody = '<html>prepared heat</html>';
+    const pageDigest = await api.sha256Bytes(
+        new TextEncoder().encode(pageBody).buffer
+    );
+    const pageHeaders = {
+        'Content-Type': 'text/html; charset=utf-8',
+        'X-ProAm-Offline-Build': manifest.application_build,
+        'X-ProAm-Offline-Schedule': manifest.schedule_fingerprint,
+        'X-ProAm-Offline-Tournament': String(manifest.tournament_id),
+        'X-ProAm-Offline-Issuer': String(manifest.issuer_user_id),
+        'X-ProAm-Offline-Role': manifest.issuer_role,
+        'X-ProAm-Offline-Content-SHA256': pageDigest
+    };
+    assert.strictEqual(
+        await api.verifyFetchedRow(
+            manifest,
+            {kind: 'page', url: '/scoring/9/heat/4/enter'},
+            new Response(pageBody, {headers: pageHeaders})
+        ),
+        pageDigest
+    );
+    await expectRejects(
+        api.verifyFetchedRow(
+            manifest,
+            {kind: 'page', url: '/scoring/9/heat/4/enter'},
+            new Response(pageBody, {
+                headers: {...pageHeaders, 'X-ProAm-Offline-Build': 'other-build'}
+            })
+        ),
+        'prepared_context_mismatch'
+    );
+
+    let updatedEntry;
+    context.fetch = async () => new Response(JSON.stringify({
+        ok: true,
+        replay_token: 'fresh-token',
+        issuer_user_id: 7,
+        issuer_role: 'judge'
+    }), {headers: {'Content-Type': 'application/json'}});
+    vm.runInContext(
+        'updateLegacyEntry = async (_database, entry) => { globalThis.updatedEntry = entry; };',
+        context
+    );
+    const entry = {id: 3, issuer_user_id: 7, issuer_role: 'judge', body: ''};
+    const params = new URLSearchParams('request_id=request-1');
+    await api.renewLegacyReplayToken({}, entry, params);
+    updatedEntry = context.updatedEntry;
+    assert.strictEqual(params.get('replay_token'), 'fresh-token');
+    assert(updatedEntry.body.includes('replay_token=fresh-token'));
+
+    context.fetch = async () => new Response(JSON.stringify({
+        ok: true,
+        replay_token: 'wrong-session-token',
+        issuer_user_id: 8,
+        issuer_role: 'judge'
+    }), {headers: {'Content-Type': 'application/json'}});
+    await expectRejects(
+        api.renewLegacyReplayToken({}, entry, params),
+        'legacy_issuer_session_mismatch'
+    );
+
+    const agedEntry = {
+        id: 4,
+        url: '/scoring/9/heat/4/enter',
+        timestamp: Date.now() - (8 * 24 * 60 * 60 * 1000),
+        request_id: 'request-aged',
+        payload_sha256: 'a'.repeat(64),
+        tournament_id: 9,
+        heat_id: 4,
+        issuer_user_id: 7,
+        issuer_role: 'judge'
+    };
+    const agedParams = new URLSearchParams({
+        request_id: agedEntry.request_id,
+        payload_sha256: agedEntry.payload_sha256,
+        tournament_id: '9',
+        heat_id: '4',
+        issuer_user_id: '7',
+        issuer_role: 'judge',
+        replay_token: 'expired-token'
+    });
+    let postCount = 0;
+    let removed = false;
+    api.setHooks({
+        prepareLegacyEntry: async () => ({
+            entry: agedEntry,
+            params: agedParams,
+            replayable: true
+        }),
+        updateLegacyEntry: async (_database, changed) => {
+            updatedEntry = changed;
+        },
+        removeLegacyEntry: async (_database, id) => {
+            removed = id === agedEntry.id;
+        },
+        postLegacy: async () => {
+            postCount += 1;
+            if (postCount === 1) {
+                return new Response(JSON.stringify({
+                    ok: false,
+                    error: {code: 'csrf_expired'}
+                }), {status: 400, headers: {'Content-Type': 'application/json'}});
+            }
+            if (postCount === 2) {
+                return new Response(JSON.stringify({
+                    ok: false,
+                    error: {code: 'replay_token_expired'}
+                }), {status: 403, headers: {'Content-Type': 'application/json'}});
+            }
+            return new Response(JSON.stringify({
+                ok: true,
+                receipt: {
+                    accepted: true,
+                    request_id: agedEntry.request_id,
+                    payload_sha256: agedEntry.payload_sha256,
+                    tournament_id: 9,
+                    heat_id: 4,
+                    issuing_user_id: 7
+                }
+            }), {status: 200, headers: {'Content-Type': 'application/json'}});
+        }
+    });
+    context.fetch = async () => new Response(JSON.stringify({
+        ok: true,
+        replay_token: 'renewed-after-eight-days',
+        issuer_user_id: 7,
+        issuer_role: 'judge'
+    }), {headers: {'Content-Type': 'application/json'}});
+
+    assert.strictEqual(await api.replayLegacyEntry({}, agedEntry), true);
+    assert.strictEqual(postCount, 3);
+    assert.strictEqual(agedParams.get('replay_token'), 'renewed-after-eight-days');
+    assert.strictEqual(removed, true);
+
+    const overAgeEntry = {
+        ...agedEntry,
+        id: 5,
+        timestamp: Date.now() - (31 * 24 * 60 * 60 * 1000)
+    };
+    api.setHooks({
+        prepareLegacyEntry: async () => ({
+            entry: overAgeEntry,
+            params: new URLSearchParams(agedParams),
+            replayable: true
+        })
+    });
+    context.fetch = async () => {
+        throw new Error('over-age entry attempted replay-token renewal');
+    };
+    await expectRejects(
+        api.replayLegacyEntry({}, overAgeEntry),
+        'manual_reconciliation_required'
+    );
+    assert.strictEqual(postCount, 3);
+}
+
+run().then(() => {
+    process.stdout.write('service worker offline tests passed\n');
+}).catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tests/test_birling_bracket.py
+++ b/tests/test_birling_bracket.py
@@ -368,7 +368,10 @@ class TestUndoMatchResult:
         assert match['loser'] == comp2
 
         with patched_bracket_deps():
-            result = b.undo_match_result(match['match_id'])
+            result = b.undo_match_result(
+                match['match_id'],
+                expected_undo_digest=b.match_fall_digest(match['match_id']),
+            )
         assert result['undone'] is True
         assert match['winner'] is None
         assert match['loser'] is None
@@ -397,7 +400,12 @@ class TestUndoMatchResult:
         # Try to undo the first-round match — should fail (downstream played)
         with patched_bracket_deps():
             with pytest.raises(ValueError, match="downstream match"):
-                b.undo_match_result(first_round[0]['match_id'])
+                b.undo_match_result(
+                    first_round[0]['match_id'],
+                    expected_undo_digest=b.match_fall_digest(
+                        first_round[0]['match_id'],
+                    ),
+                )
 
     def test_undo_match_no_winner_raises(self):
         """Try to undo a match with no winner. Expect ValueError."""
@@ -405,4 +413,7 @@ class TestUndoMatchResult:
         match = b.bracket_data['bracket']['winners'][0][0]
         with patched_bracket_deps():
             with pytest.raises(ValueError, match="no result to undo"):
-                b.undo_match_result(match['match_id'])
+                b.undo_match_result(
+                    match['match_id'],
+                    expected_undo_digest=b.match_fall_digest(match['match_id']),
+                )

--- a/tests/test_birling_refusal_surface.py
+++ b/tests/test_birling_refusal_surface.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 import copy
+import re
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from uuid import uuid4
 
 import pytest
 
@@ -28,6 +32,20 @@ def _world(session):
         {"id": person.id, "name": person.display_name} for person in people
     ])
     return event, people, bracket
+
+
+def _authenticated_client(app, session):
+    from models.user import User
+
+    admin = User(username=f'birling_operator_{uuid4().hex}', role='admin')
+    admin.set_password('test-password')
+    session.add(admin)
+    session.flush()
+    client = app.test_client()
+    with client.session_transaction() as client_session:
+        client_session['_user_id'] = str(admin.id)
+        client_session['_fresh'] = True
+    return client
 
 
 def test_rejected_document_leaves_last_valid_rows_intact(
@@ -62,8 +80,313 @@ def test_reset_keeps_payout_configuration(db_session, auth_client):
     db_session.commit()
 
     response = auth_client.post(
-        f"/scheduling/{event.tournament_id}/event/{event.id}/birling/reset")
+        f"/scheduling/{event.tournament_id}/event/{event.id}/birling/reset",
+        data={
+            'expected_bracket_digest': BirlingBracket(
+                event,
+            ).bracket_state_digest(),
+        },
+    )
 
     assert response.status_code == 302
     assert event.payouts == '{"1": 500}'
     assert rows.load_document(event) == rows.empty_document()
+
+
+def _record_direct_result(bracket, winner_index=0):
+    match = bracket.get_current_matches()[0]
+    bracket.record_direct_winner(
+        match['match_id'],
+        match[f'competitor{winner_index + 1}'],
+        expected_fall_digest=bracket.match_fall_digest(match['match_id']),
+    )
+    return match['match_id']
+
+
+def test_destructive_forms_render_current_state_digests(app, db_session):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match_id = _record_direct_result(bracket)
+
+    response = auth_client.get(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling'
+    )
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    persisted = BirlingBracket(event)
+    assert (
+        f'name="expected_undo_digest" '
+        f'value="{persisted.match_fall_digest(match_id)}"'
+    ) in html
+    rendered_reset_digest = re.search(
+        r'name="expected_bracket_digest" value="([0-9a-f]+)"',
+        html,
+    )
+    assert rendered_reset_digest is not None
+    assert rendered_reset_digest.group(1) == persisted.bracket_state_digest()
+
+
+@pytest.mark.parametrize('action', ['undo', 'reset'])
+def test_destructive_action_without_digest_is_retryable_and_does_not_mutate(
+    action, app, db_session,
+):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match_id = _record_direct_result(bracket)
+    before = rows.load_document(event)
+    data = {'match_id': match_id} if action == 'undo' else {}
+
+    response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/{action}',
+        data=data,
+    )
+
+    assert response.status_code == 409
+    assert response.headers['X-Retryable'] == 'true'
+    assert rows.load_document(event) == before
+
+
+def test_stale_undo_does_not_remove_a_newer_match_result(app, db_session):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match_id = _record_direct_result(bracket, winner_index=0)
+    stale_digest = BirlingBracket(event).match_fall_digest(match_id)
+
+    first_undo = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/undo',
+        data={
+            'match_id': match_id,
+            'expected_undo_digest': stale_digest,
+        },
+    )
+    refreshed = BirlingBracket(event)
+    match = refreshed._find_match(match_id)
+    refreshed.record_direct_winner(
+        match_id,
+        match['competitor2'],
+        expected_fall_digest=refreshed.match_fall_digest(match_id),
+    )
+
+    stale_undo = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/undo',
+        data={
+            'match_id': match_id,
+            'expected_undo_digest': stale_digest,
+        },
+    )
+
+    assert first_undo.status_code == 302
+    assert stale_undo.status_code == 409
+    assert stale_undo.headers['X-Retryable'] == 'true'
+    assert BirlingBracket(event)._find_match(match_id)['winner'] == match['competitor2']
+
+
+def test_fresh_no_js_undo_form_clears_the_result(app, db_session):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match_id = _record_direct_result(bracket)
+    persisted = BirlingBracket(event)
+
+    response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/undo',
+        data={
+            'match_id': match_id,
+            'expected_undo_digest': persisted.match_fall_digest(match_id),
+        },
+    )
+
+    assert response.status_code == 302
+    match = BirlingBracket(event)._find_match(match_id)
+    assert match['winner'] is None
+    assert match['loser'] is None
+    assert match['falls'] == []
+
+
+def test_concurrent_undo_submissions_apply_exactly_once(app, db_session):
+    event, _people, bracket = _world(db_session)
+    match_id = _record_direct_result(bracket)
+    expected_digest = BirlingBracket(event).match_fall_digest(match_id)
+    clients = [
+        _authenticated_client(app, db_session),
+        _authenticated_client(app, db_session),
+    ]
+    db_session.commit()
+    barrier = Barrier(2)
+    url = f'/scheduling/{event.tournament_id}/event/{event.id}/birling/undo'
+
+    def submit(client):
+        barrier.wait(timeout=5)
+        return client.post(url, data={
+            'match_id': match_id,
+            'expected_undo_digest': expected_digest,
+        }).status_code
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        statuses = list(pool.map(submit, clients))
+
+    assert sorted(statuses) == [302, 409]
+    match = BirlingBracket(event)._find_match(match_id)
+    assert match['winner'] is None
+    assert match['loser'] is None
+    assert match['falls'] == []
+
+
+def test_stale_reset_preserves_a_newer_fall(app, db_session):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    stale_digest = bracket.bracket_state_digest()
+    match = bracket.get_current_matches()[0]
+    bracket.record_fall(
+        match['match_id'],
+        match['competitor1'],
+        expected_fall_digest=bracket.match_fall_digest(match['match_id']),
+    )
+
+    response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/reset',
+        data={'expected_bracket_digest': stale_digest},
+    )
+
+    assert response.status_code == 409
+    assert response.headers['X-Retryable'] == 'true'
+    persisted = BirlingBracket(event)._find_match(match['match_id'])
+    assert [fall['winner'] for fall in persisted['falls']] == [
+        match['competitor1'],
+    ]
+
+
+def test_duplicate_birling_fall_submission_does_not_add_a_second_fall(
+    app, db_session,
+):
+    auth_client = _authenticated_client(app, db_session)
+
+    event, _people, bracket = _world(db_session)
+    match = bracket.get_current_matches()[0]
+    expected_fall_digest = bracket.match_fall_digest(match['match_id'])
+    payload = {
+        'match_id': match['match_id'],
+        'fall_winner_id': str(match['competitor1']),
+        'expected_fall_digest': expected_fall_digest,
+    }
+    url = (
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/fall'
+    )
+
+    first = auth_client.post(url, data=payload)
+    duplicate = auth_client.post(url, data=payload)
+
+    assert first.status_code == 302
+    assert duplicate.status_code == 409
+    assert duplicate.headers['X-Retryable'] == 'true'
+    persisted = BirlingBracket(event)._find_match(match['match_id'])
+    assert len(persisted['falls']) == 1
+    with auth_client.session_transaction() as session:
+        assert any(
+            'fall state changed since this page was loaded' in message
+            for _, message in session['_flashes']
+        )
+
+
+def test_direct_winner_form_renders_current_fall_digest(
+    app, db_session,
+):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match = bracket.get_current_matches()[0]
+    expected_fall_digest = bracket.match_fall_digest(match['match_id'])
+
+    response = auth_client.get(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling'
+    )
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert html.count(
+        f'name="expected_fall_digest" value="{expected_fall_digest}"'
+    ) == 3
+
+
+def test_stale_direct_winner_after_fall_returns_retryable_conflict(
+    app, db_session,
+):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match = bracket.get_current_matches()[0]
+    match_id = match['match_id']
+    direct_winner_id = match['competitor2']
+    fall_winner_id = match['competitor1']
+    stale_digest = bracket.match_fall_digest(match_id)
+
+    fall_response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/fall',
+        data={
+            'match_id': match_id,
+            'fall_winner_id': str(fall_winner_id),
+            'expected_fall_digest': stale_digest,
+        },
+    )
+    stale_response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/record',
+        data={
+            'match_id': match_id,
+            'winner_id': str(direct_winner_id),
+            'expected_fall_digest': stale_digest,
+        },
+    )
+
+    assert fall_response.status_code == 302
+    assert stale_response.status_code == 409
+    assert stale_response.headers['X-Retryable'] == 'true'
+
+    persisted = BirlingBracket(event)._find_match(match_id)
+    assert persisted['winner'] is None
+    assert persisted['loser'] is None
+    assert [fall['winner'] for fall in persisted['falls']] == [fall_winner_id]
+
+
+def test_direct_winner_without_fall_digest_is_rejected(app, db_session):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match = bracket.get_current_matches()[0]
+
+    response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/record',
+        data={
+            'match_id': match['match_id'],
+            'winner_id': str(match['competitor1']),
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.headers['X-Retryable'] == 'true'
+    persisted = BirlingBracket(event)._find_match(match['match_id'])
+    assert persisted['winner'] is None
+    assert persisted['loser'] is None
+    assert persisted['falls'] == []
+
+
+def test_direct_winner_with_current_digest_preserves_no_js_flow(
+    app, db_session,
+):
+    auth_client = _authenticated_client(app, db_session)
+    event, _people, bracket = _world(db_session)
+    match = bracket.get_current_matches()[0]
+    winner_id = match['competitor1']
+
+    response = auth_client.post(
+        f'/scheduling/{event.tournament_id}/event/{event.id}/birling/record',
+        data={
+            'match_id': match['match_id'],
+            'winner_id': str(winner_id),
+            'expected_fall_digest': bracket.match_fall_digest(match['match_id']),
+        },
+    )
+
+    assert response.status_code == 302
+    persisted = BirlingBracket(event)._find_match(match['match_id'])
+    assert persisted['winner'] == winner_id
+    assert [fall['winner'] for fall in persisted['falls']] == [
+        winner_id,
+        winner_id,
+    ]

--- a/tests/test_birling_rows.py
+++ b/tests/test_birling_rows.py
@@ -501,7 +501,10 @@ class TestARealSaveWritesRows:
         match = next(m for m in bracket.bracket_data["bracket"]["winners"][0]
                      if m["competitor1"] and m["competitor2"])
         bracket.record_match_result(match["match_id"], match["competitor1"])
-        bracket.undo_match_result(match["match_id"])
+        bracket.undo_match_result(
+            match["match_id"],
+            expected_undo_digest=bracket.match_fall_digest(match["match_id"]),
+        )
 
         row = next(m for m in _rows_for(event.id)["matches"]
                    if m.match_id == match["match_id"])

--- a/tests/test_daily_backup_workflow.py
+++ b/tests/test_daily_backup_workflow.py
@@ -1,0 +1,177 @@
+import re
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+WORKFLOW_PATH = Path(__file__).parents[1] / '.github' / 'workflows' / 'daily-backup.yml'
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding='utf-8')
+
+
+def _step_block(workflow: str, name: str) -> str:
+    marker = f'      - name: {name}'
+    start = workflow.index(marker)
+    next_step = workflow.find('\n      - name:', start + len(marker))
+    if next_step == -1:
+        return workflow[start:]
+    return workflow[start:next_step]
+
+
+def test_backup_restores_only_to_guarded_runner_local_postgres():
+    workflow = _workflow_text()
+
+    assert 'services:' in workflow
+    assert 'image: postgres:18' in workflow
+    assert 'RESTORE_HOST: 127.0.0.1' in workflow
+    assert 'RESTORE_DB: proam_restore_verify' in workflow
+
+    restore = _step_block(workflow, 'Restore dump into runner-local PostgreSQL')
+    assert 'pg_restore' in restore
+    assert '"$RESTORE_HOST" != "127.0.0.1"' in restore
+    assert '"$RESTORE_DB" != "proam_restore_verify"' in restore
+    assert 'RAILWAY' not in restore
+
+
+def test_restore_requires_exact_migration_head_and_current_recovery_schema():
+    workflow = _workflow_text()
+    config = Config()
+    config.set_main_option(
+        'script_location',
+        str(WORKFLOW_PATH.parents[2] / 'migrations'),
+    )
+    heads = ScriptDirectory.from_config(config).get_heads()
+
+    assert len(heads) == 1
+    assert f'EXPECTED_ALEMBIC_HEAD: {heads[0]}' in workflow
+    verify = _step_block(workflow, 'Verify restored schema and aggregate invariants')
+    assert "version_num = '$EXPECTED_ALEMBIC_HEAD'" in verify
+    assert 'score_submission_receipts' in verify
+    assert 'owner_boot_id' in verify
+    assert 'owner_heartbeat_at' in verify
+    assert 'ix_score_submission_receipts_binding' in verify
+    assert 'ix_background_jobs_owner_heartbeat_at' in verify
+    assert "column_name = 'tournament_id' AND confdeltype = 'c'" in verify
+    assert "column_name = 'issuing_user_id' AND confdeltype = 'n'" in verify
+    assert "column_name = 'heat_id') = 0" in verify
+
+
+def test_restore_password_is_scoped_to_trusted_database_steps():
+    workflow = _workflow_text()
+    job_configuration = workflow[workflow.index('jobs:') : workflow.index('    steps:')]
+
+    assert 'PGPASSWORD:' not in job_configuration
+    for step_name in (
+        'Restore dump into runner-local PostgreSQL',
+        'Verify restored schema and aggregate invariants',
+        'Drop runner-local plaintext restore',
+    ):
+        step = _step_block(workflow, step_name)
+        assert 'env:\n          PGPASSWORD: runner-local-restore-only' in step
+
+    upload = _step_block(workflow, 'Upload encrypted backup artifact')
+    assert 'PGPASSWORD' not in upload
+
+
+def test_pg_restore_diagnostics_are_withheld_and_securely_deleted():
+    workflow = _workflow_text()
+    restore = _step_block(workflow, 'Restore dump into runner-local PostgreSQL')
+
+    assert 'RESTORE_LOG=$(mktemp "$RUNNER_TEMP/proam_pg_restore_XXXXXX.log")' in restore
+    assert 'chmod 600 "$RESTORE_LOG"' in restore
+    assert 'trap secure_delete_restore_log EXIT' in restore
+    assert '>"$RESTORE_LOG" 2>&1' in restore
+    assert 'shred --remove=unlink --zero "$RESTORE_LOG"' in restore
+    assert 'database diagnostics were withheld' in restore
+    assert 'cat "$RESTORE_LOG"' not in restore
+    assert 'tail ' not in restore
+
+
+def test_production_dump_role_is_verified_without_row_output():
+    workflow = _workflow_text()
+    privilege_check = _step_block(workflow, 'Verify production dump role')
+
+    assert 'rolsuper' in privilege_check
+    assert 'default_transaction_read_only' in privilege_check
+    assert 'has_table_privilege' in privilege_check
+    assert 'RAILWAY_PG_READONLY_DUMP_URL' in privilege_check
+    assert workflow.count('${{ secrets.RAILWAY_PG_READONLY_DUMP_URL }}') == 2
+    assert 'RAILWAY_PG_PUBLIC_URL' not in workflow
+    assert 'First 20 lines' not in workflow
+    assert 'COPY public.alembic_version' not in workflow
+    assert 'head -20' not in workflow
+
+
+def test_verified_backup_is_encrypted_and_only_ciphertext_is_uploaded():
+    workflow = _workflow_text()
+    recipient_check = _step_block(workflow, 'Verify encryption recipient')
+    encryption = _step_block(workflow, 'Encrypt verified backup')
+    cleanup = _step_block(workflow, 'Delete plaintext backup')
+    drop_restore = _step_block(workflow, 'Drop runner-local plaintext restore')
+    upload = _step_block(workflow, 'Upload encrypted backup artifact')
+
+    assert '${{ vars.BACKUP_AGE_RECIPIENT }}' in recipient_check
+    assert workflow.index('Verify encryption recipient') < workflow.index('Take read-only pg_dump')
+    assert 'age --recipient' in encryption
+    assert 'if: ${{ always() }}' in cleanup
+    assert 'shred' in cleanup
+    assert 'Plaintext cleanup failed; artifact upload is blocked.' in cleanup
+    assert 'exit 1' in cleanup
+    assert 'if: ${{ success() }}' in upload
+    assert 'path: ${{ env.CIPHERTEXT_FILE }}' in upload
+    assert 'path: ${{ env.BACKUP_FILE }}' not in workflow
+    assert 'dropdb' in drop_restore
+    assert 'if: ${{ always() }}' in drop_restore
+    assert '"$RESTORE_HOST" != "127.0.0.1"' in drop_restore
+    assert '"$RESTORE_DB" != "proam_restore_verify"' in drop_restore
+    assert workflow.index('Drop runner-local plaintext restore') < workflow.index(
+        'Delete plaintext backup'
+    )
+    assert workflow.index('Delete plaintext backup') < workflow.index(
+        'Upload encrypted backup artifact'
+    )
+
+
+def test_encryption_recipient_is_pinned_by_reviewable_fingerprint():
+    workflow = _workflow_text()
+    recipient_check = _step_block(workflow, 'Verify encryption recipient')
+
+    assert '${{ vars.BACKUP_AGE_RECIPIENT_SHA256 }}' in recipient_check
+    assert 'PINNED_RECIPIENT_SHA256' in recipient_check
+    assert 'ACTUAL_RECIPIENT_SHA256' in recipient_check
+    assert 'sha256sum' in recipient_check
+    assert 'does not match the approved fingerprint' in recipient_check
+
+
+def test_workflow_does_not_claim_ciphertext_recovery_was_verified():
+    workflow = _workflow_text()
+    summary = _step_block(workflow, 'Write verification summary')
+
+    assert '## Plaintext Backup Restore Verified' in summary
+    assert '## Encrypted Backup Verified' not in summary
+    assert 'Ciphertext decrypt-and-restore: not run by this workflow' in summary
+    assert 'separately held identity rehearsal' in summary
+
+
+def test_plaintext_restore_is_dropped_before_pinned_third_party_action():
+    workflow = _workflow_text()
+    pinned_upload = (
+        'uses: actions/upload-artifact@'
+        'ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2'
+    )
+
+    uses_positions = [match.start() for match in re.finditer(r'^\s+uses:', workflow, re.MULTILINE)]
+    assert uses_positions
+    assert workflow.index('Drop runner-local plaintext restore') < min(uses_positions)
+    assert pinned_upload in workflow
+    assert 'actions/upload-artifact@v4' not in workflow
+    assert re.search(r'actions/upload-artifact@[0-9a-f]{40}\b', workflow)
+
+
+def test_workflow_does_not_claim_unapproved_race_weekend_dates():
+    workflow = _workflow_text()
+
+    assert "cron: '0 * 24-26 4 *'" not in workflow
+    assert '2027 event dates are not configured' in workflow

--- a/tests/test_day_of_operations.py
+++ b/tests/test_day_of_operations.py
@@ -209,11 +209,13 @@ def _confirm_heat_scratch(client, tournament, event, competitor, heat):
 
     preview = client.get(f'{handoff.headers["Location"]}&format=json')
     assert preview.status_code == 200
-    effects = preview.get_json()["effects"]
+    preview_payload = preview.get_json()
+    effects = preview_payload["effects"]
     data = {
         "competitor_type": event.event_type,
         "return_event_id": str(event.id),
         "effect_count": str(len(effects)),
+        "expected_effect_digest": preview_payload["effect_digest"],
     }
     for index, effect in enumerate(effects):
         data.update({
@@ -296,11 +298,13 @@ class TestScratchCompetitor:
             follow_redirects=False,
         )
         preview = auth_client.get(f'{handoff.headers["Location"]}&format=json')
-        effects = preview.get_json()["effects"]
+        preview_payload = preview.get_json()
+        effects = preview_payload["effects"]
         data = {
             "competitor_type": "pro",
             "return_event_id": str(e.id),
             "effect_count": str(len(effects)),
+            "expected_effect_digest": preview_payload["effect_digest"],
         }
         for index, effect in enumerate(effects):
             data.update({

--- a/tests/test_db_constraints.py
+++ b/tests/test_db_constraints.py
@@ -101,6 +101,97 @@ class TestForeignKeyCascades:
         assert db.session.get(Heat, hid) is None
         assert db.session.get(EventResult, rid) is None
 
+    def test_delete_heat_preserves_score_submission_receipt_tombstone(
+        self, db_session,
+    ):
+        from models.score_submission_receipt import ScoreSubmissionReceipt
+        from models.user import User
+
+        tournament = make_tournament(db_session)
+        event = make_event(db_session, tournament, 'Receipt History', event_type='pro')
+        heat = make_heat(db_session, event)
+        user = User(username='receipt_history_operator', role='admin')
+        user.set_password('testpass')
+        db_session.add(user)
+        db_session.flush()
+        heat_id = heat.id
+        request_id = '00000000-0000-0000-0000-000000000001'
+        receipt = ScoreSubmissionReceipt(
+            request_id=request_id,
+            tournament_id=tournament.id,
+            heat_id=heat_id,
+            issuing_user_id=user.id,
+            canonical_payload_sha256='a' * 64,
+            accepted_outcome_json={'ok': True},
+        )
+        db_session.add(receipt)
+        db_session.flush()
+
+        db_session.delete(heat)
+        db_session.flush()
+
+        retained = db.session.get(ScoreSubmissionReceipt, request_id)
+        assert retained is not None
+        assert retained.heat_id == heat_id
+
+    def test_delete_user_nulls_receipt_issuer_without_deleting_receipt(
+        self, db_session,
+    ):
+        from models.score_submission_receipt import ScoreSubmissionReceipt
+        from models.user import User
+
+        tournament = make_tournament(db_session)
+        event = make_event(db_session, tournament, 'Receipt Issuer', event_type='pro')
+        heat = make_heat(db_session, event)
+        user = User(username='deleted_receipt_operator', role='admin')
+        user.set_password('testpass')
+        db_session.add(user)
+        db_session.flush()
+        request_id = '00000000-0000-0000-0000-000000000002'
+        db_session.add(ScoreSubmissionReceipt(
+            request_id=request_id,
+            tournament_id=tournament.id,
+            heat_id=heat.id,
+            issuing_user_id=user.id,
+            canonical_payload_sha256='b' * 64,
+            accepted_outcome_json={'ok': True},
+        ))
+        db_session.flush()
+
+        db_session.delete(user)
+        db_session.flush()
+
+        retained = db.session.get(ScoreSubmissionReceipt, request_id)
+        assert retained is not None
+        assert retained.issuing_user_id is None
+
+    def test_delete_tournament_cascades_receipt_history(self, db_session):
+        from models.score_submission_receipt import ScoreSubmissionReceipt
+        from models.user import User
+
+        tournament = make_tournament(db_session)
+        event = make_event(db_session, tournament, 'Receipt Aggregate', event_type='pro')
+        heat = make_heat(db_session, event)
+        user = User(username='aggregate_receipt_operator', role='admin')
+        user.set_password('testpass')
+        db_session.add(user)
+        db_session.flush()
+        request_id = '00000000-0000-0000-0000-000000000003'
+        db_session.add(ScoreSubmissionReceipt(
+            request_id=request_id,
+            tournament_id=tournament.id,
+            heat_id=heat.id,
+            issuing_user_id=user.id,
+            canonical_payload_sha256='c' * 64,
+            accepted_outcome_json={'ok': True},
+        ))
+        db_session.flush()
+
+        db_session.delete(tournament)
+        db_session.flush()
+
+        assert db.session.get(ScoreSubmissionReceipt, request_id) is None
+
 
 # ===========================================================================
 # UNIQUE CONSTRAINTS

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -367,11 +367,13 @@ def test_unassigned_competitor_and_all_scratched_heat_render_cleanly(qa_env):
 
         preview = client.get(f'{handoff.headers["Location"]}&format=json')
         assert preview.status_code == 200
-        effects = preview.get_json()["effects"]
+        preview_payload = preview.get_json()
+        effects = preview_payload["effects"]
         form = {
             "competitor_type": "pro",
             "return_event_id": str(event_id),
             "effect_count": str(len(effects)),
+            "expected_effect_digest": preview_payload["effect_digest"],
         }
         for index, effect in enumerate(effects):
             form.update({
@@ -695,7 +697,10 @@ def test_pro_scratch_removes_competitor_from_generated_heat(qa_env):
     effects = payload["effects"]
 
     # Step 2: confirm — send every effect back as "checked".
-    form = {"effect_count": str(len(effects))}
+    form = {
+        "effect_count": str(len(effects)),
+        "expected_effect_digest": payload["effect_digest"],
+    }
     for i, e in enumerate(effects):
         form[f"effect_type_{i}"] = e["effect_type"]
         form[f"affected_entity_id_{i}"] = str(e["affected_entity_id"])

--- a/tests/test_flight_order_concurrency.py
+++ b/tests/test_flight_order_concurrency.py
@@ -1,5 +1,6 @@
 """Database and route guards for concurrent flight-order writers."""
 import threading
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -57,6 +58,7 @@ def _event(tournament_id, name, event_type='pro'):
 
 def _seed_schedule(app, label, heat_counts=(2,)):
     from models import Flight, Heat, Tournament
+    from routes.scheduling.flights import flight_order_digest
 
     with app.app_context():
         tournament = Tournament(name=label, year=2029, status='setup')
@@ -101,6 +103,7 @@ def _seed_schedule(app, label, heat_counts=(2,)):
             'tournament_id': tournament.id,
             'flight_ids': [flight.id for flight in flights],
             'heat_ids_by_flight': heat_ids_by_flight,
+            'order_digests': [flight_order_digest(flight.id) for flight in flights],
         }
 
 
@@ -323,10 +326,14 @@ def test_single_reorder_locks_parent_and_swaps_under_unique_constraint(
     tournament_calls = _lock_calls_for_tournaments(monkeypatch)
     expected = list(reversed(seeded['heat_ids_by_flight'][0]))
 
+    from routes.scheduling.flights import flight_order_digest
+
+    with app.app_context():
+        expected_digest = flight_order_digest(seeded['flight_ids'][0])
     response = auth_client.post(
         f"/scheduling/{seeded['tournament_id']}/flights/"
         f"{seeded['flight_ids'][0]}/reorder",
-        json={'heat_ids': expected},
+        json={'heat_ids': expected, 'expected_digest': expected_digest},
     )
 
     assert response.status_code == 200
@@ -339,6 +346,166 @@ def test_single_reorder_locks_parent_and_swaps_under_unique_constraint(
             ).order_by(Heat.flight_position).all()
         ]
     assert actual == expected
+
+
+def test_stale_single_flight_reorder_is_rejected(app, auth_client):
+    from models import Heat
+    from routes.scheduling.flights import flight_order_digest
+
+    seeded = _seed_schedule(app, 'Stale Single Reorder', (3,))
+    original = seeded['heat_ids_by_flight'][0]
+    with app.app_context():
+        expected_digest = flight_order_digest(seeded['flight_ids'][0])
+
+    first_order = [original[1], original[0], original[2]]
+    first = auth_client.post(
+        f"/scheduling/{seeded['tournament_id']}/flights/"
+        f"{seeded['flight_ids'][0]}/reorder",
+        json={'heat_ids': first_order, 'expected_digest': expected_digest},
+    )
+    stale = auth_client.post(
+        f"/scheduling/{seeded['tournament_id']}/flights/"
+        f"{seeded['flight_ids'][0]}/reorder",
+        json={
+            'heat_ids': [original[0], original[2], original[1]],
+            'expected_digest': expected_digest,
+        },
+    )
+
+    assert first.status_code == 200
+    assert stale.status_code == 409
+    assert stale.get_json()['code'] == 'stale_flight_order'
+    with app.app_context():
+        assert [
+            heat.id for heat in Heat.query.filter_by(
+                flight_id=seeded['flight_ids'][0]
+            ).order_by(Heat.flight_position).all()
+        ] == first_order
+
+
+def test_single_reorder_returns_fresh_digest_for_consecutive_reorder(
+    app, auth_client,
+):
+    from models import Heat
+
+    seeded = _seed_schedule(app, 'Consecutive Single Reorders', (3,))
+    flight_id = seeded['flight_ids'][0]
+    original = seeded['heat_ids_by_flight'][0]
+    endpoint = (
+        f"/scheduling/{seeded['tournament_id']}/flights/{flight_id}/reorder"
+    )
+
+    first_order = [original[1], original[0], original[2]]
+    first = auth_client.post(
+        endpoint,
+        json={
+            'heat_ids': first_order,
+            'expected_digest': seeded['order_digests'][0],
+        },
+    )
+
+    assert first.status_code == 200
+    first_payload = first.get_json()
+    first_digest = first_payload['order_digests'][str(flight_id)]
+    assert first_digest != seeded['order_digests'][0]
+
+    second_order = [original[1], original[2], original[0]]
+    second = auth_client.post(
+        endpoint,
+        json={'heat_ids': second_order, 'expected_digest': first_digest},
+    )
+
+    assert second.status_code == 200
+    second_digest = second.get_json()['order_digests'][str(flight_id)]
+    assert second_digest != first_digest
+    with app.app_context():
+        assert [
+            heat.id for heat in Heat.query.filter_by(
+                flight_id=flight_id,
+            ).order_by(Heat.flight_position).all()
+        ] == second_order
+
+
+def test_bulk_reorder_returns_fresh_digests_for_consecutive_page_drags(
+    app, auth_client,
+):
+    seeded = _seed_schedule(app, 'Consecutive Bulk Reorders', (2, 2))
+    flight_ids = seeded['flight_ids']
+    original = seeded['heat_ids_by_flight']
+    endpoint = f"/scheduling/{seeded['tournament_id']}/flights/bulk-reorder"
+
+    first_orders = [list(reversed(ids)) for ids in original]
+    first = auth_client.post(
+        endpoint,
+        json={'flights': [
+            {
+                'flight_id': flight_id,
+                'heat_ids': heat_ids,
+                'expected_digest': seeded['order_digests'][index],
+            }
+            for index, (flight_id, heat_ids) in enumerate(
+                zip(flight_ids, first_orders, strict=True)
+            )
+        ]},
+    )
+
+    assert first.status_code == 200
+    first_digests = first.get_json()['order_digests']
+    assert set(first_digests) == {str(flight_id) for flight_id in flight_ids}
+    assert all(
+        first_digests[str(flight_id)] != seeded['order_digests'][index]
+        for index, flight_id in enumerate(flight_ids)
+    )
+
+    second = auth_client.post(
+        endpoint,
+        json={'flights': [
+            {
+                'flight_id': flight_id,
+                'heat_ids': original[index],
+                'expected_digest': first_digests[str(flight_id)],
+            }
+            for index, flight_id in enumerate(flight_ids)
+        ]},
+    )
+
+    assert second.status_code == 200
+    second_digests = second.get_json()['order_digests']
+    assert set(second_digests) == set(first_digests)
+    assert all(
+        second_digests[flight_id] != first_digests[flight_id]
+        for flight_id in first_digests
+    )
+
+
+def test_flights_page_applies_returned_order_digests_after_success():
+    template = Path('templates/pro/flights.html').read_text(encoding='utf-8')
+
+    assert 'function applyOrderDigests(orderDigests)' in template
+    assert 'grid.dataset.orderDigest = orderDigests[flightId];' in template
+    assert 'applyOrderDigests(data.order_digests);' in template
+
+
+def test_flight_lifecycle_cannot_skip_or_regress(app, auth_client):
+    from models import Flight
+
+    seeded = _seed_schedule(app, 'Monotonic Flight Lifecycle', (1,))
+    base = (
+        f"/scheduling/{seeded['tournament_id']}/flights/"
+        f"{seeded['flight_ids'][0]}"
+    )
+
+    out_of_order = auth_client.post(f'{base}/complete')
+    assert out_of_order.status_code == 302
+    with app.app_context():
+        assert db.session.get(Flight, seeded['flight_ids'][0]).status == 'pending'
+
+    assert auth_client.post(f'{base}/start').status_code == 302
+    assert auth_client.post(f'{base}/complete').status_code == 302
+    stale_start = auth_client.post(f'{base}/start')
+    assert stale_start.status_code == 302
+    with app.app_context():
+        assert db.session.get(Flight, seeded['flight_ids'][0]).status == 'completed'
 
 
 def test_bulk_reorder_locks_parent_rows_before_cross_flight_write(
@@ -355,8 +522,16 @@ def test_bulk_reorder_locks_parent_rows_before_cross_flight_write(
     response = auth_client.post(
         f"/scheduling/{seeded['tournament_id']}/flights/bulk-reorder",
         json={'flights': [
-            {'flight_id': seeded['flight_ids'][0], 'heat_ids': [second_heat]},
-            {'flight_id': seeded['flight_ids'][1], 'heat_ids': [first_heat]},
+            {
+                'flight_id': seeded['flight_ids'][0],
+                'heat_ids': [second_heat],
+                'expected_digest': seeded['order_digests'][0],
+            },
+            {
+                'flight_id': seeded['flight_ids'][1],
+                'heat_ids': [first_heat],
+                'expected_digest': seeded['order_digests'][1],
+            },
         ]},
     )
 
@@ -386,13 +561,17 @@ def test_uniqueness_race_returns_retryable_409(
             json={'flights': [{
                 'flight_id': seeded['flight_ids'][0],
                 'heat_ids': heat_ids,
+                'expected_digest': seeded['order_digests'][0],
             }]},
         )
     else:
         response = auth_client.post(
             f"/scheduling/{seeded['tournament_id']}/flights/"
             f"{seeded['flight_ids'][0]}/reorder",
-            json={'heat_ids': heat_ids},
+            json={
+                'heat_ids': heat_ids,
+                'expected_digest': seeded['order_digests'][0],
+            },
         )
 
     assert response.status_code == 409
@@ -817,7 +996,10 @@ def test_sqlite_reorder_waits_for_shared_schedule_guard(app):
         response_box['response'] = client.post(
             f"/scheduling/{seeded['tournament_id']}/flights/"
             f"{seeded['flight_ids'][0]}/reorder",
-            json={'heat_ids': list(reversed(seeded['heat_ids_by_flight'][0]))},
+            json={
+                'heat_ids': list(reversed(seeded['heat_ids_by_flight'][0])),
+                'expected_digest': seeded['order_digests'][0],
+            },
         )
         reorder_finished.set()
 
@@ -907,6 +1089,7 @@ def test_postgres_integration_and_reorder_serialize_on_flight_parent_rows(
                 f"{seeded['flight_ids'][1]}/reorder",
                 json={
                     'heat_ids': list(reversed(seeded['heat_ids_by_flight'][1])),
+                    'expected_digest': seeded['order_digests'][1],
                 },
             )
         except Exception as exc:  # pragma: no cover - asserted in parent thread
@@ -1028,6 +1211,7 @@ def test_postgres_partnered_axe_writer_holds_tournament_lock_through_commit(app)
 def test_postgres_birling_writer_holds_tournament_lock_through_commit(app):
     import routes.scheduling.birling as birling_routes
     from models import Event, Tournament
+    from services.birling_bracket import BirlingBracket
 
     with app.app_context():
         tournament = Tournament(
@@ -1048,6 +1232,7 @@ def test_postgres_birling_writer_holds_tournament_lock_through_commit(app):
         db.session.commit()
         tournament_id = tournament.id
         event_id = event.id
+        bracket_digest = BirlingBracket(event).bracket_state_digest()
 
     entered = threading.Event()
     release = threading.Event()
@@ -1065,6 +1250,7 @@ def test_postgres_birling_writer_holds_tournament_lock_through_commit(app):
             tournament_id,
             lambda client: client.post(
                 f'/scheduling/{tournament_id}/event/{event_id}/birling/reset',
+                data={'expected_bracket_digest': bracket_digest},
                 follow_redirects=False,
             ),
             entered,

--- a/tests/test_flight_route_atomicity.py
+++ b/tests/test_flight_route_atomicity.py
@@ -403,7 +403,10 @@ def test_single_flight_reorder_cannot_move_chokerman_ahead_of_tail(
     response = auth_client.post(
         f"/scheduling/{schedule['tournament_id']}/flights/"
         f"{schedule['last_flight_id']}/reorder",
-        json={'heat_ids': [schedule['closer_id'], schedule['neutral_id']]},
+        json={
+            'heat_ids': [schedule['closer_id'], schedule['neutral_id']],
+            'expected_heat_ids': [schedule['neutral_id'], schedule['closer_id']],
+        },
     )
 
     assert response.status_code == 409
@@ -427,10 +430,14 @@ def test_bulk_reorder_cannot_move_chokerman_out_of_last_flight(
             {
                 'flight_id': schedule['first_flight_id'],
                 'heat_ids': [schedule['opener_id'], schedule['closer_id']],
+                'expected_heat_ids': [schedule['opener_id']],
             },
             {
                 'flight_id': schedule['last_flight_id'],
                 'heat_ids': [schedule['neutral_id']],
+                'expected_heat_ids': [
+                    schedule['neutral_id'], schedule['closer_id'],
+                ],
             },
         ]},
     )
@@ -457,7 +464,10 @@ def test_manual_reorder_is_blocked_after_any_flight_starts(app, auth_client):
     response = auth_client.post(
         f"/scheduling/{schedule['tournament_id']}/flights/"
         f"{schedule['last_flight_id']}/reorder",
-        json={'heat_ids': [schedule['neutral_id'], schedule['closer_id']]},
+        json={
+            'heat_ids': [schedule['neutral_id'], schedule['closer_id']],
+            'expected_heat_ids': [schedule['neutral_id'], schedule['closer_id']],
+        },
     )
 
     assert response.status_code == 409

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -55,6 +55,17 @@ def db_session(app):
 # ReportCache tests  (services/report_cache.py)
 # ===================================================================
 
+@pytest.fixture
+def l1_cache_enabled(app, monkeypatch):
+    """Exercise cache mechanics independently of the active test database."""
+    monkeypatch.setitem(
+        app.config,
+        'SQLALCHEMY_DATABASE_URI',
+        'sqlite:///:memory:',
+    )
+
+
+@pytest.mark.usefixtures('l1_cache_enabled')
 class TestReportCache:
     """Tests for the in-memory L1 TTL cache (disk layer bypassed)."""
 
@@ -120,6 +131,41 @@ class TestReportCache:
         # Other prefix untouched
         assert get('reports:2:standings') == 'data3'
 
+    def test_stale_reader_cannot_repopulate_after_invalidation(self):
+        from services import report_cache
+
+        cache_key = 'reports:1:standings'
+        reader_missed = threading.Event()
+        invalidation_finished = threading.Event()
+
+        def stale_reader():
+            assert report_cache.get(cache_key) is None
+            reader_missed.set()
+            assert invalidation_finished.wait(timeout=2)
+            report_cache.set(cache_key, 'stale', ttl_seconds=60)
+
+        reader = threading.Thread(target=stale_reader)
+        reader.start()
+        assert reader_missed.wait(timeout=2)
+
+        report_cache.invalidate_prefix('reports:1:')
+        invalidation_finished.set()
+        reader.join(timeout=2)
+
+        assert not reader.is_alive()
+        assert report_cache.get(cache_key) is None
+
+    def test_unrelated_invalidation_does_not_block_cache_fill(self):
+        from services import report_cache
+
+        cache_key = 'reports:1:standings'
+        assert report_cache.get(cache_key) is None
+
+        report_cache.invalidate_prefix('reports:2:')
+        report_cache.set(cache_key, 'fresh', ttl_seconds=60)
+
+        assert report_cache.get(cache_key) == 'fresh'
+
     def test_clear_via_invalidate_prefix_empty_string(self):
         """invalidate_prefix('') should match all keys."""
         from services.report_cache import get, invalidate_prefix, set
@@ -139,6 +185,31 @@ class TestReportCache:
         assert report_cache.get('api:standings-poll:1') is None
         assert report_cache._shelf_resolved is True
         assert report_cache._shelf_path is None
+
+    def test_disk_cache_is_disabled_across_process_boots(self, tmp_path, monkeypatch):
+        from services import report_cache
+
+        monkeypatch.setattr(report_cache, '_shelf_resolved', False)
+        monkeypatch.setattr(
+            report_cache,
+            '_shelf_path',
+            str(tmp_path / 'shared-cache'),
+        )
+
+        assert report_cache._get_shelf_path() is None
+        assert report_cache._shelf_path is None
+
+    def test_postgres_bypasses_process_local_cache(self, app, monkeypatch):
+        from services import report_cache
+
+        monkeypatch.setitem(
+            app.config,
+            'SQLALCHEMY_DATABASE_URI',
+            'postgresql://synthetic/not-connected',
+        )
+        with app.app_context():
+            report_cache.set('reports:9:standings', 'stale', ttl_seconds=60)
+            assert report_cache.get('reports:9:standings') is None
 
     def test_multiple_keys_independent(self):
         from services.report_cache import get, set
@@ -322,6 +393,24 @@ class TestBackgroundJobs:
         assert 'intentional test failure' in info['error']
         assert info['result'] is None
 
+    def test_ok_false_result_is_a_failed_job(self):
+        from services.background_jobs import get, submit
+
+        job_id = submit(
+            'truthful-failure',
+            lambda: {'ok': False, 'error': 'backup validation failed'},
+            metadata={'tournament_id': 1, 'kind': 'backup'},
+        )
+        deadline = time.time() + 2.0
+        info = get(job_id)
+        while info['status'] not in {'completed', 'failed'} and time.time() < deadline:
+            time.sleep(0.02)
+            info = get(job_id)
+
+        assert info['status'] == 'failed'
+        assert info['error'] == 'backup validation failed'
+        assert info['result']['ok'] is False
+
     def test_multiple_jobs_tracked_independently(self):
         from services.background_jobs import get, submit
         barrier = threading.Barrier(2, timeout=2.0)
@@ -345,6 +434,77 @@ class TestBackgroundJobs:
         assert info_a['label'] == 'job-a'
         assert info_b['label'] == 'job-b'
 
+    def test_executor_backlog_remains_queued_until_worker_starts(self, app):
+        from models.background_job import BackgroundJob
+        from services import background_jobs
+
+        release_first = threading.Event()
+        first_started = threading.Event()
+        second_started = threading.Event()
+        background_jobs.configure(1, app)
+
+        def blocking_job():
+            first_started.set()
+            release_first.wait(timeout=2.0)
+            return 'first'
+
+        try:
+            background_jobs.submit('worker-blocker', blocking_job)
+            assert first_started.wait(timeout=2.0)
+            queued_id = background_jobs.submit(
+                'executor-backlog',
+                lambda: (second_started.set(), 'second')[1],
+            )
+
+            with app.app_context():
+                row = _db.session.get(BackgroundJob, queued_id)
+                assert row.status == 'queued'
+                assert row.started_at is None
+
+            release_first.set()
+            assert second_started.wait(timeout=2.0)
+        finally:
+            release_first.set()
+            background_jobs.configure(2, app)
+
+    def test_terminal_persistence_retries_transient_database_failure(
+        self, app, monkeypatch,
+    ):
+        from sqlalchemy.exc import SQLAlchemyError
+
+        from models.background_job import BackgroundJob
+        from services import background_jobs
+
+        actual_persist = background_jobs._persist_job
+        terminal_attempts = []
+
+        def transient_terminal_failure(job_id, **updates):
+            if updates.get('status') in {'completed', 'failed'}:
+                terminal_attempts.append(updates['status'])
+                if len(terminal_attempts) == 1:
+                    raise SQLAlchemyError('transient terminal write failure')
+            return actual_persist(job_id, **updates)
+
+        monkeypatch.setattr(
+            background_jobs,
+            '_persist_job',
+            transient_terminal_failure,
+        )
+        job_id = background_jobs.submit('retry-terminal-write', lambda: 'done')
+
+        deadline = time.time() + 2.0
+        persisted_status = None
+        while time.time() < deadline:
+            with app.app_context():
+                _db.session.expire_all()
+                persisted_status = _db.session.get(BackgroundJob, job_id).status
+            if persisted_status == 'completed':
+                break
+            time.sleep(0.02)
+
+        assert terminal_attempts == ['completed', 'completed']
+        assert persisted_status == 'completed'
+
     def test_configure_changes_max_workers(self):
         from services import background_jobs
         old_executor = background_jobs._executor
@@ -367,6 +527,165 @@ class TestBackgroundJobs:
         assert rows[1]['id'] == first_id
         assert rows[0]['metadata']['tournament_id'] == 1
 
+    def test_list_recent_scopes_tournament_before_limit(self):
+        from services.background_jobs import list_recent, submit
+
+        wanted_id = submit(
+            'wanted-job', lambda: 'wanted', metadata={'tournament_id': 101},
+        )
+        for index in range(4):
+            submit(
+                f'other-job-{index}',
+                lambda value=index: value,
+                metadata={'tournament_id': 202},
+            )
+        time.sleep(0.1)
+
+        rows = list_recent(limit=1, tournament_id=101)
+
+        assert [row['id'] for row in rows] == [wanted_id]
+
+    def test_reconcile_marks_only_prior_boot_jobs_interrupted(self, app):
+        from datetime import timedelta
+
+        from models.background_job import BackgroundJob
+        from services import background_jobs
+        from services.time_utils import utc_now_naive
+
+        now = utc_now_naive()
+        with app.app_context():
+            prior = BackgroundJob(
+                id='prior-boot-job',
+                label='prior',
+                status='running',
+                owner_boot_id='old-boot',
+                owner_heartbeat_at=now - timedelta(seconds=31),
+            )
+            overlapping = BackgroundJob(
+                id='overlapping-boot-job',
+                label='overlapping',
+                status='running',
+                owner_boot_id='still-alive-boot',
+                owner_heartbeat_at=now - timedelta(seconds=2),
+            )
+            current = BackgroundJob(
+                id='current-boot-job',
+                label='current',
+                status='running',
+                owner_boot_id=background_jobs.boot_id(),
+                owner_heartbeat_at=now - timedelta(seconds=31),
+            )
+            _db.session.add_all([prior, overlapping, current])
+            _db.session.commit()
+            prior_id = prior.id
+            overlapping_id = overlapping.id
+            current_id = current.id
+
+        changed = background_jobs.reconcile_interrupted_jobs(
+            app,
+            now=now,
+            lease_timeout_seconds=30,
+        )
+
+        with app.app_context():
+            assert changed == 1
+            assert _db.session.get(BackgroundJob, prior_id).status == 'interrupted'
+            assert _db.session.get(BackgroundJob, prior_id).finished_at is not None
+            assert _db.session.get(BackgroundJob, overlapping_id).status == 'running'
+            assert _db.session.get(BackgroundJob, current_id).status == 'running'
+
+    def test_interrupted_job_rejects_late_owner_callback(self, app):
+        from models.background_job import BackgroundJob
+        from services import background_jobs
+
+        with app.app_context():
+            row = BackgroundJob(
+                id='late-callback-job',
+                label='late callback',
+                status='interrupted',
+                owner_boot_id=background_jobs.boot_id(),
+            )
+            _db.session.add(row)
+            _db.session.commit()
+            row_id = row.id
+
+        persisted = background_jobs._persist_job(
+            row_id,
+            status='completed',
+            result={'ok': True},
+            require_active_owner=True,
+        )
+
+        with app.app_context():
+            assert persisted is False
+            assert _db.session.get(BackgroundJob, row_id).status == 'interrupted'
+
+    @pytest.mark.parametrize(
+        'table_exists, columns',
+        [
+            (False, set()),
+            (True, {'id', 'status'}),
+        ],
+    )
+    def test_reconcile_defers_cleanly_before_boot_owner_migration(
+        self, app, monkeypatch, table_exists, columns,
+    ):
+        from services import background_jobs
+
+        class PreMigrationInspector:
+            def has_table(self, _table_name):
+                return table_exists
+
+            def get_columns(self, _table_name):
+                return [{'name': name} for name in columns]
+
+        monkeypatch.setattr(
+            background_jobs,
+            'inspect',
+            lambda _engine: PreMigrationInspector(),
+        )
+
+        assert background_jobs.reconcile_interrupted_jobs(app) == 0
+
+    def test_testing_app_never_starts_production_heartbeat(self, app, monkeypatch):
+        from services import background_jobs
+
+        monkeypatch.setitem(app.config, 'TESTING', True)
+        monkeypatch.setitem(
+            app.config,
+            'SQLALCHEMY_DATABASE_URI',
+            'postgresql://test-only/example',
+        )
+        monkeypatch.setattr(
+            background_jobs,
+            '_heartbeat_once',
+            lambda _app: pytest.fail('testing app started the production heartbeat'),
+        )
+
+        background_jobs.start_heartbeat(app)
+
+    def test_postgres_unit_mode_never_starts_production_heartbeat(
+        self, app, monkeypatch,
+    ):
+        from services import background_jobs
+
+        monkeypatch.setitem(app.config, 'TESTING', False)
+        monkeypatch.setitem(
+            app.config,
+            'SQLALCHEMY_DATABASE_URI',
+            'postgresql://test-only/example',
+        )
+        monkeypatch.delenv('FLASK_ENV', raising=False)
+        monkeypatch.delenv('TESTING', raising=False)
+        monkeypatch.setenv('PROAM_UNIT_PG', '1')
+        monkeypatch.setattr(
+            background_jobs,
+            '_heartbeat_once',
+            lambda _app: pytest.fail('PostgreSQL unit mode started a heartbeat'),
+        )
+
+        background_jobs.start_heartbeat(app)
+
     def test_jobs_are_persisted_to_database(self, app):
         from models.background_job import BackgroundJob
         from services.background_jobs import submit
@@ -385,6 +704,7 @@ class TestBackgroundJobs:
 # CacheInvalidation tests  (services/cache_invalidation.py)
 # ===================================================================
 
+@pytest.mark.usefixtures('l1_cache_enabled')
 class TestCacheInvalidation:
     """Tests for invalidate_tournament_caches()."""
 
@@ -423,6 +743,34 @@ class TestCacheInvalidation:
             # Other tournament untouched
             assert report_cache.get('reports:6:standings') == 'other'
 
+    def test_tournament_prefixes_do_not_match_larger_ids(self):
+        from services import report_cache
+        from services.cache_invalidation import invalidate_tournament_caches
+
+        keys = (
+            'reports:{tid}:standings',
+            'portal:college:{tid}',
+            'portal:pro:{tid}',
+            'api:standings-poll:{tid}',
+        )
+        with patch('services.report_cache._shelf_get', return_value=None), \
+             patch('services.report_cache._shelf_set'), \
+             patch('services.report_cache._shelf_delete_prefix'):
+            for tournament_id in (1, 10, 11):
+                for key in keys:
+                    report_cache.set(
+                        key.format(tid=tournament_id),
+                        f'tournament-{tournament_id}',
+                        ttl_seconds=60,
+                    )
+
+            invalidate_tournament_caches(1)
+
+            for key in keys:
+                assert report_cache.get(key.format(tid=1)) is None
+                assert report_cache.get(key.format(tid=10)) == 'tournament-10'
+                assert report_cache.get(key.format(tid=11)) == 'tournament-11'
+
     def test_invalidation_with_string_tournament_id(self):
         """Tournament ID is cast to int internally -- string input should work."""
         from services.cache_invalidation import invalidate_tournament_caches
@@ -437,9 +785,9 @@ class TestCacheInvalidation:
 
             expected_prefixes = [
                 'reports:7:',
-                'portal:college:7',
-                'portal:pro:7',
-                'api:standings-poll:7',
+                'portal:college:7:',
+                'portal:pro:7:',
+                'api:standings-poll:7:',
             ]
             actual_prefixes = [call.args[0] for call in mock_inv.call_args_list]
             assert actual_prefixes == expected_prefixes

--- a/tests/test_integration_qa.py
+++ b/tests/test_integration_qa.py
@@ -671,11 +671,13 @@ def test_day_of_operations_workflow(qa_env):
     assert scratch_response.status_code == 302
     preview_response = client.get(f'{scratch_response.location}&format=json')
     assert preview_response.status_code == 200
-    effects = preview_response.get_json()["effects"]
+    preview_payload = preview_response.get_json()
+    effects = preview_payload["effects"]
     scratch_form = {
         "competitor_type": "pro",
         "return_event_id": str(seeded["event_id"]),
         "effect_count": str(len(effects)),
+        "expected_effect_digest": preview_payload["effect_digest"],
     }
     for index, effect in enumerate(effects):
         scratch_form.update({

--- a/tests/test_migration_integrity.py
+++ b/tests/test_migration_integrity.py
@@ -800,8 +800,13 @@ def test_shadow_schema_repair_is_a_forward_revision_after_b7():
     migrations_dir = Path(__file__).resolve().parents[1] / "migrations"
     scripts = ScriptDirectory(str(migrations_dir))
     repair = scripts.get_revision(SHADOW_REPAIR_REVISION)
+    head = scripts.get_current_head()
+    lineage = {
+        revision.revision
+        for revision in scripts.iterate_revisions(head, "base")
+    }
 
-    assert scripts.get_current_head() == SHADOW_REPAIR_REVISION
+    assert SHADOW_REPAIR_REVISION in lineage
     assert repair.down_revision == "b7f8a9b0c1d2"
 
 

--- a/tests/test_offline_scoring_u2.py
+++ b/tests/test_offline_scoring_u2.py
@@ -1,0 +1,744 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from database import db
+from models import AuditLog, EventResult, ScoreSubmissionReceipt, User
+from services import scoring_workflow
+from services.scoring_workflow import (
+    canonical_score_payload_sha256,
+    heat_scoring_state_digest,
+    heat_submission_identity,
+    save_heat_results_submission,
+)
+from tests.conftest import (
+    make_college_competitor,
+    make_event,
+    make_heat,
+    make_team,
+    make_tournament,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope='module', autouse=True)
+def _temporary_receipt_table(app):
+    """The lead owns the combined migration; focused tests still need its table."""
+    with app.app_context():
+        ScoreSubmissionReceipt.__table__.create(bind=db.engine, checkfirst=True)
+    yield
+    with app.app_context():
+        db.session.remove()
+        ScoreSubmissionReceipt.__table__.drop(bind=db.engine, checkfirst=True)
+
+
+def _seed_score(db_session, *, user_id: int):
+    tournament = make_tournament(db_session, name=f'Offline Receipt {uuid4()}')
+    team = make_team(db_session, tournament, code=f'T-{tournament.id}')
+    competitor = make_college_competitor(
+        db_session, tournament, team, f'Scorer {tournament.id}'
+    )
+    event = make_event(
+        db_session,
+        tournament,
+        'Standing Block Hard Hit',
+        event_type='college',
+        scoring_type='hits',
+        scoring_order='highest_wins',
+    )
+    heat = make_heat(
+        db_session,
+        event,
+        competitors=[competitor.id],
+        stand_assignments={str(competitor.id): 1},
+    )
+    request_id = str(uuid4())
+    form_data = {
+        'request_id': request_id,
+        'tournament_id': str(tournament.id),
+        'heat_id': str(heat.id),
+        'issuer_user_id': str(user_id),
+        'issuer_role': 'admin',
+        'schedule_fingerprint': 'schedule-a',
+        'queued_at': datetime.now(timezone.utc).isoformat(),
+        'csrf_token': 'transport-only',
+        'replay_token': 'transport-only',
+        'heat_version': str(heat.version_id),
+        'heat_identity': heat_submission_identity(heat),
+        'scoring_state_digest': heat_scoring_state_digest(heat, event),
+        f'result_{competitor.id}': '9',
+        f'status_{competitor.id}': 'completed',
+        f'reason_{competitor.id}': '',
+    }
+    return tournament, event, heat, competitor, request_id, form_data
+
+
+def _make_user(db_session, *, role=User.ROLE_ADMIN):
+    user = User(username=f'u2-{uuid4()}', role=role)
+    user.set_password('test-password')
+    db_session.add(user)
+    db_session.flush()
+    return user
+
+
+def test_canonical_payload_ignores_transport_credentials_and_binds_route_ids():
+    first = {
+        'request_id': 'afca031f-194d-4e09-830c-fdbe25f483c0',
+        'csrf_token': 'old',
+        'replay_token': 'old-replay',
+        'heat_version': '3',
+        'heat_identity': 'heat-instance',
+        'result_9': '12.40',
+        'status_9': 'completed',
+        'reason_9': '',
+    }
+    second = dict(reversed(list(first.items())))
+    second['csrf_token'] = 'renewed'
+    second['replay_token'] = 'renewed-replay'
+    second['tournament_id'] = '999'
+    second['heat_id'] = '999'
+
+    assert canonical_score_payload_sha256(first, tournament_id=7, heat_id=11) == (
+        canonical_score_payload_sha256(second, tournament_id=7, heat_id=11)
+    )
+
+
+def test_exact_duplicate_returns_receipt_without_second_mutation_or_audit(
+    db_session, monkeypatch,
+):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+
+    first = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+    monkeypatch.setattr(
+        scoring_workflow,
+        'lock_tournament_schedule',
+        lambda _tournament_id: pytest.fail(
+            'committed receipt retry reached the mutable schedule gate'
+        ),
+    )
+    duplicate = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+
+    assert first['ok'] is True
+    assert first['receipt']['request_id'] == request_id
+    assert duplicate['ok'] is True
+    assert duplicate['receipt_replayed'] is True
+    assert duplicate['receipt'] == first['receipt']
+    assert EventResult.query.filter_by(event_id=event.id).count() == 1
+    assert ScoreSubmissionReceipt.query.filter_by(request_id=request_id).count() == 1
+    assert AuditLog.query.filter_by(
+        action='heat_results_saved', entity_type='heat', entity_id=heat.id
+    ).count() == 1
+    assert EventResult.query.filter_by(event_id=event.id).one().result_value == 9
+
+
+def test_new_submission_still_refuses_foreign_heat_lock(db_session):
+    admin_user = _make_user(db_session)
+    other_user = _make_user(db_session, role=User.ROLE_JUDGE)
+    tournament, event, heat, competitor, _request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    heat.locked_by_user_id = other_user.id
+    heat.locked_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_session.commit()
+
+    outcome = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+
+    assert outcome['ok'] is False
+    assert outcome['status_code'] == 423
+    assert outcome['error_code'] == 'heat_locked'
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).count() == 0
+
+
+def test_same_judge_lock_refresh_does_not_stale_offline_score(db_session):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, _request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    prepared_version = heat.version_id
+
+    assert heat.acquire_lock(admin_user.id) is True
+    db_session.commit()
+    assert heat.version_id > prepared_version
+
+    outcome = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+
+    assert outcome['ok'] is True
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).one().result_value == 9
+
+
+def test_scoring_state_digest_rejects_score_changed_after_offline_prepare(db_session):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, _request_id, stale_form = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    first_form = dict(stale_form)
+    first_form['request_id'] = str(uuid4())
+
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=first_form,
+        judge_user_id=admin_user.id,
+    )
+    assert accepted['ok'] is True
+
+    stale_form['request_id'] = str(uuid4())
+    stale_form['heat_version'] = str(heat.version_id)
+    rejected = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=stale_form,
+        judge_user_id=admin_user.id,
+    )
+
+    assert rejected['ok'] is False
+    assert rejected['status_code'] == 409
+    assert rejected['error_code'] == 'scoring_state_changed'
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).one().result_value == 9
+
+
+def test_request_id_payload_drift_is_rejected(db_session):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+    changed = dict(form_data)
+    changed[f'result_{competitor.id}'] = '12'
+
+    rejected = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=changed,
+        judge_user_id=admin_user.id,
+    )
+
+    assert accepted['ok'] is True
+    assert rejected['ok'] is False
+    assert rejected['status_code'] == 409
+    assert rejected['error_code'] == 'request_id_payload_mismatch'
+    assert EventResult.query.filter_by(event_id=event.id).one().result_value == 9
+
+
+def test_request_id_user_rebinding_is_rejected(db_session):
+    admin_user = _make_user(db_session)
+    other = _make_user(db_session, role=User.ROLE_JUDGE)
+    tournament, event, heat, _competitor, _request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+
+    rejected = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=other.id,
+    )
+
+    assert accepted['ok'] is True
+    assert rejected['ok'] is False
+    assert rejected['status_code'] == 409
+    assert rejected['error_code'] == 'request_id_binding_mismatch'
+
+
+def test_removed_receipt_issuer_retains_tombstone_and_disables_replay(db_session):
+    original_user = _make_user(db_session)
+    replacement_user = _make_user(db_session)
+    tournament, event, heat, _competitor, request_id, form_data = _seed_score(
+        db_session, user_id=original_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=original_user.id,
+    )
+    assert accepted['ok'] is True
+    db_session.commit()
+
+    receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+    receipt.issuing_user_id = None
+    db_session.commit()
+    db_session.expire_all()
+    receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+    assert receipt is not None
+    assert receipt.issuing_user_id is None
+
+    replay = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=replacement_user.id,
+    )
+
+    assert replay['ok'] is False
+    assert replay['status_code'] == 409
+    assert replay['error_code'] == 'request_id_issuer_deleted'
+
+
+def test_receipt_failure_rolls_back_score_heat_and_saved_audit(
+    db_session, monkeypatch
+):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, _competitor, request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    db_session.commit()
+
+    def _fail_receipt(*_args, **_kwargs):
+        raise IntegrityError('forced receipt failure', {}, RuntimeError('forced'))
+
+    monkeypatch.setattr(
+        scoring_workflow, '_create_submission_receipt', _fail_receipt, raising=False
+    )
+    outcome = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+
+    assert outcome['ok'] is False
+    assert ScoreSubmissionReceipt.query.filter_by(request_id=request_id).count() == 0
+    assert EventResult.query.filter_by(event_id=event.id).count() == 0
+    assert db.session.get(type(heat), heat.id).status == 'pending'
+    assert AuditLog.query.filter_by(
+        action='heat_results_saved', entity_type='heat', entity_id=heat.id
+    ).count() == 0
+
+
+def test_replay_rejects_entries_older_than_thirty_days_without_mutation(
+    client, db_session,
+):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, _request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    form_data['queued_at'] = (
+        datetime.now(timezone.utc) - timedelta(days=31)
+    ).isoformat()
+    db_session.commit()
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(admin_user.id)
+    token_response = client.get('/scoring/api/replay-token')
+    form_data['replay_token'] = token_response.get_json()['replay_token']
+
+    response = client.post('/scoring/api/replay', data=form_data)
+
+    assert response.status_code == 409
+    assert response.is_json
+    assert response.get_json()['error']['code'] == 'manual_reconciliation_required'
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).count() == 0
+
+
+def test_committed_retry_returns_receipt_before_foreign_heat_lock(
+    client, db_session,
+):
+    admin_user = _make_user(db_session)
+    other_user = _make_user(db_session, role=User.ROLE_JUDGE)
+    tournament, event, heat, competitor, request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+    assert accepted['ok'] is True
+
+    persisted_heat = db.session.get(type(heat), heat.id)
+    persisted_heat.locked_by_user_id = other_user.id
+    persisted_heat.locked_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_session.commit()
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(admin_user.id)
+
+    response = client.post(
+        f'/scoring/{tournament.id}/heat/{heat.id}/enter',
+        data=form_data,
+        headers={
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['ok'] is True
+    assert payload['receipt_replayed'] is True
+    assert payload['receipt']['request_id'] == request_id
+    assert EventResult.query.filter_by(event_id=event.id).one().result_value == 9
+
+
+def test_committed_retry_payload_drift_is_rejected_before_foreign_heat_lock(
+    client, db_session,
+):
+    admin_user = _make_user(db_session)
+    other_user = _make_user(db_session, role=User.ROLE_JUDGE)
+    tournament, event, heat, competitor, _request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+    assert accepted['ok'] is True
+
+    persisted_heat = db.session.get(type(heat), heat.id)
+    persisted_heat.locked_by_user_id = other_user.id
+    persisted_heat.locked_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    db_session.commit()
+    changed = dict(form_data)
+    changed[f'result_{competitor.id}'] = '17'
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(admin_user.id)
+
+    response = client.post(
+        f'/scoring/{tournament.id}/heat/{heat.id}/enter',
+        data=changed,
+        headers={
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()['error']['code'] == 'request_id_payload_mismatch'
+    assert EventResult.query.filter_by(event_id=event.id).one().result_value == 9
+
+
+def test_heat_undo_revokes_accepted_receipt_before_delayed_retry(
+    client, db_session,
+):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+    assert accepted['ok'] is True
+    db_session.commit()
+
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(admin_user.id)
+        session_data[f'undo_heat_{heat.id}'] = accepted['undo_token']
+
+    undo_response = client.post(
+        f'/scoring/{tournament.id}/heat/{heat.id}/undo',
+        headers={
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+    )
+    assert undo_response.status_code == 200
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).count() == 0
+
+    delayed_retry = client.post(
+        f'/scoring/{tournament.id}/heat/{heat.id}/enter',
+        data=form_data,
+        headers={
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+    )
+
+    assert delayed_retry.status_code == 409
+    assert delayed_retry.get_json()['error']['code'] == 'request_id_revoked'
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).count() == 0
+    receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+    assert receipt.accepted_outcome_json['receipt_revoked'] is True
+    assert receipt.accepted_outcome_json['reason'] == 'heat_undo'
+    revocation = AuditLog.query.filter_by(
+        action='score_submission_receipts_revoked',
+        entity_type='heat',
+        entity_id=heat.id,
+    ).one()
+    assert request_id in revocation.details_json
+
+
+def test_heat_undo_receipt_revocation_rolls_back_with_failed_undo(
+    client, db_session, monkeypatch,
+):
+    from routes import scoring as scoring_routes
+
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    accepted = save_heat_results_submission(
+        tournament_id=tournament.id,
+        heat=heat,
+        event=event,
+        form_data=form_data,
+        judge_user_id=admin_user.id,
+    )
+    db_session.commit()
+    real_revoke = scoring_routes.revoke_heat_submission_receipts_for_undo
+
+    def revoke_then_fail(**kwargs):
+        real_revoke(**kwargs)
+        raise RuntimeError('forced failure after receipt revocation')
+
+    monkeypatch.setattr(
+        scoring_routes,
+        'revoke_heat_submission_receipts_for_undo',
+        revoke_then_fail,
+    )
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(admin_user.id)
+        session_data[f'undo_heat_{heat.id}'] = accepted['undo_token']
+
+    response = client.post(
+        f'/scoring/{tournament.id}/heat/{heat.id}/undo',
+        headers={
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+    )
+
+    assert response.status_code == 500
+    db.session.expire_all()
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).count() == 1
+    assert db.session.get(type(heat), heat.id).status == 'completed'
+    receipt = db.session.get(ScoreSubmissionReceipt, request_id)
+    assert receipt.accepted_outcome_json.get('receipt_revoked') is not True
+    assert AuditLog.query.filter_by(
+        action='score_submission_receipts_revoked',
+        entity_type='heat',
+        entity_id=heat.id,
+    ).count() == 0
+
+
+def test_replay_requires_bound_issuer_identity(client, db_session):
+    admin_user = _make_user(db_session)
+    tournament, event, heat, competitor, _request_id, form_data = _seed_score(
+        db_session, user_id=admin_user.id
+    )
+    form_data.pop('issuer_user_id')
+    form_data.pop('issuer_role')
+    db_session.commit()
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(admin_user.id)
+    token_response = client.get('/scoring/api/replay-token')
+    form_data['replay_token'] = token_response.get_json()['replay_token']
+
+    response = client.post('/scoring/api/replay', data=form_data)
+
+    assert response.status_code == 409
+    assert response.get_json()['error']['code'] == 'issuer_identity_required'
+    assert EventResult.query.filter_by(
+        event_id=event.id, competitor_id=competitor.id
+    ).count() == 0
+
+
+def test_offline_queue_javascript_race_suite():
+    node = shutil.which('node')
+    if node is None:
+        pytest.skip('Node.js is required for executable offline queue tests')
+
+    result = subprocess.run(
+        [node, str(ROOT / 'tests' / 'js' / 'offline_queue_shared.test.js')],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_service_worker_content_and_legacy_renewal_suite():
+    node = shutil.which('node')
+    if node is None:
+        pytest.skip('Node.js is required for executable service worker tests')
+
+    result = subprocess.run(
+        [node, str(ROOT / 'tests' / 'js' / 'service_worker_offline.test.js')],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_prepared_package_manifest_and_page_bind_cached_content(
+    client,
+    db_session,
+):
+    user = _make_user(db_session)
+    tournament, _event, heat, _competitor, _request_id, _form_data = _seed_score(
+        db_session, user_id=user.id
+    )
+    db_session.commit()
+    with client.session_transaction() as session_data:
+        session_data['_user_id'] = str(user.id)
+
+    ops_response = client.get(f'/scoring/{tournament.id}/offline-ops')
+
+    assert ops_response.status_code == 200
+    html = ops_response.get_data(as_text=True)
+    context_match = re.search(
+        r'window\.ProAmOfflineContext\s*=\s*(\{.*?\});', html
+    )
+    manifest_match = re.search(
+        r'const OFFLINE_MANIFEST\s*=\s*(\{.*?\});', html
+    )
+    assert context_match is not None
+    assert manifest_match is not None
+    context = json.loads(context_match.group(1))
+    manifest = json.loads(manifest_match.group(1))
+    assert manifest['schema_version'] == 2
+    assert manifest['assets']
+    assert all(row['kind'] == 'asset' for row in manifest['assets'])
+    assert all(len(row['content_sha256']) == 64 for row in manifest['assets'])
+    assert all(row['kind'] == 'page' for row in manifest['pages'])
+    assert 'url_digests' not in manifest
+
+    page_response = client.get(
+        f'/scoring/{tournament.id}/heat/{heat.id}/enter',
+        query_string={
+            'offline_prepare': '1',
+            'prepared_schedule': context['schedule_fingerprint'],
+        },
+        headers={'X-Offline-Prepare': '1'},
+    )
+
+    assert page_response.status_code == 200
+    assert page_response.headers['X-ProAm-Offline-Build'] == context[
+        'application_build'
+    ]
+    assert page_response.headers['X-ProAm-Offline-Schedule'] == context[
+        'schedule_fingerprint'
+    ]
+    assert page_response.headers['X-ProAm-Offline-Tournament'] == str(tournament.id)
+    assert page_response.headers['X-ProAm-Offline-Issuer'] == str(user.id)
+    assert page_response.headers['X-ProAm-Offline-Role'] == user.role
+    assert page_response.headers['X-ProAm-Offline-Content-SHA256'] == hashlib.sha256(
+        page_response.data
+    ).hexdigest()
+
+
+def test_offline_client_contract_is_single_queue_receipt_verified_and_prepared():
+    sw = (ROOT / 'static' / 'sw.js').read_text(encoding='utf-8')
+    shared = (ROOT / 'static' / 'js' / 'offline_queue_shared.js').read_text(
+        encoding='utf-8'
+    )
+    entry = (ROOT / 'templates' / 'scoring' / 'enter_heat.html').read_text(
+        encoding='utf-8'
+    )
+    ops = (ROOT / 'templates' / 'scoring' / 'offline_ops.html').read_text(
+        encoding='utf-8'
+    )
+
+    assert 'handleScorePost' not in sw
+    assert "objectStore('queue').add" not in sw
+    assert 'prepare-offline-package' in sw
+    assert 'clear-prepared-package' in sw
+    assert 'legacy-queue-status' in sw
+    assert "event.tag === 'score-sync'" not in sw
+    assert 'legacy_unbound_issuer' in sw
+    assert 'receipt.issuing_user_id' in sw
+    assert 'renewLegacyReplayToken' in sw
+    assert 'verifyFetchedRow' in sw
+    assert 'cached_content_digests' in sw
+    assert 'sha256(row.url)' not in sw
+    assert sw.index('if (!prepared.replayable)') < sw.index('postLegacy(entry.url')
+    assert "controllerMessage({type: 'manual-sync'})" not in (
+        ROOT / 'static' / 'offline_queue.js'
+    ).read_text(encoding='utf-8')
+    assert 'verifyReceipt' in shared
+    assert 'navigator.locks.request' in shared
+    assert 'mutateQueue' in shared
+    assert 'manual_reconciliation_required' in shared
+    assert '30 * 24 * 60 * 60 * 1000' in shared
+    assert 'request_id' in entry
+    assert 'value="{{ score_request_id }}"' in entry
+    assert 'issuer_user_id' in entry
+    assert 'schedule_fingerprint' in entry
+    assert 'prepareOfflineBtn' in ops
+    assert 'legacyQueueCount' in ops

--- a/tests/test_owner_requirements_config.py
+++ b/tests/test_owner_requirements_config.py
@@ -1,0 +1,16 @@
+"""Executable checks for unambiguous owner-authored event rules."""
+
+from config import COLLEGE_CLOSED_EVENTS, PRO_EVENTS
+
+
+def _event(events, name):
+    return next(event for event in events if event['name'] == name)
+
+
+def test_obstacle_pole_run_counts_match_owner_requirements():
+    """College runs both courses; Pro is explicitly allotted one run."""
+    college = _event(COLLEGE_CLOSED_EVENTS, 'Obstacle Pole')
+    pro = _event(PRO_EVENTS, 'Obstacle Pole')
+
+    assert college['requires_dual_runs'] is True
+    assert pro.get('requires_dual_runs', False) is False

--- a/tests/test_partner_reassignment.py
+++ b/tests/test_partner_reassignment.py
@@ -135,6 +135,12 @@ def _make_result(session, event, competitor, partner_name=None):
     return r
 
 
+def _claim_token(event, orphan, candidate):
+    from services.partner_matching import partner_claim_digest
+
+    return partner_claim_digest(event, orphan, candidate)
+
+
 # ---------------------------------------------------------------------------
 # Helper: build orphan detection dataset
 # ---------------------------------------------------------------------------
@@ -416,6 +422,7 @@ class TestPartnerQueueRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(frank.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(event, alice, frank),
             },
             follow_redirects=False,
         )
@@ -459,6 +466,23 @@ class TestPartnerQueueRoute:
         assert b"Alice" in response.data
         assert f"/scheduling/{t.id}/events/{ev.id}/partner-queue".encode() in response.data
 
+    def test_queue_embeds_candidate_specific_claim_tokens(
+        self, app, db_session, auth_client,
+    ):
+        tournament, event, _alice, _bob, carol = _setup_orphan_scenario(db_session)
+        db_session.commit()
+
+        response = auth_client.get(
+            f'/scheduling/{tournament.id}/events/{event.id}/partner-queue'
+        )
+
+        assert response.status_code == 200
+        assert b'name="expected_claim_digest"' in response.data
+        assert f'value="{carol.id}"'.encode() in response.data
+        assert b'name="expected_claim_digest" value=""' not in response.data
+        assert b'name="partner_claim"' in response.data
+        assert f'value="{carol.id}:'.encode() in response.data
+
     def test_queue_404_for_non_partnered_event(self, app, db_session, auth_client):
         """GET partner_queue on a non-partnered event returns 404."""
         from models.event import Event
@@ -480,6 +504,35 @@ class TestPartnerQueueRoute:
         assert resp.status_code == 404
 
 
+def test_partner_reassignment_acquires_tournament_writer_lock(
+    app, db_session, auth_client, monkeypatch,
+):
+    import routes.scheduling.partners as partner_routes
+
+    tournament, event, alice, _bob, carol = _setup_orphan_scenario(db_session)
+    db_session.commit()
+    calls = []
+
+    def recording_lock(tournament_or_id):
+        calls.append(int(getattr(tournament_or_id, 'id', tournament_or_id)))
+        return db_session.get(type(tournament), tournament.id)
+
+    monkeypatch.setattr(partner_routes, 'lock_tournament_schedule', recording_lock)
+    response = auth_client.post(
+        f'/scheduling/{tournament.id}/events/{event.id}/reassign-partner',
+        data={
+            'orphan_id': alice.id,
+            'orphan_type': 'pro',
+            'new_partner_id': carol.id,
+            'new_partner_type': 'pro',
+            'expected_claim_digest': 'stale-on-purpose',
+        },
+    )
+
+    assert response.status_code == 409
+    assert calls == [tournament.id]
+
+
 # ---------------------------------------------------------------------------
 # Route tests: POST reassign_partner
 # ---------------------------------------------------------------------------
@@ -487,14 +540,9 @@ class TestPartnerQueueRoute:
 
 class TestReassignPartnerRoute:
     def test_happy_path_reassigns_bidirectionally(
-        self, app, db_session, auth_client, monkeypatch
+        self, app, db_session, auth_client
     ):
         """POST reassign_partner updates both partners' JSON and redirects."""
-        audit_calls = []
-        monkeypatch.setattr(
-            "routes.scheduling.partners.log_action",
-            lambda *args, **kwargs: audit_calls.append((args, kwargs)),
-        )
         t, ev, alice, bob, carol = _setup_orphan_scenario(db_session)
         db_session.commit()
 
@@ -505,6 +553,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(carol.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, carol),
             },
             follow_redirects=False,
         )
@@ -518,26 +567,101 @@ class TestReassignPartnerRoute:
         carol_fresh = db.session.get(ProCompetitor, carol.id)
         assert alice_fresh.get_partners().get(str(ev.id)) == "Carol"
         assert carol_fresh.get_partners().get(str(ev.id)) == "Alice"
-        assert audit_calls == [
-            (
-                (
-                    "partner_reassigned",
-                    "event",
-                    ev.id,
-                    {
-                        "tournament_id": t.id,
-                        "event_id": ev.id,
-                        "event_name": ev.display_name,
-                        "orphan_id": alice.id,
-                        "orphan_type": "pro",
-                        "previous_partner_name": "Bob",
-                        "new_partner_id": carol.id,
-                        "new_partner_type": "pro",
-                    },
-                ),
-                {},
-            )
-        ]
+
+        # Discard anything merely pending in the request session, then prove
+        # the audit evidence was committed with the reassignment.
+        event_id = ev.id
+        event_name = ev.display_name
+        tournament_id = t.id
+        db.session.rollback()
+        from models.audit_log import AuditLog
+
+        audit = AuditLog.query.filter_by(
+            action="partner_reassigned",
+            entity_type="event",
+            entity_id=event_id,
+        ).one()
+        details = json.loads(audit.details_json)
+        assert details == {
+            "tournament_id": tournament_id,
+            "event_id": event_id,
+            "event_name": event_name,
+            "orphan_id": alice.id,
+            "orphan_type": "pro",
+            "previous_partner_name": "Bob",
+            "new_partner_id": carol.id,
+            "new_partner_type": "pro",
+        }
+
+    def test_omitted_claim_token_returns_409_without_mutation(
+        self, app, db_session, auth_client,
+    ):
+        t, ev, alice, _bob, carol = _setup_orphan_scenario(db_session)
+        db_session.commit()
+
+        response = auth_client.post(
+            f"/scheduling/{t.id}/events/{ev.id}/reassign-partner",
+            data={
+                "orphan_id": str(alice.id),
+                "orphan_type": "pro",
+                "new_partner_id": str(carol.id),
+                "new_partner_type": "pro",
+            },
+        )
+
+        assert response.status_code == 409
+        db.session.refresh(alice)
+        db.session.refresh(carol)
+        assert alice.get_partners()[str(ev.id)] == "Bob"
+        assert carol.get_partners().get(str(ev.id)) is None
+
+    def test_no_js_encoded_claim_reassigns_with_server_token(
+        self, app, db_session, auth_client,
+    ):
+        t, ev, alice, _bob, carol = _setup_orphan_scenario(db_session)
+        claim = f"{carol.id}:{_claim_token(ev, alice, carol)}"
+        db_session.commit()
+
+        response = auth_client.post(
+            f"/scheduling/{t.id}/events/{ev.id}/reassign-partner",
+            data={
+                "orphan_id": str(alice.id),
+                "orphan_type": "pro",
+                "new_partner_type": "pro",
+                "partner_claim": claim,
+            },
+        )
+
+        assert response.status_code in (302, 303)
+        db.session.refresh(alice)
+        db.session.refresh(carol)
+        assert alice.get_partners()[str(ev.id)] == "Carol"
+        assert carol.get_partners()[str(ev.id)] == "Alice"
+
+    def test_stale_claim_token_returns_409_without_mutation(
+        self, app, db_session, auth_client,
+    ):
+        t, ev, alice, _bob, carol = _setup_orphan_scenario(db_session)
+        stale_token = _claim_token(ev, alice, carol)
+        carol.set_partner(ev.id, "Dave")
+        db_session.commit()
+
+        response = auth_client.post(
+            f"/scheduling/{t.id}/events/{ev.id}/reassign-partner",
+            data={
+                "orphan_id": str(alice.id),
+                "orphan_type": "pro",
+                "new_partner_id": str(carol.id),
+                "new_partner_type": "pro",
+                "expected_claim_digest": stale_token,
+            },
+        )
+
+        assert response.status_code == 409
+        db.session.refresh(alice)
+        db.session.refresh(carol)
+        assert alice.get_partners()[str(ev.id)] == "Bob"
+        assert carol.get_partners()[str(ev.id)] == "Dave"
 
     def test_wrong_gender_flashes_error(self, app, db_session, auth_client):
         """POST reassign_partner with gender mismatch flashes error and does not update."""
@@ -565,6 +689,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(carol.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, carol),
             },
             follow_redirects=True,
         )
@@ -605,6 +730,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(grace.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, grace),
             },
             follow_redirects=True,
         )
@@ -651,6 +777,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(bob.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(event, alice, bob),
             },
             follow_redirects=True,
         )
@@ -671,6 +798,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(carol.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, carol),
             },
             follow_redirects=False,
         )
@@ -710,6 +838,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(carol.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(event, alice, carol),
             },
             follow_redirects=True,
         )
@@ -736,6 +865,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(dave.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, dave),
             },
             follow_redirects=True,
         )
@@ -762,6 +892,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(outsider.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, outsider),
             },
             follow_redirects=True,
         )
@@ -790,6 +921,7 @@ class TestReassignPartnerRoute:
                 "orphan_type": "pro",
                 "new_partner_id": str(dave.id),
                 "new_partner_type": "pro",
+                "expected_claim_digest": _claim_token(ev, alice, dave),
             },
             follow_redirects=True,
         )

--- a/tests/test_proam_relay.py
+++ b/tests/test_proam_relay.py
@@ -404,6 +404,26 @@ def relay_tid(relay_app):
         return t.id
 
 
+def _payout_token(relay_app, tournament_id):
+    with relay_app.app_context():
+        from database import db as _db
+        from models import Tournament
+        from models.event import Event
+        from routes.proam_relay import _relay_payout_state_digest
+
+        tournament = _db.session.get(Tournament, tournament_id)
+        relay_event = Event.query.filter_by(
+            tournament_id=tournament_id,
+            name='Pro-Am Relay',
+        ).one()
+        return {
+            'expected_payout_digest': _relay_payout_state_digest(
+                tournament,
+                relay_event,
+            )
+        }
+
+
 class TestRelayPayoutsGet:
     def test_get_returns_200(self, relay_auth_client, relay_tid):
         resp = relay_auth_client.get(
@@ -416,6 +436,7 @@ class TestRelayPayoutsGet:
             f'/tournament/{relay_tid}/proam-relay/payouts'
         )
         assert b'payout_1' in resp.data
+        assert b'expected_payout_digest' in resp.data
 
     def test_get_prefills_existing_payouts(self, relay_app, relay_auth_client, relay_tid):
         from database import db as _db
@@ -449,10 +470,22 @@ class TestRelayPayoutsGet:
 
 
 class TestRelayPayoutsPost:
+    def test_missing_payout_digest_is_rejected(
+        self, relay_auth_client, relay_tid,
+    ):
+        response = relay_auth_client.post(
+            f'/tournament/{relay_tid}/proam-relay/payouts',
+            data={'payout_1': '1000.00'},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 409
+
     def test_save_happy_path_three_positions(self, relay_app, relay_auth_client, relay_tid):
         resp = relay_auth_client.post(
             f'/tournament/{relay_tid}/proam-relay/payouts',
             data={
+                **_payout_token(relay_app, relay_tid),
                 'payout_1': '1000.00',
                 'payout_2': '600.00',
                 'payout_3': '300.00',
@@ -475,7 +508,10 @@ class TestRelayPayoutsPost:
     def test_negative_amount_clamped_to_zero(self, relay_app, relay_auth_client, relay_tid):
         resp = relay_auth_client.post(
             f'/tournament/{relay_tid}/proam-relay/payouts',
-            data={'payout_1': '-50.00'},
+            data={
+                **_payout_token(relay_app, relay_tid),
+                'payout_1': '-50.00',
+            },
             follow_redirects=False,
         )
         assert resp.status_code == 302
@@ -488,14 +524,50 @@ class TestRelayPayoutsPost:
             saved = json.loads(ev.payouts)
         assert saved.get('1', 0.0) == 0.0
 
-    def test_non_numeric_input_flashes_error(self, relay_auth_client, relay_tid):
+    def test_non_numeric_input_flashes_error(
+        self, relay_app, relay_auth_client, relay_tid,
+    ):
         resp = relay_auth_client.post(
             f'/tournament/{relay_tid}/proam-relay/payouts',
-            data={'payout_1': 'abc'},
+            data={
+                **_payout_token(relay_app, relay_tid),
+                'payout_1': 'abc',
+            },
             follow_redirects=True,
         )
         assert resp.status_code == 200
         assert b'Invalid' in resp.data or b'invalid' in resp.data
+
+    def test_stale_payout_form_is_rejected_without_overwrite(
+        self, relay_app, relay_auth_client, relay_tid,
+    ):
+        stale = _payout_token(relay_app, relay_tid)
+        with relay_app.app_context():
+            from database import db as _db
+            from models.event import Event
+
+            relay_event = Event.query.filter_by(
+                tournament_id=relay_tid,
+                name='Pro-Am Relay',
+            ).one()
+            relay_event.set_payouts({'1': 777.0})
+            _db.session.commit()
+
+        response = relay_auth_client.post(
+            f'/tournament/{relay_tid}/proam-relay/payouts',
+            data={**stale, 'payout_1': '999.00'},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 409
+        with relay_app.app_context():
+            from models.event import Event
+
+            relay_event = Event.query.filter_by(
+                tournament_id=relay_tid,
+                name='Pro-Am Relay',
+            ).one()
+            assert relay_event.get_payouts() == {'1': 777.0}
 
     def test_post_no_relay_event_returns_404(self, relay_app, relay_auth_client):
         with relay_app.app_context():

--- a/tests/test_proam_relay_redraw_route.py
+++ b/tests/test_proam_relay_redraw_route.py
@@ -9,6 +9,7 @@ fixture in conftest.
 """
 
 import os
+import re
 
 import pytest
 
@@ -129,7 +130,10 @@ class TestRedrawNumTeams:
 
         r = auth_client.post(
             f"/tournament/{t.id}/proam-relay/redraw",
-            data={"num_teams": "3"},
+            data={
+                "num_teams": "3",
+                "expected_relay_digest": relay.state_digest(),
+            },
         )
         assert r.status_code == 302
 
@@ -138,7 +142,7 @@ class TestRedrawNumTeams:
     def test_redraw_without_num_teams_falls_back_to_existing(
         self, app, auth_client, db_session
     ):
-        """Legacy form submission without num_teams must still work."""
+        """The real redraw form may omit num_teams while retaining its token."""
         from services.proam_relay import ProAmRelay
 
         t = _seed_relay_tournament(db_session)
@@ -147,7 +151,7 @@ class TestRedrawNumTeams:
 
         r = auth_client.post(
             f"/tournament/{t.id}/proam-relay/redraw",
-            data={},
+            data={"expected_relay_digest": relay.state_digest()},
         )
         assert r.status_code == 302
 
@@ -170,7 +174,10 @@ class TestRedrawNumTeams:
 
         r = auth_client.post(
             f"/tournament/{t.id}/proam-relay/redraw",
-            data={"num_teams": bad},
+            data={
+                "num_teams": bad,
+                "expected_relay_digest": relay.state_digest(),
+            },
         )
         assert r.status_code == 302, f"bad input {bad!r} did not redirect"
         assert (
@@ -191,3 +198,186 @@ class TestRedrawNumTeams:
         html = r.get_data(as_text=True)
         assert 'name="num_teams"' in html, "num_teams select missing from dashboard"
         assert "Max 3 based on current opt-ins" in html, "capacity note missing"
+        assert re.search(
+            r'name="expected_relay_digest" value="[0-9a-f]{64}"', html
+        )
+
+
+def test_stale_relay_service_instances_merge_disjoint_team_times(
+    app, db_session,
+):
+    """Two judges saving different teams must not replace the other's time."""
+    from services.proam_relay import ProAmRelay
+
+    tournament = _seed_relay_tournament(db_session)
+    ProAmRelay(tournament).run_lottery(num_teams=2)
+
+    first_judge = ProAmRelay(tournament)
+    second_judge = ProAmRelay(tournament)
+    first_judge.record_total_time(
+        1,
+        91.25,
+        expected_digest=first_judge.team_state_digest(1),
+    )
+    second_judge.record_total_time(
+        2,
+        94.75,
+        expected_digest=second_judge.team_state_digest(2),
+    )
+
+    persisted = ProAmRelay(tournament)
+    assert [team['total_time'] for team in persisted.get_teams()] == [91.25, 94.75]
+
+
+def test_relay_results_rejects_stale_same_team_token(
+    app, auth_client, db_session,
+):
+    """A stale overwrite of one relay team is refused after the first save."""
+    from services.proam_relay import ProAmRelay
+
+    tournament = _seed_relay_tournament(db_session)
+    relay = ProAmRelay(tournament)
+    relay.run_lottery(num_teams=2)
+    expected_digest = relay.team_state_digest(1)
+
+    first = auth_client.post(
+        f'/tournament/{tournament.id}/proam-relay/results',
+        data={
+            'team_number': '1',
+            'time_seconds': '91.25',
+            'expected_relay_digest': expected_digest,
+        },
+    )
+    stale = auth_client.post(
+        f'/tournament/{tournament.id}/proam-relay/results',
+        data={
+            'team_number': '1',
+            'time_seconds': '99.00',
+            'expected_relay_digest': expected_digest,
+        },
+    )
+
+    assert first.status_code == 302
+    assert stale.status_code == 409
+    assert 'changed since this page was loaded' in stale.get_data(as_text=True)
+    assert ProAmRelay(tournament).get_teams()[0]['total_time'] == 91.25
+
+
+def test_relay_results_rejects_omitted_token_without_mutation(
+    app, auth_client, db_session,
+):
+    """A handcrafted relay result POST cannot bypass the concurrency fence."""
+    from services.proam_relay import ProAmRelay
+
+    tournament = _seed_relay_tournament(db_session)
+    relay = ProAmRelay(tournament)
+    relay.run_lottery(num_teams=2)
+
+    response = auth_client.post(
+        f'/tournament/{tournament.id}/proam-relay/results',
+        data={
+            'team_number': '1',
+            'time_seconds': '91.25',
+        },
+    )
+
+    assert response.status_code == 409
+    assert ProAmRelay(tournament).get_teams()[0]['total_time'] is None
+
+
+@pytest.mark.parametrize(
+    ('route_suffix', 'data'),
+    [
+        ('draw', {'num_teams': '2'}),
+        ('redraw', {'num_teams': '2'}),
+        ('results', {'team_number': '1', 'time_seconds': '91.25'}),
+        ('manual-teams/save', {'teams_json': '[]'}),
+        (
+            'replace-competitor',
+            {
+                'team_number': '1',
+                'old_competitor_id': '1',
+                'new_competitor_id': '2',
+                'competitor_type': 'pro',
+            },
+        ),
+    ],
+)
+def test_all_relay_mutation_routes_reject_omitted_token(
+    app,
+    auth_client,
+    db_session,
+    route_suffix,
+    data,
+):
+    """Every relay write endpoint fails closed before parsing its payload."""
+    from services.proam_relay import ProAmRelay
+
+    tournament = _seed_relay_tournament(db_session)
+    relay = ProAmRelay(tournament)
+    relay.run_lottery(num_teams=2)
+    state_before = relay.state_digest()
+
+    response = auth_client.post(
+        f'/tournament/{tournament.id}/proam-relay/{route_suffix}',
+        data=data,
+    )
+
+    assert response.status_code == 409
+    assert ProAmRelay(tournament).state_digest() == state_before
+
+
+@pytest.mark.parametrize(
+    'route_suffix',
+    ['results', 'manual-teams'],
+)
+def test_relay_mutation_forms_render_nonblank_server_token(
+    app, auth_client, db_session, route_suffix,
+):
+    from services.proam_relay import ProAmRelay
+
+    tournament = _seed_relay_tournament(db_session)
+    ProAmRelay(tournament).run_lottery(num_teams=2)
+
+    response = auth_client.get(
+        f'/tournament/{tournament.id}/proam-relay/{route_suffix}'
+    )
+
+    assert response.status_code == 200
+    assert re.search(
+        r'name="expected_relay_digest" value="[0-9a-f]{64}"',
+        response.get_data(as_text=True),
+    )
+
+
+def test_relay_teams_renders_fenced_replacement_form_for_each_member(
+    app, auth_client, db_session,
+):
+    from services.proam_relay import ProAmRelay
+
+    tournament = _seed_relay_tournament(db_session)
+    relay = ProAmRelay(tournament)
+    relay.run_lottery(num_teams=2)
+
+    response = auth_client.get(
+        f'/tournament/{tournament.id}/proam-relay/teams'
+    )
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert html.count('/proam-relay/replace-competitor') == 16
+    for team in relay.get_teams():
+        expected_digest = relay.team_state_digest(team['team_number'])
+        assert html.count(
+            f'name="expected_relay_digest" value="{expected_digest}"'
+        ) == 8
+        for competitor_type, member_key in (
+            ('pro', 'pro_members'),
+            ('college', 'college_members'),
+        ):
+            for member in team[member_key]:
+                assert (
+                    f'name="old_competitor_id" value="{member["id"]}"'
+                    in html
+                )
+                assert f'name="competitor_type" value="{competitor_type}"' in html

--- a/tests/test_race_day_postgres_concurrency.py
+++ b/tests/test_race_day_postgres_concurrency.py
@@ -1,0 +1,1017 @@
+"""Real PostgreSQL races for race-day state transitions.
+
+Run this module with ``PROAM_UNIT_PG=1``. The shared test factory clones a
+migrated PostgreSQL template into a private synthetic database; SQLite runs
+collect the module but skip every test because they cannot certify row locks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from database import db
+from tests.db_test_utils import create_test_app, drop_test_db
+
+pytestmark = pytest.mark.integration
+
+_WAIT_SECONDS = 10
+
+
+@pytest.fixture(scope="module")
+def app():
+    previous_testing = os.environ.get("TESTING")
+    os.environ["TESTING"] = "1"
+    try:
+        test_app, handle = create_test_app()
+    finally:
+        if previous_testing is None:
+            os.environ.pop("TESTING", None)
+        else:
+            os.environ["TESTING"] = previous_testing
+    try:
+        with test_app.app_context():
+            dialect = db.engine.dialect.name
+        if dialect != "postgresql":
+            pytest.skip(
+                "race-day concurrency certification requires "
+                "PROAM_UNIT_PG=1 and the isolated PostgreSQL test factory"
+            )
+        yield test_app
+    finally:
+        with test_app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+        drop_test_db(handle)
+
+
+def _new_admin(app, label: str) -> int:
+    from models import User
+
+    with app.app_context():
+        user = User(username=f"{label}-{uuid4().hex}", role=User.ROLE_ADMIN)
+        user.set_password("postgres-race-test")
+        db.session.add(user)
+        db.session.commit()
+        user_id = user.id
+        db.session.remove()
+        return user_id
+
+
+def _authenticated_client(app, user_id: int):
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session["_user_id"] = str(user_id)
+        session["_fresh"] = True
+    return client
+
+
+def _start_thread(*, name: str, target, done: threading.Event):
+    errors = []
+
+    def guarded():
+        try:
+            target()
+        except BaseException as exc:  # pragma: no cover - surfaced in caller
+            errors.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(name=name, target=guarded)
+    thread.start()
+    return thread, errors
+
+
+def _join(thread: threading.Thread, errors: list[BaseException]) -> None:
+    thread.join(_WAIT_SECONDS)
+    assert not thread.is_alive(), f"{thread.name} did not finish"
+    assert errors == []
+
+
+def _assert_peer_waits(
+    peer_started: threading.Event,
+    peer_done: threading.Event,
+) -> None:
+    assert peer_started.wait(_WAIT_SECONDS)
+    assert not peer_done.wait(0.35), (
+        "the peer transaction finished while the first PostgreSQL writer "
+        "still held the tournament row lock"
+    )
+
+
+def _seed_score(app, user_id: int) -> dict:
+    from models import User
+    from services.scoring_workflow import heat_submission_identity
+    from tests.conftest import (
+        make_college_competitor,
+        make_event,
+        make_heat,
+        make_team,
+        make_tournament,
+    )
+
+    with app.app_context():
+        session = db.session
+        tournament = make_tournament(session, name=f"PG Receipt Race {uuid4()}", year=2097)
+        team = make_team(
+            session,
+            tournament,
+            code=f"PG-{uuid4().hex[:8]}",
+            school="Synthetic PostgreSQL College",
+        )
+        competitor = make_college_competitor(
+            session,
+            tournament,
+            team,
+            f"Synthetic Scorer {uuid4().hex[:8]}",
+        )
+        event = make_event(
+            session,
+            tournament,
+            "Standing Block Hard Hit",
+            event_type="college",
+            scoring_type="hits",
+            scoring_order="highest_wins",
+        )
+        heat = make_heat(
+            session,
+            event,
+            competitors=[competitor.id],
+            stand_assignments={str(competitor.id): 1},
+        )
+        request_id = str(uuid4())
+        form_data = {
+            "request_id": request_id,
+            "tournament_id": str(tournament.id),
+            "heat_id": str(heat.id),
+            "issuer_user_id": str(user_id),
+            "issuer_role": User.ROLE_ADMIN,
+            "schedule_fingerprint": "synthetic-pg-schedule",
+            "queued_at": datetime.now(timezone.utc).isoformat(),
+            "heat_version": str(heat.version_id),
+            "heat_identity": heat_submission_identity(heat),
+            f"result_{competitor.id}": "9",
+            f"status_{competitor.id}": "completed",
+            f"reason_{competitor.id}": "",
+        }
+        ids = {
+            "tournament_id": tournament.id,
+            "event_id": event.id,
+            "heat_id": heat.id,
+            "competitor_id": competitor.id,
+            "request_id": request_id,
+            "form_data": form_data,
+        }
+        session.commit()
+        session.remove()
+        return ids
+
+
+def test_same_uuid_score_race_is_single_commit_and_replayable(
+    app,
+    monkeypatch,
+):
+    """An overlapped lost response produces one score, audit, and receipt."""
+    from models import AuditLog, Event, EventResult, Heat, ScoreSubmissionReceipt
+    from services import scoring_workflow
+    from services.scoring_workflow import save_heat_results_submission
+
+    user_id = _new_admin(app, "pg-score-operator")
+    seeded = _seed_score(app, user_id)
+    first_at_receipt = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    first_done = threading.Event()
+    second_done = threading.Event()
+    outcomes = {}
+    original_create_receipt = scoring_workflow._create_submission_receipt
+
+    def hold_first_receipt(*args, **kwargs):
+        receipt = original_create_receipt(*args, **kwargs)
+        if threading.current_thread().name == "score-first":
+            first_at_receipt.set()
+            assert release_first.wait(_WAIT_SECONDS)
+        return receipt
+
+    monkeypatch.setattr(
+        scoring_workflow,
+        "_create_submission_receipt",
+        hold_first_receipt,
+    )
+
+    def submit(slot: str, started: threading.Event | None = None):
+        if started is not None:
+            started.set()
+        with app.app_context():
+            heat = db.session.get(Heat, seeded["heat_id"])
+            event = db.session.get(Event, seeded["event_id"])
+            outcomes[slot] = save_heat_results_submission(
+                tournament_id=seeded["tournament_id"],
+                heat=heat,
+                event=event,
+                form_data=dict(seeded["form_data"]),
+                judge_user_id=user_id,
+            )
+            db.session.remove()
+
+    first_thread, first_errors = _start_thread(
+        name="score-first",
+        target=lambda: submit("first"),
+        done=first_done,
+    )
+    assert first_at_receipt.wait(_WAIT_SECONDS)
+    second_thread, second_errors = _start_thread(
+        name="score-second",
+        target=lambda: submit("second", second_started),
+        done=second_done,
+    )
+    try:
+        _assert_peer_waits(second_started, second_done)
+    finally:
+        release_first.set()
+    _join(first_thread, first_errors)
+    _join(second_thread, second_errors)
+
+    assert outcomes["first"]["ok"] is True
+    assert outcomes["first"]["receipt"]["request_id"] == seeded["request_id"]
+    assert outcomes["second"]["ok"] is True
+    assert outcomes["second"]["receipt_replayed"] is True
+    assert outcomes["second"]["receipt"]["request_id"] == seeded["request_id"]
+
+    with app.app_context():
+        replay = save_heat_results_submission(
+            tournament_id=seeded["tournament_id"],
+            heat=db.session.get(Heat, seeded["heat_id"]),
+            event=db.session.get(Event, seeded["event_id"]),
+            form_data=dict(seeded["form_data"]),
+            judge_user_id=user_id,
+        )
+        assert replay["ok"] is True
+        assert replay["receipt_replayed"] is True
+        assert replay["receipt"]["request_id"] == seeded["request_id"]
+        assert ScoreSubmissionReceipt.query.filter_by(request_id=seeded["request_id"]).count() == 1
+        result = EventResult.query.filter_by(
+            event_id=seeded["event_id"],
+            competitor_id=seeded["competitor_id"],
+        ).one()
+        assert result.result_value == 9
+        assert (
+            AuditLog.query.filter_by(
+                action="heat_results_saved",
+                entity_type="heat",
+                entity_id=seeded["heat_id"],
+            ).count()
+            == 1
+        )
+
+
+def test_receipt_lifecycle_preserves_history_and_revokes_deleted_issuer(app):
+    from models import Heat, ScoreSubmissionReceipt, Tournament, User
+    from services.scoring_workflow import save_heat_results_submission
+
+    user_id = _new_admin(app, "pg-receipt-lifecycle")
+    seeded = _seed_score(app, user_id)
+
+    with app.app_context():
+        heat = db.session.get(Heat, seeded["heat_id"])
+        outcome = save_heat_results_submission(
+            tournament_id=seeded["tournament_id"],
+            heat=heat,
+            event=heat.event,
+            form_data=seeded["form_data"],
+            judge_user_id=user_id,
+        )
+        assert outcome["ok"] is True
+        db.session.commit()
+
+        db.session.delete(heat)
+        db.session.commit()
+        receipt = db.session.get(
+            ScoreSubmissionReceipt, seeded["request_id"]
+        )
+        assert receipt is not None
+        assert receipt.heat_id == seeded["heat_id"]
+
+        removable_user = User(
+            username=f"pg-removable-receipt-{uuid4().hex}",
+            role=User.ROLE_ADMIN,
+        )
+        removable_user.set_password("postgres-race-test")
+        db.session.add(removable_user)
+        db.session.flush()
+        removable_request_id = str(uuid4())
+        db.session.add(ScoreSubmissionReceipt(
+            request_id=removable_request_id,
+            tournament_id=seeded["tournament_id"],
+            heat_id=seeded["heat_id"],
+            issuing_user_id=removable_user.id,
+            canonical_payload_sha256="d" * 64,
+            accepted_outcome_json={"ok": True},
+        ))
+        db.session.commit()
+        db.session.delete(removable_user)
+        db.session.commit()
+        receipt = db.session.get(
+            ScoreSubmissionReceipt, removable_request_id
+        )
+        assert receipt is not None
+        assert receipt.issuing_user_id is None
+
+        tournament = db.session.get(Tournament, seeded["tournament_id"])
+        db.session.delete(tournament)
+        db.session.commit()
+        assert db.session.get(
+            ScoreSubmissionReceipt, seeded["request_id"]
+        ) is None
+
+
+def _seed_relay(app) -> dict:
+    from models import Event, Tournament
+    from services.proam_relay import ProAmRelay
+
+    events = {key: {"result": None, "status": "pending"} for key in ProAmRelay.RELAY_EVENTS}
+    state = {
+        "status": "drawn",
+        "teams": [
+            {
+                "team_number": 1,
+                "name": "Synthetic Team 1",
+                "pro_members": [],
+                "college_members": [],
+                "events": events,
+                "total_time": None,
+            }
+        ],
+        "eligible_college": [],
+        "eligible_pro": [],
+        "drawn_college": [],
+        "drawn_pro": [],
+    }
+    with app.app_context():
+        tournament = Tournament(name=f"PG Relay Race {uuid4()}", year=2097, status="setup")
+        db.session.add(tournament)
+        db.session.flush()
+        relay_event = Event(
+            tournament_id=tournament.id,
+            name="Pro-Am Relay",
+            event_type="pro",
+            scoring_type="time",
+            scoring_order="lowest_wins",
+            is_partnered=True,
+            event_state=json.dumps(state),
+        )
+        db.session.add(relay_event)
+        db.session.commit()
+        digest = ProAmRelay(tournament).team_state_digest(1)
+        ids = {"tournament_id": tournament.id, "digest": digest}
+        db.session.remove()
+        return ids
+
+
+def test_same_relay_team_race_commits_one_reviewed_snapshot(
+    app,
+    monkeypatch,
+):
+    from models import Event, RelayState, RelayTeam, RelayTeamEvent, Tournament
+    from services.proam_relay import ProAmRelay
+
+    user_id = _new_admin(app, "pg-relay-operator")
+    seeded = _seed_relay(app)
+    first_inside_writer = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    first_done = threading.Event()
+    second_done = threading.Event()
+    responses = {}
+    original_record = ProAmRelay.record_total_time
+
+    def hold_first_writer(self, *args, **kwargs):
+        if threading.current_thread().name == "relay-first":
+            first_inside_writer.set()
+            assert release_first.wait(_WAIT_SECONDS)
+        return original_record(self, *args, **kwargs)
+
+    monkeypatch.setattr(ProAmRelay, "record_total_time", hold_first_writer)
+
+    def post_result(slot: str, value: str, started=None):
+        if started is not None:
+            started.set()
+        responses[slot] = _authenticated_client(app, user_id).post(
+            f"/tournament/{seeded['tournament_id']}/proam-relay/results",
+            data={
+                "team_number": "1",
+                "time_seconds": value,
+                "expected_relay_digest": seeded["digest"],
+            },
+            follow_redirects=False,
+        )
+
+    first_thread, first_errors = _start_thread(
+        name="relay-first",
+        target=lambda: post_result("first", "101.25"),
+        done=first_done,
+    )
+    assert first_inside_writer.wait(_WAIT_SECONDS)
+    second_thread, second_errors = _start_thread(
+        name="relay-second",
+        target=lambda: post_result("second", "202.50", second_started),
+        done=second_done,
+    )
+    try:
+        _assert_peer_waits(second_started, second_done)
+    finally:
+        release_first.set()
+    _join(first_thread, first_errors)
+    _join(second_thread, second_errors)
+
+    assert responses["first"].status_code in (302, 303)
+    assert responses["second"].status_code == 409
+    with app.app_context():
+        tournament = db.session.get(Tournament, seeded["tournament_id"])
+        relay = ProAmRelay(tournament)
+        team = relay.get_teams()[0]
+        assert team["total_time"] == 101.25
+        assert relay.get_status() == "completed"
+        relay_event = Event.query.filter_by(
+            tournament_id=seeded["tournament_id"],
+            name="Pro-Am Relay",
+        ).one()
+        state = RelayState.query.filter_by(event_id=relay_event.id).one()
+        assert RelayTeam.query.filter_by(relay_state_id=state.id).count() == 1
+        persisted_team = RelayTeam.query.filter_by(relay_state_id=state.id, team_number=1).one()
+        assert persisted_team.total_time == 101.25
+        assert RelayTeamEvent.query.filter_by(relay_team_id=persisted_team.id).count() == len(
+            ProAmRelay.RELAY_EVENTS
+        )
+
+
+def test_two_stale_relay_payout_forms_commit_one_reviewed_snapshot(
+    app,
+    monkeypatch,
+):
+    from models import Event, Tournament
+    from routes.proam_relay import _relay_payout_state_digest
+
+    user_id = _new_admin(app, "pg-relay-payout-operator")
+    seeded = _seed_relay(app)
+    with app.app_context():
+        tournament = db.session.get(Tournament, seeded["tournament_id"])
+        relay_event = Event.query.filter_by(
+            tournament_id=seeded["tournament_id"],
+            name="Pro-Am Relay",
+        ).one()
+        stale_digest = _relay_payout_state_digest(tournament, relay_event)
+        db.session.remove()
+
+    first_inside_writer = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    first_done = threading.Event()
+    second_done = threading.Event()
+    responses = {}
+    original_set_payouts = Event.set_payouts
+
+    def hold_first_writer(self, payout_dict):
+        if threading.current_thread().name == "relay-payout-first":
+            first_inside_writer.set()
+            assert release_first.wait(_WAIT_SECONDS)
+        return original_set_payouts(self, payout_dict)
+
+    monkeypatch.setattr(Event, "set_payouts", hold_first_writer)
+
+    def post_payouts(slot: str, amount: str, started=None):
+        if started is not None:
+            started.set()
+        responses[slot] = _authenticated_client(app, user_id).post(
+            f"/tournament/{seeded['tournament_id']}/proam-relay/payouts",
+            data={
+                "expected_payout_digest": stale_digest,
+                "payout_1": amount,
+            },
+            follow_redirects=False,
+        )
+
+    first_thread, first_errors = _start_thread(
+        name="relay-payout-first",
+        target=lambda: post_payouts("first", "800.00"),
+        done=first_done,
+    )
+    assert first_inside_writer.wait(_WAIT_SECONDS)
+    second_thread, second_errors = _start_thread(
+        name="relay-payout-second",
+        target=lambda: post_payouts("second", "1600.00", second_started),
+        done=second_done,
+    )
+    try:
+        _assert_peer_waits(second_started, second_done)
+    finally:
+        release_first.set()
+    _join(first_thread, first_errors)
+    _join(second_thread, second_errors)
+
+    assert responses["first"].status_code in (302, 303)
+    assert responses["second"].status_code == 409
+    assert b"Relay payouts or results changed" in responses["second"].data
+    with app.app_context():
+        relay_event = Event.query.filter_by(
+            tournament_id=seeded["tournament_id"],
+            name="Pro-Am Relay",
+        ).one()
+        assert relay_event.get_payouts() == {"1": 800.0}
+
+
+def _seed_partner_claim(app) -> dict:
+    from models import Event, EventResult, Tournament
+    from models.competitor import ProCompetitor
+    from services.partner_matching import partner_claim_digest
+
+    with app.app_context():
+        tournament = Tournament(name=f"PG Partner Race {uuid4()}", year=2097, status="setup")
+        db.session.add(tournament)
+        db.session.flush()
+        event = Event(
+            tournament_id=tournament.id,
+            name="Partnered Axe Throw",
+            event_type="pro",
+            scoring_type="score",
+            scoring_order="highest_wins",
+            is_partnered=True,
+            partner_gender_requirement="any",
+        )
+        db.session.add(event)
+        db.session.flush()
+
+        def competitor(name: str, *, status="active", partner=""):
+            row = ProCompetitor(
+                tournament_id=tournament.id,
+                name=name,
+                gender="F",
+                status=status,
+                events_entered=json.dumps([event.id]),
+                partners=json.dumps({str(event.id): partner} if partner else {}),
+            )
+            db.session.add(row)
+            db.session.flush()
+            return row
+
+        alice = competitor("Synthetic Alice", partner="Synthetic Bob")
+        competitor("Synthetic Bob", status="scratched", partner="Synthetic Alice")
+        dana = competitor("Synthetic Dana", partner="Synthetic Evan")
+        competitor("Synthetic Evan", status="scratched", partner="Synthetic Dana")
+        candidate = competitor("Synthetic Carol")
+        for orphan, old_name in (
+            (alice, "Synthetic Bob"),
+            (dana, "Synthetic Evan"),
+        ):
+            db.session.add(
+                EventResult(
+                    event_id=event.id,
+                    competitor_id=orphan.id,
+                    competitor_type="pro",
+                    competitor_name=orphan.name,
+                    partner_name=old_name,
+                    status="pending",
+                )
+            )
+        db.session.flush()
+        ids = {
+            "tournament_id": tournament.id,
+            "event_id": event.id,
+            "alice_id": alice.id,
+            "dana_id": dana.id,
+            "candidate_id": candidate.id,
+            "alice_digest": partner_claim_digest(event, alice, candidate),
+            "dana_digest": partner_claim_digest(event, dana, candidate),
+        }
+        db.session.commit()
+        db.session.remove()
+        return ids
+
+
+def test_two_orphans_cannot_claim_the_same_partner(
+    app,
+    monkeypatch,
+):
+    from models.competitor import ProCompetitor
+    from routes.scheduling import partners as partner_routes
+
+    user_id = _new_admin(app, "pg-partner-operator")
+    seeded = _seed_partner_claim(app)
+    first_inside_writer = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    first_done = threading.Event()
+    second_done = threading.Event()
+    responses = {}
+    original_set_partner = partner_routes.set_partner_bidirectional
+
+    def hold_first_writer(a, b, event):
+        if threading.current_thread().name == "partner-first":
+            first_inside_writer.set()
+            assert release_first.wait(_WAIT_SECONDS)
+        return original_set_partner(a, b, event)
+
+    monkeypatch.setattr(
+        partner_routes,
+        "set_partner_bidirectional",
+        hold_first_writer,
+    )
+
+    def post_claim(slot: str, orphan_id: int, digest: str, started=None):
+        if started is not None:
+            started.set()
+        responses[slot] = _authenticated_client(app, user_id).post(
+            f"/scheduling/{seeded['tournament_id']}/events/{seeded['event_id']}/reassign-partner",
+            data={
+                "orphan_id": str(orphan_id),
+                "orphan_type": "pro",
+                "new_partner_id": str(seeded["candidate_id"]),
+                "new_partner_type": "pro",
+                "expected_claim_digest": digest,
+            },
+            follow_redirects=False,
+        )
+
+    first_thread, first_errors = _start_thread(
+        name="partner-first",
+        target=lambda: post_claim("first", seeded["alice_id"], seeded["alice_digest"]),
+        done=first_done,
+    )
+    assert first_inside_writer.wait(_WAIT_SECONDS)
+    second_thread, second_errors = _start_thread(
+        name="partner-second",
+        target=lambda: post_claim(
+            "second", seeded["dana_id"], seeded["dana_digest"], second_started
+        ),
+        done=second_done,
+    )
+    try:
+        _assert_peer_waits(second_started, second_done)
+    finally:
+        release_first.set()
+    _join(first_thread, first_errors)
+    _join(second_thread, second_errors)
+
+    assert responses["first"].status_code in (302, 303)
+    assert responses["second"].status_code == 409
+    with app.app_context():
+        alice = db.session.get(ProCompetitor, seeded["alice_id"])
+        dana = db.session.get(ProCompetitor, seeded["dana_id"])
+        candidate = db.session.get(ProCompetitor, seeded["candidate_id"])
+        event_key = str(seeded["event_id"])
+        assert alice.get_partners()[event_key] == candidate.name
+        assert candidate.get_partners()[event_key] == alice.name
+        assert dana.get_partners()[event_key] == "Synthetic Evan"
+        inbound = [
+            row.id for row in (alice, dana) if row.get_partners().get(event_key) == candidate.name
+        ]
+        assert inbound == [alice.id]
+
+
+def _seed_flight(app) -> dict:
+    from models import Event, Flight, Heat, Tournament
+    from routes.scheduling.flights import flight_order_digest
+
+    with app.app_context():
+        tournament = Tournament(name=f"PG Flight Race {uuid4()}", year=2097, status="setup")
+        db.session.add(tournament)
+        db.session.flush()
+        flight = Flight(
+            tournament_id=tournament.id,
+            flight_number=1,
+            status="pending",
+        )
+        db.session.add(flight)
+        db.session.flush()
+        heat_ids = []
+        for position in (1, 2):
+            event = Event(
+                tournament_id=tournament.id,
+                name=f"Synthetic Flight Event {uuid4().hex[:8]}",
+                event_type="pro",
+                scoring_type="time",
+                scoring_order="lowest_wins",
+                status="pending",
+            )
+            db.session.add(event)
+            db.session.flush()
+            heat = Heat(
+                event_id=event.id,
+                heat_number=1,
+                run_number=1,
+                status="pending",
+                flight_id=flight.id,
+                flight_position=position,
+            )
+            heat.set_roster("pro", [])
+            db.session.add(heat)
+            db.session.flush()
+            heat_ids.append(heat.id)
+        db.session.commit()
+        ids = {
+            "tournament_id": tournament.id,
+            "flight_id": flight.id,
+            "heat_ids": heat_ids,
+            "digest": flight_order_digest(flight.id),
+        }
+        db.session.remove()
+        return ids
+
+
+def test_flight_start_wins_over_overlapped_reorder(
+    app,
+    monkeypatch,
+):
+    from models import Flight, Heat
+    from routes.scheduling import flights as flight_routes
+
+    user_id = _new_admin(app, "pg-flight-operator")
+    seeded = _seed_flight(app)
+    first_inside_writer = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    first_done = threading.Event()
+    second_done = threading.Event()
+    responses = {}
+
+    def hold_start_transaction(*_args, **_kwargs):
+        first_inside_writer.set()
+        assert release_first.wait(_WAIT_SECONDS)
+
+    monkeypatch.setattr(
+        flight_routes,
+        "_send_upcoming_heat_sms",
+        hold_start_transaction,
+    )
+
+    def start_flight():
+        responses["start"] = _authenticated_client(app, user_id).post(
+            f"/scheduling/{seeded['tournament_id']}/flights/{seeded['flight_id']}/start",
+            follow_redirects=False,
+        )
+
+    def reorder_flight():
+        second_started.set()
+        responses["reorder"] = _authenticated_client(app, user_id).post(
+            f"/scheduling/{seeded['tournament_id']}/flights/{seeded['flight_id']}/reorder",
+            json={
+                "heat_ids": list(reversed(seeded["heat_ids"])),
+                "expected_digest": seeded["digest"],
+            },
+        )
+
+    first_thread, first_errors = _start_thread(
+        name="flight-start", target=start_flight, done=first_done
+    )
+    assert first_inside_writer.wait(_WAIT_SECONDS)
+    second_thread, second_errors = _start_thread(
+        name="flight-reorder", target=reorder_flight, done=second_done
+    )
+    try:
+        _assert_peer_waits(second_started, second_done)
+    finally:
+        release_first.set()
+    _join(first_thread, first_errors)
+    _join(second_thread, second_errors)
+
+    assert responses["start"].status_code in (302, 303)
+    assert responses["reorder"].status_code == 409
+    assert responses["reorder"].get_json()["code"] == "active_flight"
+    with app.app_context():
+        assert db.session.get(Flight, seeded["flight_id"]).status == "in_progress"
+        persisted_order = [
+            heat.id
+            for heat in Heat.query.filter_by(flight_id=seeded["flight_id"]).order_by(
+                Heat.flight_position, Heat.id
+            )
+        ]
+        assert persisted_order == seeded["heat_ids"]
+        positions = [
+            heat.flight_position for heat in Heat.query.filter_by(flight_id=seeded["flight_id"])
+        ]
+        assert sorted(positions) == [1, 2]
+
+
+def _seed_birling(app) -> dict:
+    from services.birling_bracket import BirlingBracket
+    from tests.conftest import (
+        make_college_competitor,
+        make_event,
+        make_team,
+        make_tournament,
+    )
+
+    with app.app_context():
+        tournament = make_tournament(db.session, name=f"PG Birling Race {uuid4()}", year=2097)
+        team = make_team(
+            db.session,
+            tournament,
+            code=f"BR-{uuid4().hex[:8]}",
+            school="Synthetic Birling College",
+        )
+        people = [
+            make_college_competitor(
+                db.session,
+                tournament,
+                team,
+                f"Synthetic Birler {index}-{uuid4().hex[:6]}",
+            )
+            for index in range(4)
+        ]
+        event = make_event(
+            db.session,
+            tournament,
+            "Birling",
+            event_type="college",
+            scoring_type="bracket",
+        )
+        db.session.flush()
+        bracket = BirlingBracket(event)
+        bracket.generate_bracket(
+            [{"id": person.id, "name": person.display_name} for person in people]
+        )
+        match = bracket.get_current_matches()[0]
+        ids = {
+            "tournament_id": tournament.id,
+            "event_id": event.id,
+            "match_id": match["match_id"],
+            "fall_winner_id": match["competitor1"],
+            "direct_winner_id": match["competitor2"],
+            "digest": bracket.match_fall_digest(match["match_id"]),
+        }
+        db.session.remove()
+        return ids
+
+
+def test_birling_fall_wins_over_overlapped_direct_winner(
+    app,
+    monkeypatch,
+):
+    from models import Event
+    from services.birling_bracket import BirlingBracket
+
+    user_id = _new_admin(app, "pg-birling-operator")
+    seeded = _seed_birling(app)
+    first_inside_writer = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    first_done = threading.Event()
+    second_done = threading.Event()
+    responses = {}
+    original_record_fall = BirlingBracket.record_fall
+
+    def hold_first_fall(self, *args, **kwargs):
+        first_inside_writer.set()
+        assert release_first.wait(_WAIT_SECONDS)
+        return original_record_fall(self, *args, **kwargs)
+
+    monkeypatch.setattr(BirlingBracket, "record_fall", hold_first_fall)
+
+    base = f"/scheduling/{seeded['tournament_id']}/event/{seeded['event_id']}/birling"
+
+    def record_fall():
+        responses["fall"] = _authenticated_client(app, user_id).post(
+            f"{base}/fall",
+            data={
+                "match_id": seeded["match_id"],
+                "fall_winner_id": str(seeded["fall_winner_id"]),
+                "expected_fall_digest": seeded["digest"],
+            },
+            follow_redirects=False,
+        )
+
+    def declare_winner():
+        second_started.set()
+        responses["direct"] = _authenticated_client(app, user_id).post(
+            f"{base}/record",
+            data={
+                "match_id": seeded["match_id"],
+                "winner_id": str(seeded["direct_winner_id"]),
+                "expected_fall_digest": seeded["digest"],
+            },
+            follow_redirects=False,
+        )
+
+    first_thread, first_errors = _start_thread(
+        name="birling-fall", target=record_fall, done=first_done
+    )
+    assert first_inside_writer.wait(_WAIT_SECONDS)
+    second_thread, second_errors = _start_thread(
+        name="birling-direct", target=declare_winner, done=second_done
+    )
+    try:
+        _assert_peer_waits(second_started, second_done)
+    finally:
+        release_first.set()
+    _join(first_thread, first_errors)
+    _join(second_thread, second_errors)
+
+    assert responses["fall"].status_code in (302, 303)
+    assert responses["direct"].status_code == 409
+    assert responses["direct"].headers["X-Retryable"] == "true"
+    with app.app_context():
+        event = db.session.get(Event, seeded["event_id"])
+        match = BirlingBracket(event)._find_match(seeded["match_id"])
+        assert match["winner"] is None
+        assert match["loser"] is None
+        assert [fall["winner"] for fall in match["falls"]] == [seeded["fall_winner_id"]]
+
+
+def test_late_job_completion_cannot_overwrite_reconciliation(
+    app,
+    monkeypatch,
+):
+    from datetime import timedelta
+
+    from models import BackgroundJob
+    from services import background_jobs
+    from services.time_utils import utc_now_naive
+
+    old_boot_id = uuid4().hex
+    replacement_boot_id = uuid4().hex
+    job_id = uuid4().hex
+    now = utc_now_naive()
+    with app.app_context():
+        db.session.add(
+            BackgroundJob(
+                id=job_id,
+                label="Synthetic late completion",
+                status="running",
+                owner_boot_id=old_boot_id,
+                owner_heartbeat_at=now - timedelta(seconds=31),
+                submitted_at=now - timedelta(minutes=1),
+                started_at=now - timedelta(seconds=45),
+            )
+        )
+        db.session.commit()
+        db.session.remove()
+
+    reconciliation_flushed = threading.Event()
+    release_reconciliation = threading.Event()
+    completion_started = threading.Event()
+    reconciliation_done = threading.Event()
+    completion_done = threading.Event()
+    outcomes = {}
+    original_commit = db.session.commit
+
+    def hold_reconciliation_commit():
+        if threading.current_thread().name == "job-reconciliation":
+            db.session.flush()
+            reconciliation_flushed.set()
+            assert release_reconciliation.wait(_WAIT_SECONDS)
+        return original_commit()
+
+    monkeypatch.setattr(db.session, "commit", hold_reconciliation_commit)
+    monkeypatch.setattr(background_jobs, "_app", app)
+    monkeypatch.setattr(background_jobs, "_BOOT_ID", replacement_boot_id)
+
+    def reconcile():
+        outcomes["reconciled"] = background_jobs.reconcile_interrupted_jobs(
+            app,
+            now=now,
+            lease_timeout_seconds=30,
+        )
+
+    def complete_late():
+        completion_started.set()
+        outcomes["persisted"] = background_jobs._persist_job(
+            job_id,
+            status="completed",
+            finished_at=now,
+            result={"ok": True, "source": "expired worker"},
+            owner_heartbeat_at=now,
+            require_active_owner=True,
+        )
+
+    reconciliation_thread, reconciliation_errors = _start_thread(
+        name="job-reconciliation",
+        target=reconcile,
+        done=reconciliation_done,
+    )
+    assert reconciliation_flushed.wait(_WAIT_SECONDS)
+    monkeypatch.setattr(background_jobs, "_BOOT_ID", old_boot_id)
+    completion_thread, completion_errors = _start_thread(
+        name="job-late-completion",
+        target=complete_late,
+        done=completion_done,
+    )
+    try:
+        _assert_peer_waits(completion_started, completion_done)
+    finally:
+        release_reconciliation.set()
+    _join(reconciliation_thread, reconciliation_errors)
+    _join(completion_thread, completion_errors)
+
+    assert outcomes["reconciled"] == 1
+    assert outcomes["persisted"] is False
+    with app.app_context():
+        row = db.session.get(BackgroundJob, job_id)
+        assert row.status == "interrupted"
+        assert row.finished_at == now
+        assert row.result_json is None
+        assert "cannot resume" in row.error_text

--- a/tests/test_remedial_pr_fixes.py
+++ b/tests/test_remedial_pr_fixes.py
@@ -7,6 +7,7 @@ import json
 import os
 import sqlite3
 import tempfile
+import time
 
 import pytest
 
@@ -55,10 +56,11 @@ def test_background_jobs_run_with_app_context(app):
     with app.app_context():
         job_id = submit('ctx-test', _job, metadata={'tournament_id': 0, 'kind': 'ctx-test'})
 
-    for _ in range(20):
+    deadline = time.monotonic() + 2.0
+    job = get(job_id)
+    while job and job['status'] not in {'completed', 'failed'} and time.monotonic() < deadline:
+        time.sleep(0.01)
         job = get(job_id)
-        if job and job['status'] in {'completed', 'failed'}:
-            break
 
     assert job is not None
     assert job['status'] == 'completed'

--- a/tests/test_reporting_backup.py
+++ b/tests/test_reporting_backup.py
@@ -1,19 +1,102 @@
+import io
 import os
+import sqlite3
+import threading
+import time
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
 
 
-def test_sqlite_backup_download_plan_accepts_existing_relative_db(app):
+def test_sqlite_online_snapshot_is_consistent_during_active_writes(app):
+    from services.backup import create_sqlite_snapshot
+
+    db_path = os.path.join(app.instance_path, f'active-backup-{uuid.uuid4().hex}.db')
+    conn = sqlite3.connect(db_path)
+    conn.execute('PRAGMA journal_mode=WAL')
+    conn.execute('CREATE TABLE summary (row_count INTEGER NOT NULL)')
+    conn.execute('CREATE TABLE ledger (id INTEGER PRIMARY KEY)')
+    conn.execute('INSERT INTO summary VALUES (0)')
+    conn.commit()
+    conn.close()
+    stop = threading.Event()
+
+    def _writer():
+        writer = sqlite3.connect(db_path, timeout=5)
+        try:
+            while not stop.is_set():
+                writer.execute('BEGIN IMMEDIATE')
+                writer.execute('INSERT INTO ledger DEFAULT VALUES')
+                writer.execute('UPDATE summary SET row_count = row_count + 1')
+                writer.commit()
+        finally:
+            writer.close()
+
+    thread = threading.Thread(target=_writer)
+    thread.start()
+    snapshot = None
+    try:
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            observer = sqlite3.connect(db_path)
+            count = observer.execute('SELECT COUNT(*) FROM ledger').fetchone()[0]
+            observer.close()
+            if count:
+                break
+            time.sleep(0.01)
+        snapshot = create_sqlite_snapshot(db_path)
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+
+    try:
+        restored = sqlite3.connect(snapshot['path'])
+        try:
+            summary_count = restored.execute('SELECT row_count FROM summary').fetchone()[0]
+            ledger_count = restored.execute('SELECT COUNT(*) FROM ledger').fetchone()[0]
+            assert summary_count == ledger_count
+            assert restored.execute('PRAGMA integrity_check').fetchone() == ('ok',)
+        finally:
+            restored.close()
+    finally:
+        if snapshot:
+            os.remove(snapshot['path'])
+        for suffix in ('', '-wal', '-shm'):
+            try:
+                os.remove(f'{db_path}{suffix}')
+            except OSError:
+                pass
+
+
+def test_sqlite_backup_download_plan_creates_validated_snapshot(app):
     from services.reporting_backup import sqlite_backup_download_plan
 
     db_path = os.path.join(app.instance_path, 'backup-plan.db')
-    with open(db_path, 'wb') as fh:
-        fh.write(b'SQLite format 3\x00')
+    conn = sqlite3.connect(db_path)
+    conn.execute('CREATE TABLE values_seen (value INTEGER NOT NULL)')
+    conn.execute('INSERT INTO values_seen VALUES (17)')
+    conn.commit()
+    conn.close()
 
     try:
         result = sqlite_backup_download_plan('sqlite:///backup-plan.db', app.instance_path)
+        assert result['ok'] is True
+        assert result['path'] != db_path
+        assert result['cleanup'] is True
+        assert len(result['sha256']) == 64
+        snapshot = sqlite3.connect(result['path'])
+        try:
+            assert snapshot.execute('SELECT value FROM values_seen').fetchone() == (17,)
+            assert snapshot.execute('PRAGMA integrity_check').fetchone() == ('ok',)
+        finally:
+            snapshot.close()
     finally:
+        if 'result' in locals() and result.get('path'):
+            try:
+                os.remove(result['path'])
+            except OSError:
+                pass
         os.remove(db_path)
-
-    assert result == {'ok': True, 'path': db_path}
 
 
 def test_sqlite_backup_download_plan_rejects_non_sqlite(app):
@@ -36,6 +119,162 @@ def test_sqlite_backup_download_plan_rejects_missing_file(app):
         'reason': 'missing',
         'message': 'Database file not found.',
     }
+
+
+def test_local_backup_uses_durable_directory_publish(tmp_path, monkeypatch):
+    from services import backup
+
+    source = tmp_path / 'source.db'
+    connection = sqlite3.connect(source)
+    connection.execute('CREATE TABLE evidence (value INTEGER NOT NULL)')
+    connection.execute('INSERT INTO evidence VALUES (17)')
+    connection.commit()
+    connection.close()
+    calls = []
+    real_replace = backup._replace_file_durably
+
+    def recording_replace(source_path, destination_path):
+        calls.append((source_path, destination_path))
+        return real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(backup, '_replace_file_durably', recording_replace)
+
+    result = backup.backup_to_local(
+        str(source),
+        str(tmp_path / 'backups'),
+        tournament_id=7,
+    )
+
+    assert result['ok'] is True
+    assert len(calls) == 1
+    assert calls[0][1] == result['dest']
+
+
+def test_postgres_local_backup_publishes_only_complete_archive(tmp_path, monkeypatch):
+    from services import backup
+
+    def fake_pg_dump(args, **_kwargs):
+        output = next(value.split('=', 1)[1] for value in args if value.startswith('--file='))
+        Path(output).write_bytes(b'PGDMP\x01synthetic-archive')
+        return SimpleNamespace(returncode=0, stderr='')
+
+    monkeypatch.setattr(backup.subprocess, 'run', fake_pg_dump)
+    result = backup.backup_pg_to_local(
+        'postgresql://proam:proam@localhost/proam',
+        str(tmp_path),
+        tournament_id=17,
+    )
+
+    assert result['ok'] is True
+    assert Path(result['dest']).read_bytes() == b'PGDMP\x01synthetic-archive'
+    assert result['sha256'] == backup.sha256_file(result['dest'])
+    assert not list(tmp_path.glob('.proam_pg_backup_*.tmp'))
+
+
+def test_failed_postgres_dump_leaves_no_final_or_partial_archive(tmp_path, monkeypatch):
+    from services import backup
+
+    def failed_pg_dump(args, **_kwargs):
+        output = next(value.split('=', 1)[1] for value in args if value.startswith('--file='))
+        Path(output).write_bytes(b'partial')
+        return SimpleNamespace(returncode=1, stderr='synthetic failure')
+
+    monkeypatch.setattr(backup.subprocess, 'run', failed_pg_dump)
+    result = backup.backup_pg_to_local(
+        'postgresql://proam:proam@localhost/proam',
+        str(tmp_path),
+        tournament_id=17,
+    )
+
+    assert result['ok'] is False
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_postgres_s3_failure_falls_back_to_local_backup(tmp_path, monkeypatch):
+    from services import backup
+
+    local_calls = []
+    monkeypatch.setenv('LOCAL_BACKUP_DIR', str(tmp_path))
+    monkeypatch.setattr(backup, 'is_s3_configured', lambda: True)
+    monkeypatch.setattr(
+        backup,
+        'backup_pg_to_s3',
+        lambda *_args: {'ok': False, 'error': 'synthetic S3 outage'},
+    )
+
+    def local_backup(db_uri, dest_dir, tournament_id):
+        local_calls.append((db_uri, dest_dir, tournament_id))
+        return {'ok': True, 'dest': str(tmp_path / 'fallback.dump')}
+
+    monkeypatch.setattr(backup, 'backup_pg_to_local', local_backup)
+    result = backup.backup_database(
+        'postgresql://proam:proam@localhost/proam',
+        tournament_id=17,
+    )
+
+    assert result['ok'] is True
+    assert result['fallback_from'] == 's3'
+    assert result['primary_error'] == 'synthetic S3 outage'
+    assert local_calls == [
+        (
+            'postgresql://proam:proam@localhost/proam',
+            str(tmp_path),
+            17,
+        )
+    ]
+
+
+def test_sqlite_s3_failure_falls_back_to_local_backup(tmp_path, monkeypatch):
+    from services import backup
+
+    source = tmp_path / 'source.db'
+    source.write_bytes(b'SQLite format 3\x00synthetic')
+    local_calls = []
+    monkeypatch.setenv('LOCAL_BACKUP_DIR', str(tmp_path / 'backups'))
+    monkeypatch.setattr(backup, 'is_s3_configured', lambda: True)
+    monkeypatch.setattr(
+        backup,
+        'backup_to_s3',
+        lambda *_args: {'ok': False, 'error': 'synthetic S3 outage'},
+    )
+
+    def local_backup(db_path, dest_dir, tournament_id):
+        local_calls.append((db_path, dest_dir, tournament_id))
+        return {'ok': True, 'dest': str(tmp_path / 'fallback.db')}
+
+    monkeypatch.setattr(backup, 'backup_to_local', local_backup)
+    result = backup.backup_database(
+        f'sqlite:///{source}',
+        tournament_id=9,
+    )
+
+    assert result['ok'] is True
+    assert result['fallback_from'] == 's3'
+    assert result['primary_error'] == 'synthetic S3 outage'
+    assert local_calls == [
+        (str(source), str(tmp_path / 'backups'), 9)
+    ]
+
+
+def test_same_second_local_backups_use_distinct_artifact_names(tmp_path, monkeypatch):
+    from services import backup
+
+    source = tmp_path / 'source.db'
+    connection = sqlite3.connect(source)
+    connection.execute('CREATE TABLE evidence (value INTEGER NOT NULL)')
+    connection.commit()
+    connection.close()
+    destination = tmp_path / 'backups'
+    monkeypatch.setattr(backup, '_timestamp', lambda: '20270818_120000')
+
+    first = backup.backup_to_local(str(source), str(destination), tournament_id=9)
+    second = backup.backup_to_local(str(source), str(destination), tournament_id=9)
+
+    assert first['ok'] is True
+    assert second['ok'] is True
+    assert first['dest'] != second['dest']
+    assert Path(first['dest']).is_file()
+    assert Path(second['dest']).is_file()
 
 
 def test_submit_database_backup_job_is_tournament_bound(monkeypatch):
@@ -63,6 +302,62 @@ def test_submit_database_backup_job_is_tournament_bound(monkeypatch):
     assert captured['args'] == ('sqlite:///proam.db', 42, '/instance')
     assert captured['metadata'] == {'tournament_id': 42, 'kind': 'backup'}
     assert captured['kwargs'] == {}
+
+
+def test_restore_route_validates_and_stages_without_replacing_database(
+    app, db_session, auth_client, admin_user, monkeypatch,
+):
+    from models.audit_log import AuditLog
+    from models.tournament import Tournament
+    from tests.conftest import make_tournament
+
+    tournament = make_tournament(db_session)
+    db_session.commit()
+    captured = {}
+    monkeypatch.setitem(
+        app.config,
+        'SQLALCHEMY_DATABASE_URI',
+        'sqlite:///synthetic-stage.db',
+    )
+
+    def _stage(**kwargs):
+        captured.update(kwargs)
+        assert os.path.exists(kwargs['upload_path'])
+        return {
+            'ok': True,
+            'stage_id': 'stage-123',
+            'source_sha256': 'a' * 64,
+        }
+
+    monkeypatch.setattr('routes.reporting.stage_sqlite_restore', _stage)
+
+    response = auth_client.post(
+        f'/reporting/{tournament.id}/restore',
+        data={
+            'backup_file': (
+                io.BytesIO(b'SQLite format 3\x00synthetic'),
+                'recovery.db',
+            )
+        },
+        content_type='multipart/form-data',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert captured['tournament_id'] == tournament.id
+    assert captured['source_filename'] == 'recovery.db'
+    assert captured['actor'].startswith('user:')
+    assert db_session.get(Tournament, tournament.id).name == tournament.name
+    assert AuditLog.query.filter_by(
+        action='database_restore_staged', entity_id=tournament.id,
+    ).count() == 1
+    assert AuditLog.query.filter_by(
+        action='database_restored', entity_id=tournament.id,
+    ).count() == 0
+    AuditLog.query.filter_by(entity_id=tournament.id).delete()
+    db_session.delete(tournament)
+    db_session.delete(admin_user)
+    db_session.commit()
 
 
 def test_restore_refuses_on_non_sqlite_engines(app, db_session, auth_client, monkeypatch):

--- a/tests/test_reporting_export.py
+++ b/tests/test_reporting_export.py
@@ -1,4 +1,6 @@
+import hashlib
 import os
+import time
 
 
 def test_build_results_export_returns_file_metadata(app, monkeypatch):
@@ -28,6 +30,7 @@ def test_build_results_export_returns_file_metadata(app, monkeypatch):
         'download_name': 'Export_Smoke_2026_results.xlsx',
         'format': 'xlsx',
         'kind': 'all_results',
+        'sha256': hashlib.sha256(b'xlsx').hexdigest(),
     }
     assert os.path.exists(out)
     os.remove(out)
@@ -85,11 +88,227 @@ def test_submit_results_export_job_is_tournament_bound(monkeypatch):
     assert captured['kwargs'] == {}
 
 
-def test_resolve_completed_export_path_rejects_cross_tournament_jobs():
+def test_resolve_completed_export_path_rejects_cross_tournament_jobs(tmp_path):
     from services.reporting_export import resolve_completed_export_path
 
+    artifact = tmp_path / 'out.xlsx'
+    artifact.write_bytes(b'xlsx')
+
     def _get_job(_job_id):
-        return {'metadata': {'tournament_id': 7}, 'status': 'completed', 'result': 'out.xlsx'}
+        return {
+            'metadata': {'tournament_id': 7, 'kind': 'export_results'},
+            'status': 'completed',
+            'result': {
+                'path': str(artifact),
+                'sha256': hashlib.sha256(b'xlsx').hexdigest(),
+            },
+        }
 
     assert resolve_completed_export_path(8, 'job-1', _get_job) is None
-    assert resolve_completed_export_path(7, 'job-1', _get_job)['result'] == 'out.xlsx'
+    resolved = resolve_completed_export_path(7, 'job-1', _get_job)
+    assert resolved['status'] == 'completed'
+    assert resolved['result']['path'] == str(artifact)
+
+
+def test_resolve_completed_export_path_expires_missing_artifact_after_restart(tmp_path):
+    from services.reporting_export import resolve_completed_export_path
+
+    missing = tmp_path / 'missing.xlsx'
+    job = {
+        'metadata': {'tournament_id': 7, 'kind': 'export_results'},
+        'status': 'completed',
+        'result': {
+            'path': str(missing),
+            'sha256': hashlib.sha256(b'xlsx').hexdigest(),
+        },
+    }
+
+    resolved = resolve_completed_export_path(7, 'job-1', lambda _job_id: job)
+
+    assert resolved['status'] == 'expired'
+    assert 'no longer exists' in resolved['error']
+
+
+def test_export_artifact_cleanup_expires_old_files_and_bounds_count(tmp_path):
+    from services.reporting_export import prune_export_artifacts
+
+    now = time.time()
+    old = tmp_path / 'proam_export_1_old.xlsx'
+    old.write_bytes(b'old')
+    os.utime(old, (now - 7200, now - 7200))
+    fresh = []
+    for index in range(3):
+        path = tmp_path / f'proam_export_1_fresh_{index}.xlsx'
+        path.write_bytes(str(index).encode())
+        os.utime(path, (now + index, now + index))
+        fresh.append(path)
+    unrelated = tmp_path / 'another-project.xlsx'
+    unrelated.write_bytes(b'keep')
+
+    removed = prune_export_artifacts(
+        directory=str(tmp_path),
+        now=now,
+        max_age_seconds=3600,
+        max_files=2,
+    )
+
+    assert removed == 2
+    assert not old.exists()
+    assert not fresh[0].exists()
+    assert fresh[1].exists()
+    assert fresh[2].exists()
+    assert unrelated.exists()
+
+
+def test_resolve_completed_export_path_expires_tampered_artifact(tmp_path):
+    from services.reporting_export import resolve_completed_export_path
+
+    artifact = tmp_path / 'tampered.xlsx'
+    artifact.write_bytes(b'original')
+    job = {
+        'metadata': {'tournament_id': 7, 'kind': 'video_judge_sheets'},
+        'status': 'completed',
+        'result': {
+            'path': str(artifact),
+            'sha256': hashlib.sha256(b'original').hexdigest(),
+        },
+    }
+    artifact.write_bytes(b'changed')
+
+    resolved = resolve_completed_export_path(7, 'job-1', lambda _job_id: job)
+
+    assert resolved['status'] == 'expired'
+    assert 'checksum' in resolved['error'].lower()
+
+
+def test_resolve_completed_export_path_expires_legacy_result_without_checksum(tmp_path):
+    from services.reporting_export import resolve_completed_export_path
+
+    artifact = tmp_path / 'legacy.xlsx'
+    artifact.write_bytes(b'xlsx')
+    job = {
+        'metadata': {'tournament_id': 7, 'kind': 'export_results'},
+        'status': 'completed',
+        'result': str(artifact),
+    }
+
+    resolved = resolve_completed_export_path(7, 'job-1', lambda _job_id: job)
+
+    assert resolved['status'] == 'expired'
+    assert 'checksum metadata' in resolved['error'].lower()
+
+
+def test_export_job_route_downloads_checksum_verified_artifact(
+    auth_client, db_session, monkeypatch, tmp_path,
+):
+    from models import Tournament
+    from routes import reporting
+
+    artifact = tmp_path / 'verified.xlsx'
+    artifact.write_bytes(b'verified-xlsx')
+    tournament = Tournament(name='Verified Export', year=2027, status='setup')
+    db_session.add(tournament)
+    db_session.flush()
+    tournament_id = tournament.id
+    job = {
+        'metadata': {'tournament_id': tournament_id, 'kind': 'export_results'},
+        'status': 'completed',
+        'result': {
+            'path': str(artifact),
+            'sha256': hashlib.sha256(b'verified-xlsx').hexdigest(),
+        },
+    }
+    monkeypatch.setattr(reporting, 'get_job', lambda _job_id: job)
+
+    response = auth_client.get(f'/reporting/{tournament_id}/jobs/export-job')
+
+    assert response.status_code == 200
+    assert response.data == b'verified-xlsx'
+    assert 'results.xlsx' in response.headers['Content-Disposition']
+    assert artifact.exists()
+
+    retry = auth_client.get(f'/reporting/{tournament_id}/jobs/export-job')
+    assert retry.status_code == 200
+    assert retry.data == b'verified-xlsx'
+
+
+def test_export_job_route_rechecks_same_handle_after_status_resolution(
+    auth_client, db_session, monkeypatch, tmp_path,
+):
+    from models import Tournament
+    from routes import reporting
+
+    artifact = tmp_path / 'replaced-after-status.xlsx'
+    artifact.write_bytes(b'original')
+    tournament = Tournament(name='Raced Export', year=2027, status='setup')
+    db_session.add(tournament)
+    db_session.flush()
+    tournament_id = tournament.id
+    job = {
+        'metadata': {'tournament_id': tournament_id, 'kind': 'export_results'},
+        'status': 'completed',
+        'result': {
+            'path': str(artifact),
+            'sha256': hashlib.sha256(b'original').hexdigest(),
+        },
+    }
+    real_resolve = reporting.resolve_completed_export_path
+
+    def resolve_then_replace(*args, **kwargs):
+        resolved = real_resolve(*args, **kwargs)
+        artifact.write_bytes(b'replacement')
+        return resolved
+
+    monkeypatch.setattr(reporting, 'get_job', lambda _job_id: job)
+    monkeypatch.setattr(
+        reporting,
+        'resolve_completed_export_path',
+        resolve_then_replace,
+    )
+
+    response = auth_client.get(
+        f'/reporting/{tournament_id}/jobs/export-job',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    with auth_client.session_transaction() as session:
+        assert any(
+            category == 'error' and 'checksum verification failed' in message
+            for category, message in session.get('_flashes', [])
+        )
+
+
+def test_export_job_route_redirects_tampered_artifact(
+    auth_client, db_session, monkeypatch, tmp_path,
+):
+    from models import Tournament
+    from routes import reporting
+
+    artifact = tmp_path / 'tampered-route.xlsx'
+    artifact.write_bytes(b'changed')
+    tournament = Tournament(name='Tampered Export', year=2027, status='setup')
+    db_session.add(tournament)
+    db_session.flush()
+    tournament_id = tournament.id
+    job = {
+        'metadata': {'tournament_id': tournament_id, 'kind': 'export_results'},
+        'status': 'completed',
+        'result': {
+            'path': str(artifact),
+            'sha256': hashlib.sha256(b'original').hexdigest(),
+        },
+    }
+    monkeypatch.setattr(reporting, 'get_job', lambda _job_id: job)
+
+    response = auth_client.get(
+        f'/reporting/{tournament_id}/jobs/export-job',
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    with auth_client.session_transaction() as session:
+        assert any(
+            category == 'error' and 'checksum verification failed' in message
+            for category, message in session.get('_flashes', [])
+        )

--- a/tests/test_restore_workflow.py
+++ b/tests/test_restore_workflow.py
@@ -1,15 +1,28 @@
 from __future__ import annotations
 
+import json
+import os
 import shutil
 import sqlite3
+import subprocess
+import sys
+import textwrap
 import uuid
 from pathlib import Path
 
 import pytest
 
+import services.restore_workflow as restore_workflow
 from services.restore_workflow import (
+    MaintenanceFenceBusy,
+    RestoreValidationError,
+    apply_staged_sqlite_restore,
+    configure_sqlite_process_fence,
+    database_activity_fence,
     prepare_sqlite_restore,
+    sha256_file,
     sqlite_db_path_from_uri,
+    stage_sqlite_restore,
     validate_sqlite_restore_file,
 )
 
@@ -22,15 +35,119 @@ def workspace_tmpdir() -> Path:
     shutil.rmtree(path, ignore_errors=True)
 
 
-def _make_sqlite_db(path, *, revision='rev1', tables=None):
+def _make_sqlite_db(
+    path,
+    *,
+    revision='rev1',
+    tables=None,
+    tournament=(1, 'Missoula Pro-Am', 2027),
+    tournaments=None,
+    marker='original',
+    invalid_foreign_key=False,
+):
     tables = tables or {'tournaments', 'events', 'event_results', 'heats', 'users'}
+    tournament_rows = list(tournaments) if tournaments is not None else [tournament]
     conn = sqlite3.connect(path)
     try:
+        conn.execute('PRAGMA foreign_keys=ON')
         conn.execute('CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)')
         conn.execute('INSERT INTO alembic_version (version_num) VALUES (?)', (revision,))
-        for table in tables:
-            conn.execute(f'CREATE TABLE {table} (id INTEGER PRIMARY KEY)')
+        if 'tournaments' in tables:
+            conn.execute(
+                'CREATE TABLE tournaments ('
+                'id INTEGER PRIMARY KEY, name VARCHAR(200) NOT NULL, '
+                'year INTEGER NOT NULL, status VARCHAR(50) NOT NULL DEFAULT "setup", '
+                'providing_shirts BOOLEAN NOT NULL DEFAULT 0, '
+                'schedule_config TEXT)'
+            )
+            conn.executemany(
+                'INSERT INTO tournaments (id, name, year) VALUES (?, ?, ?)',
+                tournament_rows,
+            )
+        if 'users' in tables:
+            conn.execute(
+                'CREATE TABLE users ('
+                'id INTEGER PRIMARY KEY, username VARCHAR(80) NOT NULL UNIQUE, '
+                'password_hash VARCHAR(255) NOT NULL, role VARCHAR(20) NOT NULL, '
+                'tournament_id INTEGER REFERENCES tournaments(id) ON DELETE SET NULL, '
+                'display_name VARCHAR(200), is_active_user BOOLEAN NOT NULL DEFAULT 1)'
+            )
+            conn.execute('CREATE INDEX ix_users_tournament_id ON users(tournament_id)')
+        if 'events' in tables:
+            conn.execute(
+                'CREATE TABLE events ('
+                'id INTEGER PRIMARY KEY, tournament_id INTEGER NOT NULL '
+                'REFERENCES tournaments(id) ON DELETE CASCADE, '
+                'name VARCHAR(200) NOT NULL, event_type VARCHAR(20) NOT NULL, '
+                'scoring_type VARCHAR(20) NOT NULL, '
+                'scoring_order VARCHAR(20) NOT NULL DEFAULT "lowest_wins", '
+                'status VARCHAR(20) NOT NULL DEFAULT "pending", '
+                'is_finalized BOOLEAN NOT NULL DEFAULT 0)'
+            )
+            conn.execute(
+                'CREATE INDEX ix_events_tournament_type_status '
+                'ON events(tournament_id, event_type, status)'
+            )
+        if 'heats' in tables:
+            conn.execute(
+                'CREATE TABLE heats ('
+                'id INTEGER PRIMARY KEY, event_id INTEGER NOT NULL '
+                'REFERENCES events(id) ON DELETE CASCADE, '
+                'heat_number INTEGER NOT NULL, run_number INTEGER NOT NULL DEFAULT 1, '
+                'status VARCHAR(20) NOT NULL DEFAULT "pending", '
+                'version_id INTEGER NOT NULL DEFAULT 1, '
+                'locked_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL, '
+                'UNIQUE(event_id, heat_number, run_number))'
+            )
+            conn.execute('CREATE INDEX ix_heats_event_status ON heats(event_id, status)')
+        if 'event_results' in tables:
+            conn.execute(
+                'CREATE TABLE event_results ('
+                'id INTEGER PRIMARY KEY, event_id INTEGER NOT NULL '
+                'REFERENCES events(id) ON DELETE CASCADE, '
+                'heat_id INTEGER REFERENCES heats(id) ON DELETE SET NULL, '
+                'competitor_id INTEGER NOT NULL, competitor_type VARCHAR(20) NOT NULL, '
+                'result_value REAL, final_position INTEGER, '
+                'points_awarded NUMERIC(6, 2) NOT NULL DEFAULT 0, '
+                'status VARCHAR(20) NOT NULL DEFAULT "pending", '
+                'version_id INTEGER NOT NULL DEFAULT 1, '
+                'UNIQUE(event_id, competitor_id, competitor_type))'
+            )
+            conn.execute(
+                'CREATE INDEX ix_event_results_event_status '
+                'ON event_results(event_id, status)'
+            )
+        conn.execute('CREATE TABLE restore_marker (value TEXT NOT NULL)')
+        conn.execute('INSERT INTO restore_marker VALUES (?)', (marker,))
+        conn.execute(
+            'CREATE TABLE audit_logs ('
+            'id INTEGER PRIMARY KEY, action TEXT NOT NULL, details_json TEXT)'
+        )
+        conn.execute(
+            'INSERT INTO audit_logs (action, details_json) VALUES (?, ?)',
+            ('fixture_created', '{}'),
+        )
+        conn.execute(
+            'CREATE TABLE parent_rows (id INTEGER PRIMARY KEY)'
+        )
+        conn.execute(
+            'CREATE TABLE child_rows ('
+            'id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL '
+            'REFERENCES parent_rows(id))'
+        )
+        if invalid_foreign_key:
+            conn.commit()
+            conn.execute('PRAGMA foreign_keys=OFF')
+            conn.execute('INSERT INTO child_rows VALUES (1, 999)')
         conn.commit()
+    finally:
+        conn.close()
+
+
+def _marker(path: Path) -> str:
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute('SELECT value FROM restore_marker').fetchone()[0]
     finally:
         conn.close()
 
@@ -41,11 +158,21 @@ def test_validate_sqlite_restore_file_accepts_matching_schema(workspace_tmpdir):
     _make_sqlite_db(current, revision='head')
     _make_sqlite_db(upload, revision='head')
 
-    result = validate_sqlite_restore_file(str(upload), str(current))
+    result = validate_sqlite_restore_file(
+        str(upload), str(current), tournament_id=1,
+    )
 
     assert result['target_path'] == str(current)
     assert result['current_revision'] == 'head'
     assert result['uploaded_revision'] == 'head'
+    assert result['integrity_check'] == 'ok'
+    assert result['foreign_key_violations'] == 0
+    assert result['tournament_identity_matches'] is True
+    assert result['database_identity_matches'] is True
+    assert result['database_identity_tournament_count'] == 1
+    assert result['required_schema_matches'] is True
+    assert len(result['database_identity_sha256']) == 64
+    assert len(result['required_schema_sha256']) == 64
 
 
 def test_validate_sqlite_restore_file_rejects_missing_tables(workspace_tmpdir):
@@ -55,7 +182,7 @@ def test_validate_sqlite_restore_file_rejects_missing_tables(workspace_tmpdir):
     _make_sqlite_db(upload, revision='head', tables={'tournaments'})
 
     with pytest.raises(RuntimeError, match='missing required tables'):
-        validate_sqlite_restore_file(str(upload), str(current))
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
 
 
 def test_validate_sqlite_restore_file_rejects_revision_mismatch(workspace_tmpdir):
@@ -65,7 +192,115 @@ def test_validate_sqlite_restore_file_rejects_revision_mismatch(workspace_tmpdir
     _make_sqlite_db(upload, revision='old')
 
     with pytest.raises(RuntimeError, match='schema revision does not match'):
-        validate_sqlite_restore_file(str(upload), str(current))
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
+
+
+def test_validate_sqlite_restore_file_rejects_foreign_key_damage(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head', invalid_foreign_key=True)
+
+    with pytest.raises(RestoreValidationError, match='foreign key'):
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
+
+
+def test_validate_sqlite_restore_file_rejects_wrong_tournament(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(
+        upload,
+        revision='head',
+        tournament=(1, 'Different Tournament', 2027),
+    )
+
+    with pytest.raises(RestoreValidationError, match='tournament identity'):
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
+
+
+def test_validate_sqlite_restore_file_rejects_required_table_structure_drift(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head')
+    conn = sqlite3.connect(upload)
+    try:
+        conn.execute('DROP INDEX ix_events_tournament_type_status')
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(RestoreValidationError, match='required-table structure'):
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
+
+
+def test_validate_sqlite_restore_file_rejects_missing_application_table(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head')
+    conn = sqlite3.connect(current)
+    try:
+        conn.execute(
+            'CREATE TABLE score_submission_receipts ('
+            'request_id VARCHAR(36) PRIMARY KEY, '
+            'payload_sha256 VARCHAR(64) NOT NULL)'
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(RestoreValidationError, match='application tables'):
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
+
+
+def test_validate_sqlite_restore_file_rejects_noncore_schema_drift(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head')
+    conn = sqlite3.connect(upload)
+    try:
+        conn.execute('CREATE INDEX ix_audit_logs_action ON audit_logs(action)')
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(RestoreValidationError, match='application-table structure'):
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
+
+
+def test_validate_sqlite_restore_file_rejects_full_tournament_set_mismatch(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(
+        current,
+        revision='head',
+        tournaments=[
+            (1, 'Missoula Pro-Am', 2027),
+            (2, 'Missoula Pro-Am', 2026),
+        ],
+    )
+    _make_sqlite_db(
+        upload,
+        revision='head',
+        tournaments=[
+            (1, 'Missoula Pro-Am', 2027),
+            (2, 'Unrelated Tournament', 2026),
+        ],
+    )
+
+    with pytest.raises(RestoreValidationError, match='database identity'):
+        validate_sqlite_restore_file(str(upload), str(current), tournament_id=1)
 
 
 def test_sqlite_db_path_from_uri_rejects_non_sqlite(workspace_tmpdir):
@@ -89,9 +324,484 @@ def test_prepare_sqlite_restore_runs_scan_and_returns_plan(workspace_tmpdir, mon
         upload_path=str(upload),
         db_uri='sqlite:///current.db',
         instance_path=str(workspace_tmpdir),
+        tournament_id=1,
         malware_scan_enabled=True,
         malware_scan_command='scan {path}',
     )
 
     assert result['target_path'] == str(current)
     assert calls == [(str(upload), True, 'scan {path}')]
+
+
+def test_stage_restore_writes_fsynced_package_manifest(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+
+    result = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+
+    package_dir = Path(result['package_dir'])
+    manifest = json.loads((package_dir / 'manifest.json').read_text(encoding='utf-8'))
+    staged_db = package_dir / 'restore.db'
+    assert package_dir.parent == workspace_tmpdir / '.restore-staging'
+    assert manifest['status'] == 'staged'
+    assert manifest['tournament_id'] == 1
+    assert manifest['source_sha256'] == sha256_file(staged_db)
+    assert manifest['target_sha256_at_stage'] == sha256_file(current)
+    assert manifest['actor'] == 'admin:7'
+    assert manifest['source_filename'] == 'race-day.db'
+    assert len(manifest['required_schema_sha256']) == 64
+    assert len(manifest['database_identity_sha256']) == 64
+    assert manifest['database_identity_tournament_count'] == 1
+
+
+def test_stage_restore_restricts_package_database_and_journal_modes(
+    workspace_tmpdir,
+    monkeypatch,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    restricted = []
+
+    monkeypatch.setattr(
+        restore_workflow,
+        '_chmod_if_supported',
+        lambda path, mode: restricted.append((Path(path), mode)),
+    )
+
+    result = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+
+    package_dir = Path(result['package_dir'])
+    assert (package_dir.parent, 0o700) in restricted
+    assert (package_dir, 0o700) in restricted
+    assert (package_dir / 'restore.db', 0o600) in restricted
+    assert (package_dir / 'restore-journal.jsonl', 0o600) in restricted
+    assert (package_dir / 'manifest.json', 0o600) in restricted
+
+
+def test_failed_stage_removes_incomplete_plaintext_package(
+    workspace_tmpdir,
+    monkeypatch,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    actual_copy = restore_workflow.shutil.copyfile
+
+    def copy_then_fail(source, destination):
+        actual_copy(source, destination)
+        raise RuntimeError('injected staging failure')
+
+    monkeypatch.setattr(restore_workflow.shutil, 'copyfile', copy_then_fail)
+
+    with pytest.raises(RuntimeError, match='injected staging failure'):
+        stage_sqlite_restore(
+            upload_path=str(upload),
+            db_uri='sqlite:///current.db',
+            instance_path=str(workspace_tmpdir),
+            tournament_id=1,
+            actor='admin:7',
+            source_filename='race-day.db',
+        )
+
+    staging_root = workspace_tmpdir / '.restore-staging'
+    assert not list(staging_root.glob('*/restore.db'))
+    assert not [path for path in staging_root.iterdir() if path.is_dir()]
+
+
+def test_windows_restore_acl_is_explicit_and_verified(tmp_path, monkeypatch):
+    package_dir = tmp_path / 'restore-package'
+    package_dir.mkdir()
+    calls = []
+
+    def successful_acl(command, **kwargs):
+        calls.append((command, kwargs))
+        return type('Result', (), {'returncode': 0, 'stdout': '', 'stderr': ''})()
+
+    monkeypatch.setattr(restore_workflow.subprocess, 'run', successful_acl)
+
+    restore_workflow._restrict_windows_acl(package_dir)
+
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert 'SetAccessRuleProtection($true, $false)' in command[-1]
+    assert 'SetAccessControl($acl)' in command[-1]
+    assert 'GetAccessRules(' in command[-1]
+    assert kwargs['env']['PROAM_RESTORE_ACL_TARGET'] == str(package_dir)
+    assert kwargs['check'] is False
+    assert kwargs['timeout'] == 30
+
+
+@pytest.mark.parametrize(
+    'fail_at',
+    [
+        'before_safety_snapshot',
+        'after_safety_snapshot',
+        'before_replace',
+        'after_replace',
+        'before_reopen',
+        'after_reopen',
+        'before_post_validation',
+        'after_post_validation',
+    ],
+)
+def test_offline_restore_failure_leaves_old_valid_database(
+    workspace_tmpdir, fail_at,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head', marker='original')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    staged = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+
+    with pytest.raises(RuntimeError, match='Injected restore failure'):
+        apply_staged_sqlite_restore(
+            staged['package_dir'],
+            actor='maintenance:test',
+            fail_at=fail_at,
+        )
+
+    assert _marker(current) == 'original'
+    validation = validate_sqlite_restore_file(
+        str(current), str(current), tournament_id=1,
+    )
+    assert validation['integrity_check'] == 'ok'
+    journal = (Path(staged['package_dir']) / 'restore-journal.jsonl').read_text(
+        encoding='utf-8'
+    )
+    assert 'rollback' in journal or fail_at.startswith('before_')
+
+
+@pytest.mark.parametrize(
+    'fail_at',
+    [
+        'after_quarantine_wal',
+        'after_quarantine_shm',
+        'after_sidecar_quarantine',
+    ],
+)
+def test_sidecar_quarantine_failure_rolls_back_without_reattaching_stale_pages(
+    workspace_tmpdir,
+    monkeypatch,
+    fail_at,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head', marker='original')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    staged = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+    original_snapshot = restore_workflow.create_sqlite_snapshot
+
+    def _snapshot_then_create_stale_sidecars(source_path, destination_path):
+        result = original_snapshot(source_path, destination_path)
+        Path(f'{source_path}-wal').write_bytes(b'stale-wal-pages')
+        Path(f'{source_path}-shm').write_bytes(b'stale-shared-memory')
+        return result
+
+    monkeypatch.setattr(
+        restore_workflow,
+        'create_sqlite_snapshot',
+        _snapshot_then_create_stale_sidecars,
+    )
+
+    with pytest.raises(RuntimeError, match='Injected restore failure'):
+        apply_staged_sqlite_restore(
+            staged['package_dir'],
+            actor='maintenance:test',
+            fail_at=fail_at,
+        )
+
+    assert _marker(current) == 'original'
+    assert not Path(f'{current}-wal').exists()
+    assert not Path(f'{current}-shm').exists()
+    quarantine_dir = Path(staged['package_dir']) / 'sidecar-quarantine'
+    assert list(quarantine_dir.glob('*-wal'))
+    assert list(quarantine_dir.glob('*-shm'))
+    journal = (Path(staged['package_dir']) / 'restore-journal.jsonl').read_text(
+        encoding='utf-8'
+    )
+    assert 'sidecar_quarantined' in journal
+    assert 'rollback_completed' in journal
+
+
+def test_next_boot_recovers_after_abrupt_exit_during_sidecar_quarantine(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head', marker='original')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    staged = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+    crash_script = textwrap.dedent(
+        """
+        import os
+        import sys
+        from pathlib import Path
+
+        import services.restore_workflow as restore_workflow
+
+        original_snapshot = restore_workflow.create_sqlite_snapshot
+        original_inject = restore_workflow._inject_failure
+
+        def snapshot_then_create_stale_sidecars(source_path, destination_path):
+            result = original_snapshot(source_path, destination_path)
+            Path(f'{source_path}-wal').write_bytes(b'stale-wal-pages')
+            Path(f'{source_path}-shm').write_bytes(b'stale-shared-memory')
+            return result
+
+        def terminate_after_quarantine(fail_at, checkpoint):
+            if checkpoint == 'after_sidecar_quarantine':
+                os._exit(87)
+            original_inject(fail_at, checkpoint)
+
+        restore_workflow.create_sqlite_snapshot = snapshot_then_create_stale_sidecars
+        restore_workflow._inject_failure = terminate_after_quarantine
+        restore_workflow.apply_staged_sqlite_restore(
+            sys.argv[1], actor='maintenance:crash-test', fail_at='crash'
+        )
+        """
+    )
+
+    crashed = subprocess.run(
+        [sys.executable, '-c', crash_script, staged['package_dir']],
+        cwd=Path.cwd(),
+        env=os.environ.copy(),
+        check=False,
+    )
+
+    assert crashed.returncode == 87
+    manifest_path = Path(staged['package_dir']) / 'manifest.json'
+    interrupted_manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    assert interrupted_manifest['status'] == 'applying'
+    assert interrupted_manifest['phase'] == 'replace_sidecars_quarantined'
+    assert not Path(f'{current}-wal').exists()
+    assert not Path(f'{current}-shm').exists()
+
+    recovered = apply_staged_sqlite_restore(
+        staged['package_dir'], actor='maintenance:next-boot',
+    )
+
+    assert recovered['ok'] is True
+    assert _marker(current) == 'replacement'
+    assert not Path(f'{current}-wal').exists()
+    assert not Path(f'{current}-shm').exists()
+    journal = (Path(staged['package_dir']) / 'restore-journal.jsonl').read_text(
+        encoding='utf-8'
+    )
+    assert 'interrupted_apply' in journal
+    assert 'rollback_completed' in journal
+
+
+def test_next_boot_reconciles_sidecar_moved_before_manifest_update(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head', marker='original')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    staged = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+    crash_script = textwrap.dedent(
+        """
+        import os
+        import sys
+        from pathlib import Path
+
+        import services.restore_workflow as restore_workflow
+
+        original_snapshot = restore_workflow.create_sqlite_snapshot
+        original_inject = restore_workflow._inject_failure
+
+        def snapshot_then_create_stale_sidecars(source_path, destination_path):
+            result = original_snapshot(source_path, destination_path)
+            Path(f'{source_path}-wal').write_bytes(b'stale-wal-pages')
+            Path(f'{source_path}-shm').write_bytes(b'stale-shared-memory')
+            return result
+
+        def terminate_after_move(fail_at, checkpoint):
+            if checkpoint == 'after_sidecar_move_before_manifest_wal':
+                os._exit(88)
+            original_inject(fail_at, checkpoint)
+
+        restore_workflow.create_sqlite_snapshot = snapshot_then_create_stale_sidecars
+        restore_workflow._inject_failure = terminate_after_move
+        restore_workflow.apply_staged_sqlite_restore(
+            sys.argv[1], actor='maintenance:move-crash-test', fail_at='crash'
+        )
+        """
+    )
+
+    crashed = subprocess.run(
+        [sys.executable, '-c', crash_script, staged['package_dir']],
+        cwd=Path.cwd(),
+        env=os.environ.copy(),
+        check=False,
+    )
+
+    assert crashed.returncode == 88
+    package_dir = Path(staged['package_dir'])
+    interrupted = json.loads(
+        (package_dir / 'manifest.json').read_text(encoding='utf-8')
+    )
+    record = interrupted['sidecar_quarantines'][-1]
+    wal_entry = next(entry for entry in record['entries'] if entry['suffix'] == '-wal')
+    assert wal_entry['status'] == 'move_pending'
+    assert len(wal_entry['source_sha256']) == 64
+    assert not Path(f'{current}-wal').exists()
+    assert (package_dir / 'sidecar-quarantine' / wal_entry['quarantine_name']).is_file()
+
+    recovered = apply_staged_sqlite_restore(
+        staged['package_dir'], actor='maintenance:next-boot',
+    )
+
+    assert recovered['ok'] is True
+    completed = json.loads(
+        (package_dir / 'manifest.json').read_text(encoding='utf-8')
+    )
+    original_record = next(
+        item for item in completed['sidecar_quarantines']
+        if item['attempt_id'] == record['attempt_id']
+    )
+    assert original_record['status'] == 'completed'
+    assert all(
+        entry['status'] in {'absent', 'quarantined'}
+        for entry in original_record['entries']
+    )
+    journal = (package_dir / 'restore-journal.jsonl').read_text(encoding='utf-8')
+    assert 'sidecar_quarantine_reconciled' in journal
+
+
+def test_offline_restore_applies_validated_database_and_journals_hashes(
+    workspace_tmpdir,
+):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head', marker='original')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    staged = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+
+    result = apply_staged_sqlite_restore(
+        staged['package_dir'], actor='maintenance:test',
+    )
+
+    assert result['ok'] is True
+    assert result['status'] == 'completed'
+    assert _marker(current) == 'replacement'
+    entries = [
+        json.loads(line)
+        for line in (Path(staged['package_dir']) / 'restore-journal.jsonl')
+        .read_text(encoding='utf-8')
+        .splitlines()
+    ]
+    assert entries[-1]['event'] == 'restore_completed'
+    assert entries[-1]['source_sha256'] == sha256_file(current)
+    assert entries[-1]['safety_sha256']
+    assert entries[-1]['audit_chain_head']
+    assert all('details_json' not in entry for entry in entries)
+
+
+def test_offline_restore_refuses_while_web_process_fence_is_held(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    upload = workspace_tmpdir / 'upload.db'
+    _make_sqlite_db(current, revision='head', marker='original')
+    _make_sqlite_db(upload, revision='head', marker='replacement')
+    staged = stage_sqlite_restore(
+        upload_path=str(upload),
+        db_uri='sqlite:///current.db',
+        instance_path=str(workspace_tmpdir),
+        tournament_id=1,
+        actor='admin:7',
+        source_filename='race-day.db',
+    )
+
+    with database_activity_fence(str(current), exclusive=False, timeout=0):
+        with pytest.raises(RuntimeError, match='still running'):
+            apply_staged_sqlite_restore(
+                staged['package_dir'], actor='maintenance:test',
+            )
+
+    assert _marker(current) == 'original'
+
+
+def test_same_process_apps_share_one_sqlite_lifetime_fence(workspace_tmpdir):
+    current = workspace_tmpdir / 'current.db'
+    _make_sqlite_db(current, revision='head')
+
+    class TestApp:
+        def __init__(self):
+            self.config = {'SQLALCHEMY_DATABASE_URI': f'sqlite:///{current}'}
+            self.instance_path = str(workspace_tmpdir)
+            self.extensions = {}
+
+    first = TestApp()
+    second = TestApp()
+    configure_sqlite_process_fence(first)
+    configure_sqlite_process_fence(second)
+
+    assert first.extensions['sqlite_process_fence'] is second.extensions[
+        'sqlite_process_fence'
+    ]
+    with pytest.raises(MaintenanceFenceBusy):
+        with database_activity_fence(str(current), exclusive=True, timeout=0):
+            pass
+
+    first.extensions['sqlite_process_fence_finalizer']()
+    with pytest.raises(MaintenanceFenceBusy):
+        with database_activity_fence(str(current), exclusive=True, timeout=0):
+            pass
+
+    second.extensions['sqlite_process_fence_finalizer']()
+    with database_activity_fence(str(current), exclusive=True, timeout=0):
+        pass

--- a/tests/test_route_smoke.py
+++ b/tests/test_route_smoke.py
@@ -36,8 +36,8 @@ def _discover_routes() -> list[dict[str, object]]:
 ROUTE_SPECS = _discover_routes()
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _SOURCE_DB_ENV = os.environ.get("PROAM_ROUTE_SMOKE_SOURCE_DB", "").strip()
-SOURCE_DB = Path(_SOURCE_DB_ENV) if _SOURCE_DB_ENV else PROJECT_ROOT / "instance" / "proam.db"
-if not SOURCE_DB.is_absolute():
+SOURCE_DB = Path(_SOURCE_DB_ENV) if _SOURCE_DB_ENV else None
+if SOURCE_DB is not None and not SOURCE_DB.is_absolute():
     SOURCE_DB = PROJECT_ROOT / SOURCE_DB
 TMP_ROOT = PROJECT_ROOT / ".qa_tmp"
 
@@ -134,24 +134,28 @@ def _seed_minimal_smoke_data(app):
 
 @pytest.fixture()
 def smoke_env(monkeypatch):
-    """Return a fresh app/client pair backed by either a copied real DB
-    (local dev) or a freshly migrated + seeded DB (CI)."""
+    """Return an app/client backed by an isolated migrated database.
+
+    A source database is copied only when PROAM_ROUTE_SMOKE_SOURCE_DB is set
+    explicitly (CI supplies its synthetic fixture). Local runs default to the
+    same deterministic seed path instead of reading instance/proam.db.
+    """
     TMP_ROOT.mkdir(exist_ok=True)
     temp_dir = TMP_ROOT / f"route-smoke-{uuid.uuid4().hex}"
     temp_dir.mkdir()
     db_copy = temp_dir / "proam-copy.db"
 
-    use_real_db = SOURCE_DB.exists()
+    use_real_db = SOURCE_DB is not None and SOURCE_DB.exists()
     if use_real_db:
-        # D12-C commit F3: a copy of the developer database is only useful if
+        # D12-C commit F3: an explicitly supplied source is only useful if
         # the chain will run over it. Revision t9b3c4d5e6f7 refuses one that
         # holds a heat whose roster exists only in heats.competitors, which
         # any database stamped before D12-C commit E can be. Asking first
         # costs one chain replay per session; not asking cost 243 setup
         # errors, none of them about a route.
         #
-        # The fresh-DB branch below is the one CI has always taken, so
-        # falling back to it loses no coverage, and it replays the whole
+        # The fresh-DB branch is the baseline behavior, so falling back to it
+        # loses no coverage, and it replays the whole
         # chain itself, so a genuinely broken migration still fails loudly
         # there instead of hiding here. The only thing this can mask is a
         # bad source database, which is the thing it is reporting.
@@ -174,14 +178,13 @@ def smoke_env(monkeypatch):
     app = create_app()
     app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
 
-    # Migrate unconditionally, including the copied database.  A copy of
-    # instance/proam.db is stamped at whatever revision that developer's
-    # machine last ran, which is not necessarily head, and running these routes
-    # against a stale schema produces failures that look like route bugs.
+    # Migrate unconditionally, including an explicitly supplied copy. Its
+    # revision is not necessarily head, and running these routes against a
+    # stale schema produces failures that look like route bugs.
     # D12-C commit A is where this first bit: nine smoke tests failed with
     # "no such column: heat_assignments.uid" on a machine holding a dev
-    # database, and passed in CI, where SOURCE_DB does not exist and the
-    # fresh-DB branch below already migrated.  On a copy already at head this
+    # database, and passed in CI, where the seeded source is already at head.
+    # On a copy already at head this
     # is a no-op that costs one alembic_version read.
     from flask_migrate import upgrade
     migrations_dir = PROJECT_ROOT / "migrations"
@@ -409,7 +412,11 @@ def _run_smoke(route: dict[str, object], smoke_env) -> None:
 
     allowed = {200, 202, 301, 302, 403}
     if method == "POST":
-        allowed.add(400)
+        # Empty generic smoke payloads can be rejected by validation (400) or
+        # by a required stale-state token (409). Focused route tests prove the
+        # mutation contract; this suite proves every discovered route avoids a
+        # server error when called with a disposable authenticated fixture.
+        allowed.update({400, 409})
         allowed.update(_POST_ALLOWED_STATUS.get(endpoint, set()))
 
     assert response.status_code in allowed, (

--- a/tests/test_saw_block_integration.py
+++ b/tests/test_saw_block_integration.py
@@ -458,7 +458,10 @@ def test_reorder_flight_heats_triggers_recompute(app, auth_client):
     # Reverse two different events. Event-local heat sequencing stays valid.
     resp = auth_client.post(
         f"/scheduling/{tid}/flights/{fid}/reorder",
-        json={"heat_ids": [h_b_id, h_a_id]},
+        json={
+            "heat_ids": [h_b_id, h_a_id],
+            "expected_heat_ids": [h_a_id, h_b_id],
+        },
     )
     assert resp.status_code == 200
 
@@ -493,7 +496,10 @@ def test_reorder_flight_heats_rejects_out_of_order_event(app, auth_client):
 
     resp = auth_client.post(
         f"/scheduling/{tid}/flights/{fid}/reorder",
-        json={"heat_ids": [second_id, first_id]},
+        json={
+            "heat_ids": [second_id, first_id],
+            "expected_heat_ids": [first_id, second_id],
+        },
     )
 
     assert resp.status_code == 409
@@ -528,7 +534,10 @@ def test_reorder_flight_heats_rejects_completed_heat_move(app, auth_client):
 
     resp = auth_client.post(
         f"/scheduling/{tid}/flights/{fid}/reorder",
-        json={"heat_ids": [pending_id, completed_id]},
+        json={
+            "heat_ids": [pending_id, completed_id],
+            "expected_heat_ids": [completed_id, pending_id],
+        },
     )
 
     assert resp.status_code == 409
@@ -562,7 +571,10 @@ def test_reorder_flight_heats_rejects_duplicate_heat_id(app, auth_client):
 
     resp = auth_client.post(
         f"/scheduling/{tid}/flights/{fid}/reorder",
-        json={"heat_ids": [first_id, second_id, second_id]},
+        json={
+            "heat_ids": [first_id, second_id, second_id],
+            "expected_heat_ids": [first_id, second_id],
+        },
     )
 
     assert resp.status_code == 400
@@ -603,8 +615,16 @@ def test_bulk_reorder_moves_heat_between_flights(app, auth_client):
         f"/scheduling/{tid}/flights/bulk-reorder",
         json={
             "flights": [
-                {"flight_id": f1_id, "heat_ids": [h_a_id]},
-                {"flight_id": f2_id, "heat_ids": [h_b_id, h_c_id]},
+                {
+                    "flight_id": f1_id,
+                    "heat_ids": [h_a_id],
+                    "expected_heat_ids": [h_a_id, h_b_id],
+                },
+                {
+                    "flight_id": f2_id,
+                    "heat_ids": [h_b_id, h_c_id],
+                    "expected_heat_ids": [h_c_id],
+                },
             ]
         },
     )
@@ -647,8 +667,16 @@ def test_bulk_reorder_rejects_out_of_order_event(app, auth_client):
         f"/scheduling/{tid}/flights/bulk-reorder",
         json={
             "flights": [
-                {"flight_id": first_flight_id, "heat_ids": [second_id]},
-                {"flight_id": second_flight_id, "heat_ids": [first_id]},
+                {
+                    "flight_id": first_flight_id,
+                    "heat_ids": [second_id],
+                    "expected_heat_ids": [first_id],
+                },
+                {
+                    "flight_id": second_flight_id,
+                    "heat_ids": [first_id],
+                    "expected_heat_ids": [second_id],
+                },
             ]
         },
     )
@@ -690,8 +718,16 @@ def test_bulk_reorder_rejects_completed_heat_move(app, auth_client):
         f"/scheduling/{tid}/flights/bulk-reorder",
         json={
             "flights": [
-                {"flight_id": first_flight_id, "heat_ids": [pending_id]},
-                {"flight_id": second_flight_id, "heat_ids": [completed_id]},
+                {
+                    "flight_id": first_flight_id,
+                    "heat_ids": [pending_id],
+                    "expected_heat_ids": [completed_id],
+                },
+                {
+                    "flight_id": second_flight_id,
+                    "heat_ids": [completed_id],
+                    "expected_heat_ids": [pending_id],
+                },
             ]
         },
     )
@@ -732,8 +768,16 @@ def test_bulk_reorder_rejects_duplicate_heat_id(app, auth_client):
         f"/scheduling/{tid}/flights/bulk-reorder",
         json={
             "flights": [
-                {"flight_id": first_flight_id, "heat_ids": [first_id, second_id]},
-                {"flight_id": second_flight_id, "heat_ids": [second_id]},
+                {
+                    "flight_id": first_flight_id,
+                    "heat_ids": [first_id, second_id],
+                    "expected_heat_ids": [first_id],
+                },
+                {
+                    "flight_id": second_flight_id,
+                    "heat_ids": [second_id],
+                    "expected_heat_ids": [second_id],
+                },
             ]
         },
     )
@@ -764,10 +808,15 @@ def test_bulk_reorder_rejects_mismatched_heat_set(app, auth_client):
         _db.session.commit()
         tid, f1_id = t.id, f1.id
         h_a_id = h_a.id  # intentionally omit h_b from the payload
+        h_b_id = h_b.id
 
     resp = auth_client.post(
         f"/scheduling/{tid}/flights/bulk-reorder",
-        json={"flights": [{"flight_id": f1_id, "heat_ids": [h_a_id]}]},
+        json={"flights": [{
+            "flight_id": f1_id,
+            "heat_ids": [h_a_id],
+            "expected_heat_ids": [h_a_id, h_b_id],
+        }]},
     )
     assert resp.status_code == 400
     body = resp.get_json()
@@ -806,7 +855,10 @@ def test_reorder_rejects_new_shared_stand_conflict(app, auth_client):
 
     response = auth_client.post(
         f"/scheduling/{tournament_id}/flights/{flight_id}/reorder",
-        json={"heat_ids": [cookie_heat_id, standing_heat_id, *neutral_heat_ids]},
+        json={
+            "heat_ids": [cookie_heat_id, standing_heat_id, *neutral_heat_ids],
+            "expected_heat_ids": original_ids,
+        },
     )
 
     assert response.status_code == 409
@@ -861,6 +913,7 @@ def test_bulk_reorder_rejects_new_shared_stand_conflict(app, auth_client):
                     standing_heat_id,
                     *neutral_heat_ids,
                 ],
+                "expected_heat_ids": original_ids,
             }],
         },
     )
@@ -898,7 +951,10 @@ def test_reorder_keeps_preexisting_unavoidable_shared_stand_conflict(app, auth_c
 
     response = auth_client.post(
         f"/scheduling/{tournament_id}/flights/{flight_id}/reorder",
-        json={"heat_ids": [standing_heat_id, cookie_heat_id]},
+        json={
+            "heat_ids": [standing_heat_id, cookie_heat_id],
+            "expected_heat_ids": [cookie_heat_id, standing_heat_id],
+        },
     )
 
     assert response.status_code == 200, response.data

--- a/tests/test_scratch_cascade.py
+++ b/tests/test_scratch_cascade.py
@@ -338,7 +338,7 @@ def test_normalized_relay_membership_is_scratched_and_undone(app):
         relay_effect = next(e for e in effects if e.effect_type == "relay_team")
         assert relay_effect.metadata["source"] == "normalized"
 
-        execute_cascade(
+        scratched = execute_cascade(
             competitor, [relay_effect], judge_user_id=1, tournament=tournament,
         )
         db.session.commit()
@@ -349,6 +349,7 @@ def test_normalized_relay_membership_is_scratched_and_undone(app):
         undo = reverse_cascade(
             competitor.id, judge_user_id=1, tournament=tournament,
             competitor_type="pro",
+            expected_undo_token=scratched["undo_token"],
         )
         db.session.commit()
 
@@ -393,7 +394,7 @@ def test_normalized_relay_undo_preserves_a_later_reassignment(app):
             effect for effect in compute_scratch_effects(competitor, tournament)
             if effect.effect_type == "relay_team"
         )
-        execute_cascade(
+        scratched = execute_cascade(
             competitor, [relay_effect], judge_user_id=1, tournament=tournament,
         )
         db.session.commit()
@@ -407,6 +408,7 @@ def test_normalized_relay_undo_preserves_a_later_reassignment(app):
         undo = reverse_cascade(
             competitor.id, judge_user_id=1, tournament=tournament,
             competitor_type="pro",
+            expected_undo_token=scratched["undo_token"],
         )
         db.session.commit()
 
@@ -706,7 +708,9 @@ class TestExecuteCascadeResultStatuses:
             db.session.commit()
 
             effects = compute_scratch_effects(comp, t)
-            execute_cascade(comp, effects, judge_user_id=1, tournament=t)
+            scratched = execute_cascade(
+                comp, effects, judge_user_id=1, tournament=t,
+            )
             db.session.commit()
 
             updated = db.session.get(EventResult, result_id)
@@ -738,7 +742,9 @@ class TestExecuteCascadeResultStatuses:
             db.session.commit()
 
             effects = compute_scratch_effects(competitor, tournament)
-            execute_cascade(competitor, effects, judge_user_id=1, tournament=tournament)
+            scratched = execute_cascade(
+                competitor, effects, judge_user_id=1, tournament=tournament,
+            )
             db.session.commit()
 
             scratched_competitor = db.session.get(ProCompetitor, competitor.id)
@@ -749,6 +755,7 @@ class TestExecuteCascadeResultStatuses:
 
             undo = reverse_cascade(
                 competitor.id, judge_user_id=1, tournament=tournament,
+                expected_undo_token=scratched['undo_token'],
             )
             db.session.commit()
 
@@ -832,13 +839,18 @@ class TestReverseCascadeHappyPath:
             )
             db.session.commit()
 
-            execute_cascade(
+            scratched = execute_cascade(
                 comp, compute_scratch_effects(comp, t), judge_user_id=1, tournament=t,
             )
             db.session.commit()
             assert db.session.get(Event, event.id).is_finalized is False
 
-            undo = reverse_cascade(comp.id, judge_user_id=1, tournament=t)
+            undo = reverse_cascade(
+                comp.id,
+                judge_user_id=1,
+                tournament=t,
+                expected_undo_token=scratched['undo_token'],
+            )
             db.session.commit()
 
             assert undo["success"] is True
@@ -867,14 +879,19 @@ class TestReverseCascadeHappyPath:
             survivor_result_id = survivor_result.id
             db.session.commit()
 
-            execute_cascade(
+            scratched = execute_cascade(
                 comp, compute_scratch_effects(comp, t), judge_user_id=1, tournament=t,
             )
             db.session.commit()
             db.session.get(EventResult, survivor_result_id).result_value = 12.34
             db.session.commit()
 
-            undo = reverse_cascade(comp.id, judge_user_id=1, tournament=t)
+            undo = reverse_cascade(
+                comp.id,
+                judge_user_id=1,
+                tournament=t,
+                expected_undo_token=scratched['undo_token'],
+            )
             db.session.commit()
 
             assert undo["success"] is True
@@ -902,18 +919,206 @@ class TestReverseCascadeHappyPath:
             db.session.commit()
 
             effects = compute_scratch_effects(comp, t)
-            execute_cascade(comp, effects, judge_user_id=1, tournament=t)
+            scratched = execute_cascade(comp, effects, judge_user_id=1, tournament=t)
             db.session.commit()
 
             assert comp.status == "scratched"
 
-            undo = reverse_cascade(comp.id, judge_user_id=1, tournament=t)
+            undo = reverse_cascade(
+                comp.id,
+                judge_user_id=1,
+                tournament=t,
+                expected_undo_token=scratched['undo_token'],
+            )
             db.session.commit()
 
             assert undo["success"] is True
             assert comp.status == original_status
             restored = db.session.get(EventResult, result_id)
             assert restored.status == "pending"
+
+    def test_reverse_is_one_shot_and_replay_preserves_later_state(self, app):
+        from database import db
+        from models.audit_log import AuditLog
+        from models.competitor import ProCompetitor
+        from models.event import EventResult
+        from services.scratch_cascade import (
+            compute_scratch_effects,
+            execute_cascade,
+            find_undoable_scratch,
+            reverse_cascade,
+        )
+
+        with app.app_context():
+            tournament = _seed_base(db)
+            competitor = _seed_pro(db, tournament, name="One Shot Undo")
+            competitor.total_earnings = 125.0
+            event = _seed_event(db, tournament, name="One Shot Event")
+            result = _seed_result_with_points(
+                db,
+                event,
+                competitor,
+                comp_type="pro",
+                result_status="completed",
+                payout=125.0,
+            )
+            result_id = result.id
+            db.session.commit()
+
+            scratched = execute_cascade(
+                competitor,
+                compute_scratch_effects(competitor, tournament),
+                judge_user_id=1,
+                tournament=tournament,
+            )
+            db.session.commit()
+            first = reverse_cascade(
+                competitor.id,
+                judge_user_id=1,
+                tournament=tournament,
+                expected_undo_token=scratched["undo_token"],
+            )
+            db.session.commit()
+            assert first["success"] is True
+            assert find_undoable_scratch(competitor.id, "pro") is None
+
+            current_competitor = db.session.get(ProCompetitor, competitor.id)
+            current_result = db.session.get(EventResult, result_id)
+            current_competitor.total_earnings = 777.0
+            current_result.payout_amount = 777.0
+            current_result.status = "completed"
+            db.session.commit()
+
+            replay = reverse_cascade(
+                competitor.id,
+                judge_user_id=1,
+                tournament=tournament,
+                expected_undo_token=scratched["undo_token"],
+            )
+            db.session.rollback()
+
+            assert replay["success"] is False
+            assert db.session.get(ProCompetitor, competitor.id).total_earnings == 777.0
+            assert db.session.get(EventResult, result_id).payout_amount == 777.0
+            assert AuditLog.query.filter_by(
+                action="scratch_undone", entity_id=competitor.id,
+            ).count() == 1
+
+    def test_reverse_refuses_scoring_state_changed_after_scratch(self, app):
+        from database import db
+        from models.competitor import ProCompetitor
+        from models.event import EventResult
+        from services.scratch_cascade import (
+            compute_scratch_effects,
+            execute_cascade,
+            reverse_cascade,
+        )
+
+        with app.app_context():
+            tournament = _seed_base(db)
+            competitor = _seed_pro(db, tournament, name="Stale Financial Undo")
+            competitor.total_earnings = 200.0
+            event = _seed_event(db, tournament, name="Stale Financial Event")
+            result = _seed_result_with_points(
+                db,
+                event,
+                competitor,
+                comp_type="pro",
+                result_status="completed",
+                payout=200.0,
+            )
+            result_id = result.id
+            db.session.commit()
+
+            scratched = execute_cascade(
+                competitor,
+                compute_scratch_effects(competitor, tournament),
+                judge_user_id=1,
+                tournament=tournament,
+            )
+            db.session.commit()
+            changed_result = db.session.get(EventResult, result_id)
+            changed_result.status = "completed"
+            changed_result.payout_amount = 75.0
+            db.session.get(ProCompetitor, competitor.id).total_earnings = 75.0
+            db.session.commit()
+
+            stale = reverse_cascade(
+                competitor.id,
+                judge_user_id=1,
+                tournament=tournament,
+                expected_undo_token=scratched["undo_token"],
+            )
+            db.session.rollback()
+
+            assert stale["success"] is False
+            assert "changed" in stale["message"].lower()
+            assert db.session.get(ProCompetitor, competitor.id).status == "scratched"
+            assert db.session.get(ProCompetitor, competitor.id).total_earnings == 75.0
+            assert db.session.get(EventResult, result_id).payout_amount == 75.0
+
+    def test_stale_tab_token_cannot_undo_a_newer_scratch(self, app):
+        from database import db
+        from models.competitor import ProCompetitor
+        from services.scratch_cascade import (
+            compute_scratch_effects,
+            execute_cascade,
+            reverse_cascade,
+        )
+
+        with app.app_context():
+            tournament = _seed_base(db)
+            competitor = _seed_pro(db, tournament, name="Two Scratch Cycles")
+            event = _seed_event(db, tournament, name="Two Cycle Event")
+            _seed_result_with_points(
+                db, event, competitor, comp_type="pro", result_status="pending",
+            )
+            db.session.commit()
+
+            first_scratch = execute_cascade(
+                competitor,
+                compute_scratch_effects(competitor, tournament),
+                judge_user_id=1,
+                tournament=tournament,
+            )
+            db.session.commit()
+            first_undo = reverse_cascade(
+                competitor.id,
+                judge_user_id=1,
+                tournament=tournament,
+                expected_undo_token=first_scratch["undo_token"],
+            )
+            db.session.commit()
+            assert first_undo["success"] is True
+
+            current = db.session.get(ProCompetitor, competitor.id)
+            second_scratch = execute_cascade(
+                current,
+                compute_scratch_effects(current, tournament),
+                judge_user_id=1,
+                tournament=tournament,
+            )
+            db.session.commit()
+
+            stale_tab = reverse_cascade(
+                competitor.id,
+                judge_user_id=1,
+                tournament=tournament,
+                expected_undo_token=first_scratch["undo_token"],
+            )
+            db.session.rollback()
+            assert stale_tab["success"] is False
+            assert db.session.get(ProCompetitor, competitor.id).status == "scratched"
+
+            current_tab = reverse_cascade(
+                competitor.id,
+                judge_user_id=1,
+                tournament=tournament,
+                expected_undo_token=second_scratch["undo_token"],
+            )
+            db.session.commit()
+            assert current_tab["success"] is True
+            assert db.session.get(ProCompetitor, competitor.id).status == "active"
 
 
 class TestReverseCascadeExpiredWindow:
@@ -939,7 +1144,7 @@ class TestReverseCascadeExpiredWindow:
             db.session.commit()
 
             effects = compute_scratch_effects(comp, t)
-            execute_cascade(comp, effects, judge_user_id=1, tournament=t)
+            scratched = execute_cascade(comp, effects, judge_user_id=1, tournament=t)
             db.session.commit()
 
             # Back-date the audit log entry so it's outside the undo window
@@ -1007,10 +1212,17 @@ class TestExecuteReverseRoundTrip:
             db.session.commit()
 
             effects = compute_scratch_effects(comp, t)
-            execute_cascade(comp, effects, judge_user_id=1, tournament=t)
+            scratched = execute_cascade(
+                comp, effects, judge_user_id=1, tournament=t,
+            )
             db.session.commit()
 
-            reverse_cascade(comp.id, judge_user_id=1, tournament=t)
+            reverse_cascade(
+                comp.id,
+                judge_user_id=1,
+                tournament=t,
+                expected_undo_token=scratched['undo_token'],
+            )
             db.session.commit()
 
             final_comp = db.session.get(ProCompetitor, comp.id)

--- a/tests/test_scratch_routes.py
+++ b/tests/test_scratch_routes.py
@@ -177,7 +177,7 @@ def _auth_client(app, user):
 # ---------------------------------------------------------------------------
 
 
-def _build_effect_form(effects: list[dict]) -> dict:
+def _build_effect_form(effects: list[dict], effect_digest: str | None = None) -> dict:
     """Convert a list of effect dicts (from JSON preview) into POST form data."""
     data = {}
     for i, eff in enumerate(effects):
@@ -186,6 +186,8 @@ def _build_effect_form(effects: list[dict]) -> dict:
         data[f"affected_entity_type_{i}"] = eff["affected_entity_type"]
         data[f"effect_checked_{i}"] = "on"
     data["effect_count"] = str(len(effects))
+    if effect_digest is not None:
+        data["expected_effect_digest"] = effect_digest
     return data
 
 
@@ -213,6 +215,7 @@ class TestScratchPreviewGet:
             assert resp.status_code == 200
             data = json.loads(resp.data)
             assert "effects" in data
+            assert "effect_digest" in data
             assert isinstance(data["effects"], list)
             # At least one event_result effect expected
             types = [e["effect_type"] for e in data["effects"]]
@@ -293,9 +296,10 @@ class TestScratchConfirmPost:
             preview_resp = client.get(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
             )
-            effects = json.loads(preview_resp.data)["effects"]
+            preview = json.loads(preview_resp.data)
+            effects = preview["effects"]
 
-            form_data = _build_effect_form(effects)
+            form_data = _build_effect_form(effects, preview['effect_digest'])
             resp = client.post(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
                 data=form_data,
@@ -310,6 +314,47 @@ class TestScratchConfirmPost:
 
             result_reloaded = db.session.get(EventResult, result_id)
             assert result_reloaded.status == "scratched"
+
+    def test_changed_effect_digest_rejects_stale_confirmation(self, app):
+        from database import db
+        from models.competitor import ProCompetitor
+
+        with app.app_context():
+            tournament = _seed_tournament(db)
+            user = _seed_admin(db)
+            competitor = _seed_pro(db, tournament)
+            first_event = _seed_event(db, tournament)
+            _seed_result(db, first_event, competitor)
+            db.session.commit()
+
+            client = _auth_client(app, user)
+            preview = client.get(
+                f'/scoring/{tournament.id}/competitor/{competitor.id}/scratch-preview',
+                headers={'Accept': 'application/json'},
+            ).get_json()
+            stale_form = _build_effect_form(
+                preview['effects'], preview['effect_digest']
+            )
+
+            second_event = _seed_event(db, tournament)
+            second_event.name = 'Late Added Event'
+            _seed_result(db, second_event, competitor)
+            db.session.commit()
+
+            response = client.post(
+                f'/scoring/{tournament.id}/competitor/{competitor.id}/scratch-confirm',
+                data=stale_form,
+                follow_redirects=False,
+            )
+
+            assert response.status_code == 302
+            db.session.expire_all()
+            assert db.session.get(ProCompetitor, competitor.id).status == 'active'
+            with client.session_transaction() as session:
+                assert any(
+                    'effects changed since you reviewed them' in message
+                    for _, message in session['_flashes']
+                )
 
     def test_happy_path_partial_effects_only_checked_execute(self, app):
         """Unchecked effects are not applied."""
@@ -331,7 +376,8 @@ class TestScratchConfirmPost:
             preview_resp = client.get(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
             )
-            effects = json.loads(preview_resp.data)["effects"]
+            preview = json.loads(preview_resp.data)
+            effects = preview["effects"]
 
             # Build form but omit effect_checked for all effects (none checked)
             data = {}
@@ -341,6 +387,7 @@ class TestScratchConfirmPost:
                 data[f"affected_entity_type_{i}"] = eff["affected_entity_type"]
                 # No effect_checked_{i} key → unchecked
             data["effect_count"] = str(len(effects))
+            data["expected_effect_digest"] = preview["effect_digest"]
 
             resp = client.post(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
@@ -369,9 +416,15 @@ class TestScratchConfirmPost:
             db.session.commit()
 
             client = _auth_client(app, u)
+            preview = client.get(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
+            ).get_json()
             resp = client.post(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
-                data={"effect_count": "0"},
+                data={
+                    "effect_count": "0",
+                    "expected_effect_digest": preview["effect_digest"],
+                },
                 follow_redirects=True,
             )
             assert resp.status_code == 200
@@ -410,9 +463,15 @@ class TestScratchConfirmPost:
             db.session.commit()
 
             client = _auth_client(app, u)
+            preview = client.get(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
+            ).get_json()
             resp = client.post(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
-                data={"effect_count": "0"},
+                data={
+                    "effect_count": "0",
+                    "expected_effect_digest": preview["effect_digest"],
+                },
                 follow_redirects=False,
             )
             assert resp.status_code in (302, 303)
@@ -431,13 +490,19 @@ class TestScratchConfirmPost:
             db.session.commit()
 
             client = _auth_client(app, u)
+            preview = client.get(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
+            ).get_json()
             with patch(
                 'services.scratch_cascade.execute_cascade',
                 side_effect=StaleDataError(),
             ):
                 resp = client.post(
                     f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
-                    data={"effect_count": "0"},
+                    data={
+                        "effect_count": "0",
+                        "expected_effect_digest": preview["effect_digest"],
+                    },
                     follow_redirects=False,
                 )
 
@@ -458,13 +523,19 @@ class TestScratchConfirmPost:
             db.session.commit()
 
             client = _auth_client(app, u)
+            preview = client.get(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
+            ).get_json()
             with patch(
                 'services.scratch_cascade.execute_cascade',
                 side_effect=ScratchCascadeConflict("locked"),
             ):
                 resp = client.post(
                     f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
-                    data={"effect_count": "0"},
+                    data={
+                        "effect_count": "0",
+                        "expected_effect_digest": preview["effect_digest"],
+                    },
                     follow_redirects=False,
                 )
 
@@ -500,15 +571,37 @@ class TestScratchUndoPost:
             preview_resp = client.get(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview"
             )
-            effects = json.loads(preview_resp.data)["effects"]
+            preview = json.loads(preview_resp.data)
             client.post(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-confirm",
-                data=_build_effect_form(effects),
+                data=_build_effect_form(
+                    preview["effects"], preview["effect_digest"]
+                ),
             )
+
+            undo_preview = client.get(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview?format=json"
+            ).get_json()
+            reviewed_page = client.get(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-preview",
+                headers={"Accept": "text/html"},
+            )
+            assert b"Scratch Active" in reviewed_page.data
+            assert b'name="expected_undo_token"' in reviewed_page.data
+            assert b">Confirm Scratch<" not in reviewed_page.data
+
+            unreviewed = client.post(
+                f"/scoring/{t.id}/competitor/{comp_id}/scratch-undo",
+                follow_redirects=False,
+            )
+            assert unreviewed.status_code in (302, 303)
+            assert "scratch-preview" in unreviewed.location
+            assert db.session.get(ProCompetitor, comp_id).status == "scratched"
 
             # Now undo
             undo_resp = client.post(
                 f"/scoring/{t.id}/competitor/{comp_id}/scratch-undo",
+                data={"expected_undo_token": undo_preview["undo_token"]},
                 follow_redirects=False,
             )
             assert undo_resp.status_code in (302, 303)
@@ -575,6 +668,7 @@ class TestScratchUndoPost:
             ):
                 resp = client.post(
                     f"/scoring/{t.id}/competitor/{comp_id}/scratch-undo",
+                    data={"expected_undo_token": "test-token"},
                     follow_redirects=False,
                 )
 
@@ -601,6 +695,7 @@ class TestScratchUndoPost:
             ):
                 resp = client.post(
                     f"/scoring/{t.id}/competitor/{comp_id}/scratch-undo",
+                    data={"expected_undo_token": "test-token"},
                     follow_redirects=False,
                 )
 

--- a/tests/test_service_worker_offline_contract.py
+++ b/tests/test_service_worker_offline_contract.py
@@ -32,9 +32,9 @@ def test_worker_installs_fallback_and_retires_only_old_scoring_caches():
     assert "cache.addAll([OFFLINE_FALLBACK])" in source
     assert ".then(() => self.skipWaiting())" in source
     assert "offline.html optional" not in source
-    assert "key.startsWith(CACHE_PREFIX)" in source
-    assert "key !== CACHE_NAME" in source
-    assert "caches.delete(key)" in source
+    assert "name.startsWith(CACHE_PREFIX)" in source
+    assert "name !== CACHE_NAME" in source
+    assert "caches.delete(name)" in source
 
 
 def test_worker_never_caches_redirects_errors_or_non_html_score_responses():
@@ -44,38 +44,39 @@ def test_worker_never_caches_redirects_errors_or_non_html_score_responses():
     assert "!response.redirected" in source
     assert "response.url === request.url" in source
     assert "contentType.includes('text/html')" in source
-    assert "isCacheableScorePage(resp, req)" in source
+    assert "isCacheableScorePage(response, request)" in source
     assert "catch (_cacheErr)" in source
 
 
-def test_worker_intercepts_and_replays_only_same_origin_score_urls():
+def test_worker_keeps_new_score_posts_in_the_canonical_page_queue():
     source = _worker_source()
 
-    assert "function isSameOriginScoreEntryUrl(rawUrl)" in source
-    assert "url.origin === self.location.origin" in source
-    assert source.count("isScoreEntryRequest(req)") == 2
-    assert "isSameOriginScoreEntryUrl(entry.url)" in source
-    assert "failReasons.push('invalid_queue_target')" in source
-    assert "SCORE_ENTRY_PATTERN.test(req.url)" not in source
+    assert "handleScorePost" not in source
+    assert "objectStore('queue').add" not in source
+    assert "request.method !== 'GET' || !sameOrigin(request.url)" in source
+    assert "request.method === 'POST' && LOGOUT_PATTERN.test(request.url)" in source
+    assert "drain-legacy-queue" in source
+    assert "renewLegacyReplayToken" in source
 
 
 def test_worker_uses_exact_cached_page_then_static_fallback_then_bounded_503():
     source = _worker_source()
 
     assert source.count("const cache = await caches.open(CACHE_NAME)") == 2
-    assert "await cache.match(req)" in source
+    assert "await cache.match(request)" in source
     assert "await cache.match(OFFLINE_FALLBACK)" in source
-    assert "await caches.match(req)" not in source
+    assert "await caches.match(request)" not in source
     assert "status: 503" in source
     assert "Offline score page unavailable" in source
 
 
-def test_worker_queues_only_the_server_issued_hmac_replay_token():
+def test_worker_only_renews_legacy_entries_with_server_issued_replay_tokens():
     source = _worker_source()
 
-    assert "new URLSearchParams(body).get('replay_token')" in source
+    assert "params.set('replay_token', String(data.replay_token || ''))" in source
+    assert "'/scoring/api/replay-token'" in source
+    assert "legacy_issuer_session_mismatch" in source
     assert "generateReplayToken" not in source
-    assert "crypto.getRandomValues" not in source
 
 
 def test_service_worker_route_is_strict_javascript_and_not_cache_stale(client):

--- a/tests/test_shadow_release_readiness.py
+++ b/tests/test_shadow_release_readiness.py
@@ -322,6 +322,7 @@ def test_release_docs_and_dependency_comments_describe_the_real_shadow_authority
     unit_postgres_job = workflow.split("  unit-postgres:\n", 1)[1].split("\n  lint:\n", 1)[0]
     assert verifier_install in test_job
     assert verifier_install in unit_postgres_job
+    assert "timeout-minutes: 30" in unit_postgres_job
     assert [
         line.strip() for line in requirements.splitlines() if line.strip() == "jsonschema==4.25.1"
     ] == ["jsonschema==4.25.1"]

--- a/tests/test_sms_backup.py
+++ b/tests/test_sms_backup.py
@@ -16,9 +16,18 @@ Design notes:
     (sms_notify depends only on env vars and the twilio package).
 """
 import os
+import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _create_valid_sqlite(path):
+    connection = sqlite3.connect(path)
+    connection.execute('CREATE TABLE evidence (value INTEGER NOT NULL)')
+    connection.execute('INSERT INTO evidence VALUES (17)')
+    connection.commit()
+    connection.close()
 
 # =====================================================================
 # SMS Notify Tests
@@ -327,9 +336,8 @@ class TestBackupToLocal:
     def test_creates_backup_file(self, tmp_path):
         """backup_to_local() copies the source DB to dest_dir."""
         from services.backup import backup_to_local
-        # Create a fake source DB
         src = tmp_path / 'source.db'
-        src.write_bytes(b'SQLite format 3' + b'\x00' * 100)
+        _create_valid_sqlite(src)
 
         dest_dir = tmp_path / 'backups'
         result = backup_to_local(str(src), str(dest_dir), tournament_id=1)
@@ -343,7 +351,7 @@ class TestBackupToLocal:
         """backup_to_local() returns dict with ok, dest, size_bytes, error."""
         from services.backup import backup_to_local
         src = tmp_path / 'source.db'
-        src.write_bytes(b'test data')
+        _create_valid_sqlite(src)
 
         dest_dir = tmp_path / 'backups'
         result = backup_to_local(str(src), str(dest_dir), tournament_id=42)
@@ -356,7 +364,7 @@ class TestBackupToLocal:
         """backup_to_local() creates the destination directory if it does not exist."""
         from services.backup import backup_to_local
         src = tmp_path / 'source.db'
-        src.write_bytes(b'test')
+        _create_valid_sqlite(src)
 
         nested_dir = tmp_path / 'a' / 'b' / 'c'
         assert not nested_dir.exists()
@@ -392,9 +400,8 @@ class TestBackupToS3:
         """backup_to_s3() calls s3.upload_file() when configured."""
         from services.backup import backup_to_s3
 
-        # Create a fake source DB
         src = tmp_path / 'source.db'
-        src.write_bytes(b'SQLite format 3' + b'\x00' * 100)
+        _create_valid_sqlite(src)
 
         mock_s3_client = MagicMock()
         mock_session = MagicMock()
@@ -426,7 +433,7 @@ class TestBackupToS3:
         from services.backup import backup_to_s3
 
         src = tmp_path / 'source.db'
-        src.write_bytes(b'test')
+        _create_valid_sqlite(src)
 
         mock_s3_client = MagicMock()
         mock_s3_client.upload_file.side_effect = Exception('Access Denied')


### PR DESCRIPTION
## Summary
- make score submission retries durable and deterministic across offline replay, duplicate requests, stale writers, and receipt lifecycle changes
- harden race-day concurrency, background jobs, cache invalidation, exports, SQLite restore, and PostgreSQL backup verification
- consolidate the offline queue/service-worker contract and add operator-visible recovery controls
- add the 2027 requirements/evidence ledger, recovery plan, migration, and broad regression coverage

## Verification
- full isolated SQLite suite: **4,342 passed, 42 expected skips** (4,384 collected; 0 failures/errors)
- disposable PostgreSQL combined lane: **10 passed**, covering eight recovery races plus shadow migration round-trip and locked delivery
- installed STRATHMARK exact-commit rehearsal: seven expected routes, pinned digest/provenance, exact replay, duplicate outcome, no network
- release-readiness and PostgreSQL migration-safety modules: **12 passed**
- offline/service-worker targeted lane: **42 passed**; service-worker contract: **7 passed**
- Node offline suites: **2 passed**
- Ruff, Python 3.10 grammar parse (380 files), JavaScript syntax, and diff checks passed
- browser QA passed at 1440x900 and 390x844, including prepared cold-offline loading, two exact receipt replays, relay replacement controls, and no page/console errors

## Data and release boundaries
- all local test/browser data was synthetic and isolated
- no production database or PII was accessed
- this does **not** claim final 2027 race-day certification; annual owner decisions, physical-device rehearsal, hosted backup secrets/key custody, hosted CI, and production smoke remain separately gated
- live/provisional scoring remains Missoula-owned; STRATHMARK remains recommendation/settlement evidence and is not a race-day network dependency
