### PR TITLE
Harden 2027 full-dress rehearsal

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,7 +330,12 @@ def _create_app_inner():
         # ORM logic per CLAUDE.md §6 development rule.
         from services.sidebar_aggregator import unscored_heats_count
         tid = request.view_args.get('tournament_id') if request.view_args else None
-        unscored_heats = unscored_heats_count(tid) if tid else 0
+        show_judge_sidebar = bool(
+            tid
+            and getattr(current_user, 'is_authenticated', False)
+            and getattr(current_user, 'is_judge', False)
+        )
+        unscored_heats = unscored_heats_count(tid) if show_judge_sidebar else 0
 
         # Public languages always available; restricted languages (Arapaho) only for judge/admin.
         available_languages = dict(text.PUBLIC_LANGUAGES)

--- a/app.py
+++ b/app.py
@@ -608,6 +608,7 @@ def _create_app_inner():
 
     @app.errorhandler(500)
     def internal_error(error):
+        db.session.rollback()
         if request.path.startswith('/api/'):
             return jsonify({'error': 'Internal server error', 'status': 500}), 500
         return render_template('errors/500.html'), 500

--- a/docs/2027_FULL_DRESS_REHEARSAL.md
+++ b/docs/2027_FULL_DRESS_REHEARSAL.md
@@ -1,0 +1,174 @@
+# 2027 Full-Dress Rehearsal Receipt
+
+Date: 2026-08-19
+
+Branch: `rehearsal/2027-full-dress`
+
+Deployed-code baseline: `7544ad421eae31b1084c9e3c149ff7bf2ace1734`
+
+## Scope And Safety Boundary
+
+This was a local, synthetic, non-production rehearsal. It exercised the
+deployed code baseline plus the fixes described below. It did not access a
+production database, Railway, production PII, or the optional STRATHMARK
+network integration.
+
+SQLite tests used migration-built temporary databases. PostgreSQL tests used
+unique disposable clones of `proam_unit_template` and ran serially. The
+rehearsal did not delete databases by prefix. PostgreSQL inventory was the same
+before and after the lanes: `proam_unit_44728_1` and
+`proam_unit_template`. The worktree default `instance/proam.db` did not exist
+before or after the rehearsal.
+
+The retained browser fixture is a synthetic database outside the Git worktree:
+`.rehearsal-tmp/browser-rehearsal.db`.
+
+## Rehearsal Fixture
+
+The deterministic fixture contained:
+
+- one `[REHEARSAL]` 2027 tournament;
+- 8 college teams, 25 college competitors, and 25 pro competitors;
+- 10 synthetic judges;
+- completed events and results for spectator and reporting surfaces; and
+- one live timed event with two heats for scoring, concurrency, and offline
+  recovery.
+
+The load harness now migrates and seeds its own database, refuses
+`instance/proam.db`, refuses every pre-existing database path, releases its
+database and process-fence resources before starting the child server, and
+returns a failing process status when the latency, aggregate-error, or
+zero-server-error gate fails. Judge users establish independent authenticated
+sessions with the real CSRF-backed login flow before reading scoring pages.
+
+## Load Gate
+
+The inherited zero-ramp stress shape exposed the failure mode before any
+optimization: 260 users started together, producing 615 requests, 436
+successful responses, and 179 request timeouts. Error rate was 29.11%, p95 was
+5,314.03 ms, and the gate failed. Every response that completed returned HTTP
+200, so the failure was saturation and timeout behavior rather than an
+application-error response.
+
+Profiling found two avoidable burst costs: anonymous public pages performed a
+judge-only pending-heat query, and concurrent cold public-cache misses rebuilt
+the same payload independently. The fixes skip the judge query for anonymous
+traffic and coalesce cache fills per key without serializing unrelated keys.
+
+The final operator-paced gate used the repository defaults intended to model
+real polling and entry cadence:
+
+| Metric | Result | Gate |
+|---|---:|---:|
+| Virtual users | 260 (200 spectator, 50 competitor, 10 judge) | n/a |
+| Ramp | 15.001 s actual | 15 s configured |
+| Steady state | 15 s | 15 s configured |
+| Requests | 342 | n/a |
+| Successful requests | 342 | n/a |
+| Errors | 0 (0.00%) | no more than 0.50% |
+| HTTP 5xx responses | 0 | 0 |
+| Throughput | 11.35 requests/s | informational |
+| Mean latency | 33.67 ms | informational |
+| p50 latency | 9.36 ms | informational |
+| p95 latency | 134.74 ms | no more than 800 ms |
+| p99 latency | 266.96 ms | informational |
+| Maximum latency | 575.96 ms | informational |
+
+Role p95 latency was 80.64 ms for spectators, 48.24 ms for competitors, and
+266.96 ms for authenticated judges. The final gate passed.
+
+This passing paced run does not erase the zero-ramp result. The zero-ramp mode
+remains available as an explicit saturation test; it is not represented as the
+expected human traffic shape.
+
+## Automated Evidence
+
+- Rehearsal harness, cache, and anonymous-context focused lane: 28 passed.
+- Rehearsal safety module: 11 passed, including production-path refusal,
+  existing-path refusal, generated-database disposal, truthful gate status,
+  zero-server-error enforcement, CSRF token parsing, error classification,
+  configurable load shape, authenticated judge assignment, and no PostgreSQL
+  prefix sweep.
+- SQLite operations lane: 160 passed across daily backup, offline assets,
+  offline scoring, reporting backup/export, restore, service-worker contract,
+  shadow release readiness, tournament lifecycle portals, and end-to-end
+  workflow modules.
+- JavaScript offline lanes: `service_worker_offline.test.js` and
+  `offline_queue_shared.test.js` passed.
+- Disposable PostgreSQL adversarial lane: 10 passed, comprising eight
+  race-day concurrency tests, populated shadow-migration repair, and the
+  locked-delivery worker.
+- Disposable PostgreSQL runtime smoke: 4 passed for PostgreSQL URI selection,
+  health and migration state, ORM round trip, and real `FOR UPDATE NOWAIT`.
+- Migration-safety lane: 26 passed and 2 expected skips. The listener-hygiene
+  tests used their own temporary SQLite database and verified the default
+  database fingerprint was unchanged.
+
+## Browser Evidence
+
+All browser data and credentials were synthetic.
+
+- Desktop scoring at 1440x900 rendered without overlap, hidden primary
+  commands, document overflow, page errors, or console warnings/errors.
+- Phone results and spectator views at 390x844 had document width equal to
+  viewport width. Tables remained inside explicit horizontal-scroll
+  containers, and no console warnings/errors were recorded.
+- Heat 1 persisted 11.00/11.20 as 11.10 and 12.00/12.20 as 12.10.
+- Two authenticated judge sessions loaded Heat 2 at different versions. The
+  newer session persisted 13.00/13.20 as 13.10 and 14.00/14.20 as 14.10. The
+  stale session attempted different values and received the `Score Entry
+  Conflict` dialog. A separate results view confirmed that 13.10 and 14.10
+  remained authoritative; no silent overwrite occurred.
+- Offline preparation byte-verified 15 of 15 package items. After the local
+  application origin was stopped, a cold reload of the prepared scoring URL
+  still rendered the complete authenticated heat form, competitors, persisted
+  averages, offline/reconciliation state, and Save Results command from the
+  service-worker package.
+
+The origin-stop drill proves service-worker survival of an unavailable local
+server. It is not represented as a physical phone restart or an operating
+system radio-disable test.
+
+## Defects Corrected
+
+1. The load harness could touch an implicit local database and returned success
+   even when its gate failed. It now owns a guarded synthetic lifecycle and
+   returns truthful status, attributes failures to endpoints, retains server
+   diagnostics for failed requests, and refuses to pass any HTTP 5xx response.
+2. Test setup swept every PostgreSQL database matching `proam_unit_%`, which
+   could destroy another concurrent run. Cleanup is now limited to the unique
+   database created by the current factory call.
+3. Fresh isolated clones did not guarantee Flask's instance directory existed.
+   Test factories now establish it explicitly.
+4. Anonymous public requests paid for a judge-only pending-heat query. The
+   sidebar query now runs only for an authenticated judge with a tournament.
+5. Concurrent cold public requests duplicated standings work. Per-key fill
+   locking now coalesces the build and releases correctly after builder errors.
+6. PostgreSQL runtime-smoke cleanup explicitly deleted both parent and
+   delete-orphan child rows, producing duplicate-delete warnings. Cleanup now
+   deletes only the owning tournament.
+7. Migration listener-hygiene tests could instantiate the default application
+   database. They now bind a temporary SQLite database, release all handles and
+   process fences, and assert the default database remains unchanged.
+
+## Uncertified Gates
+
+This receipt is substantial local evidence, not a 2027 certification claim.
+The following gates remain open:
+
+- dated owner approval of the 2027 event matrix, Springboard exception policy,
+  Pro Birling decision, Relay composition, tie splitting, timer averaging,
+  event dates, and recovery objectives;
+- a complete approved 2027 show-order rehearsal after those choices are
+  recorded in the Domain Contract and configuration;
+- physical release-phone/device restart, cross-device queue transfer, and
+  radio-disabled scoring rehearsals;
+- hosted exact-head GitHub Actions evidence;
+- a production-mirror PostgreSQL rehearsal;
+- deployment and production smoke evidence; and
+- approved backup recipient/key custody, least-privilege dump access, hosted
+  encryption, retained-artifact decryption/restore, retention, and audit
+  evidence.
+
+Until those gates are satisfied, the correct disposition remains
+**implemented and locally rehearsed, not 2027 race-day certified**.

--- a/docs/2027_FULL_DRESS_REHEARSAL.md
+++ b/docs/2027_FULL_DRESS_REHEARSAL.md
@@ -15,9 +15,10 @@ network integration.
 
 SQLite tests used migration-built temporary databases. PostgreSQL tests used
 unique disposable clones of `proam_unit_template` and ran serially. The
-rehearsal did not delete databases by prefix. PostgreSQL inventory was the same
-before and after the lanes: `proam_unit_44728_1` and
-`proam_unit_template`. The worktree default `instance/proam.db` did not exist
+rehearsal did not delete databases by prefix. The unit-test database namespace
+was the same before and after the lanes: `proam_unit_44728_1` and
+`proam_unit_template`. Other pre-existing local databases were outside this
+rehearsal and untouched. The worktree default `instance/proam.db` did not exist
 before or after the rehearsal.
 
 The retained browser fixture is a synthetic database outside the Git worktree:
@@ -35,11 +36,18 @@ The deterministic fixture contained:
   recovery.
 
 The load harness now migrates and seeds its own database, refuses
-`instance/proam.db`, refuses every pre-existing database path, releases its
-database and process-fence resources before starting the child server, and
-returns a failing process status when the latency, aggregate-error, or
-zero-server-error gate fails. Judge users establish independent authenticated
-sessions with the real CSRF-backed login flow before reading scoring pages.
+`instance/proam.db`, refuses every pre-existing database path, prevents the
+report output from aliasing either database, and requires an explicit flag to
+replace an existing report. Existing aliases are detected by file identity and
+authorized replacement is an atomic file swap, so the report writer never
+truncates an existing target. It releases database, process-fence, worker, and
+server-log resources on failure and returns a failing process status when any
+aggregate, role, endpoint, activation, authentication, error-rate,
+sample-count, or zero-server-error gate fails. Judge users establish
+independent authenticated sessions with the real CSRF-backed login flow before
+reading scoring pages. Every measured request rejects an unexpected redirect,
+and every timed response includes the full body transfer. Workload ordering and
+per-worker random streams use the recorded seed `2027`.
 
 ## Load Gate
 
@@ -55,27 +63,46 @@ judge-only pending-heat query, and concurrent cold public-cache misses rebuilt
 the same payload independently. The fixes skip the judge query for anonymous
 traffic and coalesce cache fills per key without serializing unrelated keys.
 
+The first run with exact activation and authentication accounting exposed a
+third defect rather than passing around it: concurrent judge GETs attempted
+optimistic ORM updates to acquire the same heat lock, producing three HTTP 500
+responses and a poisoned-session failure while rendering the error page. Heat
+lock acquisition is now one conditional database update; losing requests
+reload the winner and render a blocked form instead of racing the heat version.
+The global 500 handler also rolls back before consulting users or templates.
+
+A subsequent zero-error run exposed a harness timing defect: its shared ramp
+clock started before all 260 client threads were ready, so host scheduling
+delays inflated both the observed activation spread and response latency. A
+ready barrier now excludes client-launch overhead and releases every worker
+against one shared ramp epoch. Neither failed run is represented as a pass.
+
 The final operator-paced gate used the repository defaults intended to model
 real polling and entry cadence:
 
 | Metric | Result | Gate |
 |---|---:|---:|
 | Virtual users | 260 (200 spectator, 50 competitor, 10 judge) | n/a |
-| Ramp | 15.001 s actual | 15 s configured |
+| Worker activation spread | 14.999 s actual | 15 s ramp configured |
 | Steady state | 15 s | 15 s configured |
 | Requests | 342 | n/a |
 | Successful requests | 342 | n/a |
 | Errors | 0 (0.00%) | no more than 0.50% |
 | HTTP 5xx responses | 0 | 0 |
 | Throughput | 11.35 requests/s | informational |
-| Mean latency | 33.67 ms | informational |
-| p50 latency | 9.36 ms | informational |
-| p95 latency | 134.74 ms | no more than 800 ms |
-| p99 latency | 266.96 ms | informational |
-| Maximum latency | 575.96 ms | informational |
+| Mean latency | 32.51 ms | informational |
+| p50 latency | 7.73 ms | informational |
+| p95 latency | 154.50 ms | no more than 800 ms |
+| p99 latency | 361.72 ms | informational |
+| Maximum latency | 563.75 ms | informational |
 
-Role p95 latency was 80.64 ms for spectators, 48.24 ms for competitors, and
-266.96 ms for authenticated judges. The final gate passed.
+Role p95 latency was 56.65 ms for spectators, 47.21 ms for competitors, and
+282.90 ms for authenticated judges. All 260 configured users activated, all 10
+distinct judges authenticated, and all 11 expected endpoints received samples
+and passed their independent 800 ms p95 and 0.50% error-rate gates. The slowest
+endpoint p95 was 345.92 ms for the first scoring heat. The final gate passed.
+The external report `load-report-auth-final-v8.json` has SHA-256
+`df2d5209c206fdbfd7f0ff4257510e2782034438963adc9f8dca3f55ee6a01e0`.
 
 This passing paced run does not erase the zero-ramp result. The zero-ramp mode
 remains available as an explicit saturation test; it is not represented as the
@@ -83,12 +110,20 @@ expected human traffic shape.
 
 ## Automated Evidence
 
-- Rehearsal harness, cache, and anonymous-context focused lane: 28 passed.
-- Rehearsal safety module: 11 passed, including production-path refusal,
-  existing-path refusal, generated-database disposal, truthful gate status,
-  zero-server-error enforcement, CSRF token parsing, error classification,
-  configurable load shape, authenticated judge assignment, and no PostgreSQL
-  prefix sweep.
+- Broad focused regression lane: 249 passed across rehearsal safety,
+  infrastructure/cache, Flask reliability, spectator portals, API endpoints,
+  and migration/listener hygiene.
+- Rehearsal safety module: 33 passed, including database and report-path
+  refusal, generated-database disposal, aggregate/role/endpoint gate status,
+  hard-link/path-swap refusal, atomic report replacement, exact user activation
+  and judge authentication counts, minimum judge login samples,
+  zero-server-error enforcement, public/authenticated redirect rejection,
+  full-body timing, CSRF parsing, deterministic load streams, bounded thread
+  cleanup, and PostgreSQL template isolation.
+- Scoring and day-of-operations regression lane: 66 passed across concurrent
+  integration QA, scoring workflow, dual-timer entry, operator actions, and
+  stale/invalid edge cases. This includes an eight-session same-account heat
+  GET race that produced one lock/version update and eight HTTP 200 responses.
 - SQLite operations lane: 160 passed across daily backup, offline assets,
   offline scoring, reporting backup/export, restore, service-worker contract,
   shadow release readiness, tournament lifecycle portals, and end-to-end
@@ -150,6 +185,40 @@ system radio-disable test.
 7. Migration listener-hygiene tests could instantiate the default application
    database. They now bind a temporary SQLite database, release all handles and
    process fences, and assert the default database remains unchanged.
+8. Report output could alias and overwrite a protected or retained database.
+   Output paths are now checked before startup and publication, hard-link and
+   symlink aliases are rejected by file identity, existing reports require
+   explicit overwrite authorization, and replacement is atomic.
+9. Authenticated scoring redirects, partial-body timing, aggregate-only p95,
+   unseeded worker streams, and unbounded worker cleanup could produce a
+   misleading or stuck load receipt. The harness now rejects every unexpected
+   public or authenticated redirect, consumes complete responses, requires
+   every configured user to activate and every judge to authenticate, gates
+   every role and endpoint with minimum samples, records a deterministic seed,
+   and stops started workers in `finally`.
+10. Concurrent checkouts shared one mutable PostgreSQL schema template. Test
+    templates are now namespaced by migration head, construction is serialized
+    with a PostgreSQL advisory lock, and every template drop/create is checked.
+11. Per-key cache fill locks accumulated for the process lifetime. Idle locks
+    now retire automatically, while active readers retain the shared lock.
+12. Concurrent judge page loads used ordinary optimistic ORM writes to acquire
+    a heat lock, so simultaneous requests could raise `StaleDataError`. Lock
+    acquisition is now an atomic available-or-expired update, repeat ownership
+    checks are read-only, and losing judges render the existing blocked state.
+13. The 500 handler rendered against a failed SQLAlchemy transaction. It now
+    rolls back before API serialization, user lookup, or template rendering.
+14. Client-thread creation occurred inside the measured ramp and could delay
+    later virtual users. Every client now reaches a ready barrier before one
+    shared launch epoch begins the measured ramp.
+15. Redirect validation compared only paths after redirects had already been
+    followed. A same-origin redirect handler now blocks scheme, host, or port
+    changes before network follow, and final scheme/host/port/path must match.
+16. First-time report creation could leave a partial final file after a crash
+    or serialization error. New and replacement reports are now fully written
+    and flushed in a sibling temporary file before atomic publication.
+17. A heat deleted between route lookup and lock acquisition could fail during
+    ORM refresh. The lock path now re-queries after commit and returns 404 when
+    the row no longer exists.
 
 ## Uncertified Gates
 

--- a/docs/2027_RACE_DAY_CERTIFICATION.md
+++ b/docs/2027_RACE_DAY_CERTIFICATION.md
@@ -47,7 +47,7 @@ stand in for hosted CI, a production mirror, or production smoke evidence.
 | R27-004 | A prepared device can restart during WAN loss and open every scheduled heat page and local asset. | Domain Contract local-first boundary | Implemented | Bound manifest verifies content hashes; 2026-08-19 browser rehearsal prepared 15/15 items and cold-reloaded a heat with the local application origin stopped | Physical-device restart rehearsal on the approved 2027 schedule |
 | R27-005 | One request produces at most one committed scoring action across duplicate, lost-response, retry, reconnect, and transfer paths; request tombstones remain with tournament history. | Owner scoring integrity | Implemented | Durable receipts/tombstones, rollback and duplicate tests, eight PostgreSQL races, lifecycle FK tests, and two browser replays with matching UUID/SHA-256 receipts | Hosted exact-head run and production-like multi-device rehearsal |
 | R27-006 | Queues are inspectable and transferable as data, while replay authority remains bound to the issuing user and current role/tournament access; old entries stop automatic mutation. | Local-first and authorization controls | Implemented | Canonical LocalStorage queue; issuer/role/tournament/schedule binding; authenticated 8-30 day renewal; 30-day cutoff; export/import and stale-context tests; browser queue inspection | Physical cross-device transfer rehearsal and approved operator procedure |
-| R27-007 | Compatible concurrent operations survive; conflicting, duplicate, stale, and out-of-order operations receive deterministic outcomes without silent loss. | Owner workflows; Domain Contract | Implemented | Stale-writer fences cover relay, payout, partner, scratch, flight, Birling, scoring, and background completion; eight disposable PostgreSQL races passed; lock-only scoring version race passed in two browser sessions | Hosted PostgreSQL lane plus complete 2027 full-show adversarial rehearsal |
+| R27-007 | Compatible concurrent operations survive; conflicting, duplicate, stale, and out-of-order operations receive deterministic outcomes without silent loss. | Owner workflows; Domain Contract | Implemented | Stale-writer fences cover relay, payout, partner, scratch, flight, Birling, scoring, and background completion; eight disposable PostgreSQL races passed; lock-only scoring version race passed in two browser sessions; eight simultaneous same-account scoring GETs produced one atomic lock update and eight successful responses | Hosted PostgreSQL lane plus complete 2027 full-show adversarial rehearsal |
 | R27-008 | Background work reports failed, interrupted, expired, and completed truthfully and is scoped before tournament limits are applied. | Operator recovery integrity | Implemented | Boot ownership, heartbeat, interrupted reconciliation, atomic completion, truthful return-state tests, and tournament-scope tests passed | Hosted restart/reconciliation rehearsal with retained operator evidence |
 | R27-009 | SQLite backup is consistent; restore is quiesced, validated, journaled outside the DB, rollback-capable, and never reported ambiguously. | Existing SQLite recovery surface | Implemented | Process fence, consistent snapshot, restore package v2, schema/FK/index/trigger fingerprint, private permissions, WAL/SHM intent journal, quarantine, rollback, and 31 restore tests passed | Operator rehearsal on release hardware; provenance remains transport/host evidence, not a signature claim |
 | R27-010 | A PostgreSQL artifact is restored only into a runner-local disposable target and passes schema/migration checks before publication. | Production PostgreSQL boundary | Implemented | Workflow enforces a least-privilege dump URL, runner-local target guard, current-head schema checks, encrypted-only upload, and plaintext cleanup; local PostgreSQL drill passed | Hosted workflow run with the approved secrets and retained artifact evidence |
@@ -143,10 +143,13 @@ SQLite databases, a disposable local PostgreSQL database, and
 The follow-up local rehearsal is recorded in
 `docs/2027_FULL_DRESS_REHEARSAL.md`. It adds a deterministic guarded load
 harness, a passing 260-user operator-paced load gate, safe run-owned PostgreSQL
-cleanup, cold-cache request coalescing, anonymous public-request query
-reduction, 160 SQLite operations checks, 14 disposable PostgreSQL checks,
-migration safety evidence, a two-session stale-score conflict, responsive
-desktop/phone inspection, and a 15-of-15 origin-down offline reload.
+cleanup and migration-head template isolation, cold-cache request coalescing,
+anonymous public-request query reduction, deterministic full-response load
+measurement with activation, authentication, role, and endpoint gates, atomic
+heat-lock acquisition under simultaneous judge page loads, 160 SQLite
+operations checks, 14 disposable PostgreSQL checks, migration safety evidence,
+a two-session stale-score conflict, responsive desktop/phone inspection, and a
+15-of-15 origin-down offline reload.
 
 It does not change any `Owner decision` to `Certified` and does not stand in
 for a physical device, hosted CI, production mirror, deployment, production

--- a/docs/2027_RACE_DAY_CERTIFICATION.md
+++ b/docs/2027_RACE_DAY_CERTIFICATION.md
@@ -44,7 +44,7 @@ stand in for hosted CI, a production mirror, or production smoke evidence.
 |---|---|---|---|---|---|
 | R27-001 | Friday/Pro Saturday show order and spillover follow the contract. | Domain Contract 15-30, 123-134; FlightLogic | Partial | Full isolated SQLite suite passed; flight/order tests passed inside it | Approved 2027 event matrix, exact PostgreSQL order lane, and full-show browser digest |
 | R27-003 | Gear sharing fails closed without unsafe same-heat/overlap placement. | GEAR_SHARING_DOMAIN; Domain Contract 69-92 | Partial | Full isolated SQLite suite passed, including generator/readiness coverage | Exact disposable PostgreSQL result and synthetic browser sharing rehearsal |
-| R27-004 | A prepared device can restart during WAN loss and open every scheduled heat page and local asset. | Domain Contract local-first boundary | Implemented | Bound manifest verifies content hashes; browser prepared 14/14 items and cold-reloaded the heat with `navigator.onLine=false` under service-worker control | Physical-device restart rehearsal on the approved 2027 schedule |
+| R27-004 | A prepared device can restart during WAN loss and open every scheduled heat page and local asset. | Domain Contract local-first boundary | Implemented | Bound manifest verifies content hashes; 2026-08-19 browser rehearsal prepared 15/15 items and cold-reloaded a heat with the local application origin stopped | Physical-device restart rehearsal on the approved 2027 schedule |
 | R27-005 | One request produces at most one committed scoring action across duplicate, lost-response, retry, reconnect, and transfer paths; request tombstones remain with tournament history. | Owner scoring integrity | Implemented | Durable receipts/tombstones, rollback and duplicate tests, eight PostgreSQL races, lifecycle FK tests, and two browser replays with matching UUID/SHA-256 receipts | Hosted exact-head run and production-like multi-device rehearsal |
 | R27-006 | Queues are inspectable and transferable as data, while replay authority remains bound to the issuing user and current role/tournament access; old entries stop automatic mutation. | Local-first and authorization controls | Implemented | Canonical LocalStorage queue; issuer/role/tournament/schedule binding; authenticated 8-30 day renewal; 30-day cutoff; export/import and stale-context tests; browser queue inspection | Physical cross-device transfer rehearsal and approved operator procedure |
 | R27-007 | Compatible concurrent operations survive; conflicting, duplicate, stale, and out-of-order operations receive deterministic outcomes without silent loss. | Owner workflows; Domain Contract | Implemented | Stale-writer fences cover relay, payout, partner, scratch, flight, Birling, scoring, and background completion; eight disposable PostgreSQL races passed; lock-only scoring version race passed in two browser sessions | Hosted PostgreSQL lane plus complete 2027 full-show adversarial rehearsal |
@@ -52,7 +52,7 @@ stand in for hosted CI, a production mirror, or production smoke evidence.
 | R27-009 | SQLite backup is consistent; restore is quiesced, validated, journaled outside the DB, rollback-capable, and never reported ambiguously. | Existing SQLite recovery surface | Implemented | Process fence, consistent snapshot, restore package v2, schema/FK/index/trigger fingerprint, private permissions, WAL/SHM intent journal, quarantine, rollback, and 31 restore tests passed | Operator rehearsal on release hardware; provenance remains transport/host evidence, not a signature claim |
 | R27-010 | A PostgreSQL artifact is restored only into a runner-local disposable target and passes schema/migration checks before publication. | Production PostgreSQL boundary | Implemented | Workflow enforces a least-privilege dump URL, runner-local target guard, current-head schema checks, encrypted-only upload, and plaintext cleanup; local PostgreSQL drill passed | Hosted workflow run with the approved secrets and retained artifact evidence |
 | R27-011 | Backup cadence and recovery objectives match the approved 2027 event window and owner-approved tolerances. | Release operations | Owner decision | Stale 2026 race-window schedule exists | Approved dates/objectives recorded in release docs and rehearsed against the configured cadence |
-| R27-012 | Operator controls and recovery states work at desktop/phone widths without console errors, hidden actions, overlap, or overflow. | Operator UI requirement | Implemented | Browser QA at 1440x900 and 390x844 found no document overflow or page/console errors; commands remained visible and screenshots were reviewed | Checked-in browser scenario and physical-phone rehearsal on release head |
+| R27-012 | Operator controls and recovery states work at desktop/phone widths without console errors, hidden actions, overlap, or overflow. | Operator UI requirement | Implemented | Browser QA at 1440x900 and 390x844 found no document overflow or page/console errors; commands remained visible and screenshots were reviewed in the 2026-08-19 full-dress rehearsal | Checked-in browser scenario and physical-phone rehearsal on release head |
 | R27-013 | SQLite, disposable PostgreSQL, production mirror, migration, browser, hosted CI, and production smoke evidence are separate. | Release Checklist; isolation rule | Partial | This ledger records SQLite, disposable PostgreSQL, migration, static, and browser evidence separately | Production mirror, hosted CI, deployment, and production smoke receipts remain absent |
 | R27-014 | MNEMEX/STRATHMARK are not live-scoring dependencies and Missoula owns provisional results. | Domain Contract | Partial | Architecture and failure-handling code exists; not rerun here | Explicit network-denial scoring/build browser test |
 | R27-021 | Cache invalidation cannot evict another tournament or resurrect stale standings after commit. | Multi-tournament integrity | Implemented | Delimited cache keys, generation fencing, PostgreSQL process-cache bypass, and controlled race tests passed | Hosted multi-process cache rehearsal |
@@ -137,6 +137,20 @@ SQLite databases, a disposable local PostgreSQL database, and
   production smoke. The PostgreSQL backup workflow still requires the approved
   `RAILWAY_PG_READONLY_DUMP_URL`, `BACKUP_AGE_RECIPIENT`, and a separately held
   private `age` identity before its hosted evidence can exist.
+
+## 2026-08-19 Full-Dress Rehearsal Receipt
+
+The follow-up local rehearsal is recorded in
+`docs/2027_FULL_DRESS_REHEARSAL.md`. It adds a deterministic guarded load
+harness, a passing 260-user operator-paced load gate, safe run-owned PostgreSQL
+cleanup, cold-cache request coalescing, anonymous public-request query
+reduction, 160 SQLite operations checks, 14 disposable PostgreSQL checks,
+migration safety evidence, a two-session stale-score conflict, responsive
+desktop/phone inspection, and a 15-of-15 origin-down offline reload.
+
+It does not change any `Owner decision` to `Certified` and does not stand in
+for a physical device, hosted CI, production mirror, deployment, production
+smoke, or backup-key-custody receipt.
 
 ## Baseline Disposition
 

--- a/models/heat.py
+++ b/models/heat.py
@@ -425,8 +425,8 @@ class Heat(db.Model):
 
     def acquire_lock(self, user_id: int) -> bool:
         """Attempt to acquire the edit lock. Returns True if successful."""
-        if self.is_locked() and self.locked_by_user_id != user_id:
-            return False
+        if self.is_locked():
+            return self.locked_by_user_id == user_id
         self.locked_by_user_id = user_id
         # The column is timezone-naive. Persisting an aware value lets
         # PostgreSQL convert it through the session timezone before dropping

--- a/routes/api.py
+++ b/routes/api.py
@@ -30,7 +30,7 @@ from models import Event, EventResult, Heat, Team, Tournament
 from models.competitor import ProCompetitor
 from services.handicap_export import build_chopping_rows
 from services.report_cache import get as cache_get
-from services.report_cache import set as cache_set
+from services.report_cache import get_or_compute as cache_get_or_compute
 
 # ---------------------------------------------------------------------------
 # SSE connection counter — caps concurrent long-lived streams at SSE_MAX_CONNECTIONS
@@ -235,59 +235,51 @@ def standings_poll(tournament_id):
     tournament = db.get_or_404(Tournament, tournament_id)
     cache_key = f'api:standings-poll:{tournament_id}'
     ttl_seconds = max(1, int(current_app.config.get('PUBLIC_CACHE_TTL_SECONDS', 5)))
-    cached = cache_get(cache_key)
-    if cached is not None:
-        return jsonify(cached)
 
-    # College team standings
-    teams = []
-    top_teams = (
-        Team.query
-        .filter_by(tournament_id=tournament.id, status='active')
-        .order_by(Team.total_points.desc(), Team.team_code)
-        .limit(15)
-        .all()
-    )
-    for team in top_teams:
-        teams.append({
-            'id': team.id,
-            'team_code': team.team_code,
-            'school_name': team.school_name,
-            'points': team.total_points,
-        })
+    def build_payload():
+        teams = [
+            {
+                'id': team.id,
+                'team_code': team.team_code,
+                'school_name': team.school_name,
+                'points': team.total_points,
+            }
+            for team in (
+                Team.query
+                .filter_by(tournament_id=tournament.id, status='active')
+                .order_by(Team.total_points.desc(), Team.team_code)
+                .limit(15)
+                .all()
+            )
+        ]
+        bull = [
+            {'id': c.id, 'name': c.display_name, 'points': c.individual_points}
+            for c in tournament.get_bull_of_woods(10)
+        ]
+        belle = [
+            {'id': c.id, 'name': c.display_name, 'points': c.individual_points}
+            for c in tournament.get_belle_of_woods(10)
+        ]
+        pro_data = [
+            {'id': c.id, 'name': c.name, 'earnings': c.total_earnings or 0}
+            for c in (
+                ProCompetitor.query
+                .filter_by(tournament_id=tournament.id, status='active')
+                .order_by(ProCompetitor.total_earnings.desc(), ProCompetitor.name)
+                .limit(15)
+                .all()
+            )
+        ]
+        return {
+            'tournament_id': tournament_id,
+            'last_updated': utc_now_naive().isoformat() + 'Z',
+            'college_teams': teams,
+            'bull': bull,
+            'belle': belle,
+            'pro': pro_data,
+        }
 
-    # Bull/Belle of the Woods top 10
-    bull = [
-        {'id': c.id, 'name': c.display_name, 'points': c.individual_points}
-        for c in tournament.get_bull_of_woods(10)
-    ]
-    belle = [
-        {'id': c.id, 'name': c.display_name, 'points': c.individual_points}
-        for c in tournament.get_belle_of_woods(10)
-    ]
-
-    # Pro top earners
-    pro = (
-        ProCompetitor.query
-        .filter_by(tournament_id=tournament.id, status='active')
-        .order_by(ProCompetitor.total_earnings.desc(), ProCompetitor.name)
-        .limit(15)
-        .all()
-    )
-    pro_data = [
-        {'id': c.id, 'name': c.name, 'earnings': c.total_earnings or 0}
-        for c in pro
-    ]
-
-    payload = {
-        'tournament_id': tournament_id,
-        'last_updated': utc_now_naive().isoformat() + 'Z',
-        'college_teams': teams,
-        'bull': bull,
-        'belle': belle,
-        'pro': pro_data,
-    }
-    cache_set(cache_key, payload, ttl_seconds)
+    payload = cache_get_or_compute(cache_key, ttl_seconds, build_payload)
     return jsonify(payload)
 
 

--- a/routes/portal.py
+++ b/routes/portal.py
@@ -21,8 +21,7 @@ from models import Event, EventResult, Heat, Team, Tournament
 from models.competitor import CollegeCompetitor, ProCompetitor
 from models.school_captain import SchoolCaptain
 from routes.api import write_limit
-from services.report_cache import get as cache_get
-from services.report_cache import set as cache_set
+from services.report_cache import get_or_compute as cache_get_or_compute
 
 portal_bp = Blueprint('portal', __name__)
 
@@ -623,12 +622,7 @@ def _completed_result_counts_by_event(event_ids: list[int]) -> dict[int, int]:
 
 def _cached_public_payload(key: str, builder):
     ttl_seconds = max(1, int(current_app.config.get('PUBLIC_CACHE_TTL_SECONDS', 5)))
-    cached = cache_get(key)
-    if cached is not None:
-        return cached
-    payload = builder()
-    cache_set(key, payload, ttl_seconds)
-    return payload
+    return cache_get_or_compute(key, ttl_seconds, builder)
 
 
 def _build_college_spectator_payload(tournament: Tournament) -> dict:

--- a/routes/scoring.py
+++ b/routes/scoring.py
@@ -29,6 +29,7 @@ from flask import (
 )
 from flask_login import current_user, login_required
 from flask_wtf.csrf import CSRFError
+from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import StaleDataError
 
@@ -56,6 +57,7 @@ from services.scoring_workflow import (
     revoke_heat_submission_receipts_for_undo,
     save_heat_results_submission,
 )
+from services.time_utils import utc_now_naive
 
 scoring_bp = Blueprint('scoring', __name__)
 
@@ -139,6 +141,43 @@ def _current_user_can_score_tournament(tournament_id: int) -> bool:
         return False
     user_tournament_id = getattr(current_user, 'tournament_id', None)
     return user_tournament_id is None or int(user_tournament_id) == int(tournament_id)
+
+
+def _acquire_heat_edit_lock(heat: Heat, user_id: int) -> tuple[Heat, bool]:
+    """Atomically acquire an available heat lock without an ORM version race."""
+    if heat.is_locked():
+        return heat, heat.locked_by_user_id == user_id
+
+    heat_id = heat.id
+    now = utc_now_naive()
+    expired_before = now - timedelta(seconds=config.HEAT_LOCK_TTL_SECONDS)
+    updated = (
+        Heat.query.filter(Heat.id == heat_id)
+        .filter(
+            or_(
+                Heat.locked_by_user_id.is_(None),
+                Heat.locked_at.is_(None),
+                Heat.locked_at <= expired_before,
+            )
+        )
+        .update(
+            {
+                Heat.locked_by_user_id: user_id,
+                Heat.locked_at: now,
+                Heat.version_id: Heat.version_id + 1,
+            },
+            synchronize_session=False,
+        )
+    )
+    db.session.commit()
+    db.session.expire_all()
+    current_heat = db.session.get(Heat, heat_id, populate_existing=True)
+    if current_heat is None:
+        abort(404)
+    return current_heat, bool(updated) or (
+        current_heat.is_locked()
+        and current_heat.locked_by_user_id == user_id
+    )
 
 
 def _offline_build_id() -> str:
@@ -985,14 +1024,12 @@ def enter_heat_results(tournament_id, heat_id):
     lock_owner = None
     lock_blocked = False
     if user_id and not preparing_offline:
-        if heat.is_locked() and heat.locked_by_user_id != user_id:
+        heat, lock_acquired = _acquire_heat_edit_lock(heat, user_id)
+        if not lock_acquired:
             lock_blocked = True
             from models.user import User
             locker = db.session.get(User, heat.locked_by_user_id)
             lock_owner = locker.username if locker else f'User #{heat.locked_by_user_id}'
-        else:
-            heat.acquire_lock(user_id)
-            db.session.commit()
 
     competitor_ids = _normalized_heat_competitor_ids(heat)
     comp_lookup = _competitor_lookup(event, competitor_ids)

--- a/scripts/load_test_race_day.py
+++ b/scripts/load_test_race_day.py
@@ -32,6 +32,8 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PRODUCTION_DB_PATH = (PROJECT_ROOT / "instance" / "proam.db").resolve()
+JUDGE_USERNAME = "judge_loadtest_1"
+JUDGE_PASSWORD = "LoadTest123!"
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -56,7 +58,9 @@ def _seed_race_day_data() -> dict:
 
     seed_rng = random.Random(2027)
     app = create_app()
-    with app.app_context():
+    app_context = app.app_context()
+    app_context.push()
+    try:
         tournament = (
             Tournament.query.filter(
                 Tournament.status.in_(["setup", "college_active", "pro_active"])
@@ -120,17 +124,21 @@ def _seed_race_day_data() -> dict:
             db.session.flush()
             pro.append(comp)
 
-        judges = User.query.filter_by(role=User.ROLE_JUDGE).count()
-        while judges < 10:
-            idx = judges + 1
+        judge_usernames = []
+        for idx in range(1, 11):
             username = f"judge_loadtest_{idx}"
-            if User.query.filter_by(username=username).first():
-                judges += 1
-                continue
-            user = User(username=username, role=User.ROLE_JUDGE, display_name=f"Judge {idx}")
-            user.set_password("LoadTest123!")
-            db.session.add(user)
-            judges += 1
+            user = User.query.filter_by(username=username).first()
+            if user is None:
+                user = User(
+                    username=username,
+                    role=User.ROLE_JUDGE,
+                    display_name=f"Judge {idx}",
+                )
+                db.session.add(user)
+            else:
+                user.role = User.ROLE_JUDGE
+            user.set_password(JUDGE_PASSWORD)
+            judge_usernames.append(username)
 
         existing_college_events = (
             Event.query.filter_by(tournament_id=tournament.id, event_type="college", status="completed")
@@ -261,9 +269,15 @@ def _seed_race_day_data() -> dict:
                 int(heat.id)
                 for heat in live_event.heats.order_by(Heat.heat_number).all()
             ],
-            "judge_username": "judge_loadtest_1",
+            "judge_username": JUDGE_USERNAME,
+            "judge_usernames": judge_usernames,
+            "judge_password": JUDGE_PASSWORD,
         }
-    _release_app(app)
+    finally:
+        try:
+            app_context.pop()
+        finally:
+            _release_app(app)
     return seed
 
 
@@ -276,7 +290,20 @@ class Stats:
     status_codes: dict[int, int] = field(default_factory=dict)
     error_kinds: dict[str, int] = field(default_factory=dict)
     error_paths: dict[str, int] = field(default_factory=dict)
+    path_requests: dict[str, int] = field(default_factory=dict)
+    path_errors: dict[str, int] = field(default_factory=dict)
+    path_latencies: dict[str, list[float]] = field(default_factory=dict)
+    activations: list[float] = field(default_factory=list)
+    authentications: int = 0
     lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def activate(self, activated_at: float) -> None:
+        with self.lock:
+            self.activations.append(activated_at)
+
+    def authenticate(self) -> None:
+        with self.lock:
+            self.authentications += 1
 
     def add(
         self,
@@ -290,12 +317,17 @@ class Stats:
             self.total += 1
             if latency >= 0:
                 self.latencies.append(latency)
+            if path:
+                self.path_requests[path] = self.path_requests.get(path, 0) + 1
+                if latency >= 0:
+                    self.path_latencies.setdefault(path, []).append(latency)
             if status is None:
                 self.errors += 1
                 kind = error_kind or "request_error"
                 self.error_kinds[kind] = self.error_kinds.get(kind, 0) + 1
                 if path:
                     self.error_paths[path] = self.error_paths.get(path, 0) + 1
+                    self.path_errors[path] = self.path_errors.get(path, 0) + 1
             elif 200 <= status < 400:
                 self.success += 1
                 self.status_codes[status] = self.status_codes.get(status, 0) + 1
@@ -306,6 +338,7 @@ class Stats:
                 self.error_kinds[kind] = self.error_kinds.get(kind, 0) + 1
                 if path:
                     self.error_paths[path] = self.error_paths.get(path, 0) + 1
+                    self.path_errors[path] = self.path_errors.get(path, 0) + 1
 
 
 def _error_kind(exc: Exception) -> str:
@@ -321,6 +354,39 @@ def _error_kind(exc: Exception) -> str:
     return type(reason).__name__.lower()
 
 
+def _drain_http_error(exc: urllib.error.HTTPError) -> None:
+    try:
+        exc.read()
+    except Exception:
+        pass
+
+
+class CrossOriginRedirectError(RuntimeError):
+    pass
+
+
+def _url_origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urllib.parse.urlsplit(url)
+    port = parsed.port
+    if port is None:
+        port = 443 if parsed.scheme.lower() == "https" else 80
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), port
+
+
+class _SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def __init__(self, base_url: str) -> None:
+        super().__init__()
+        self.allowed_origin = _url_origin(base_url)
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        redirect_url = urllib.parse.urljoin(req.full_url, newurl)
+        if _url_origin(redirect_url) != self.allowed_origin:
+            raise CrossOriginRedirectError(
+                f"Refused cross-origin redirect to {_url_origin(redirect_url)}"
+            )
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
 class _CsrfTokenParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
@@ -334,21 +400,51 @@ class _CsrfTokenParser(HTMLParser):
             self.token = attributes["value"]
 
 
+def _consume_measured_response(
+    response,
+    requested_url: str,
+    *,
+    authenticated: bool,
+) -> tuple[int | None, str | None]:
+    """Read the full response and reject lost authenticated sessions."""
+    response.read()
+    status = int(response.status)
+    final_url = urllib.parse.urlsplit(response.geturl())
+    expected_url = urllib.parse.urlsplit(requested_url)
+    final_target = (
+        *_url_origin(response.geturl()),
+        final_url.path,
+    )
+    expected_target = (
+        *_url_origin(requested_url),
+        expected_url.path,
+    )
+    if final_target == expected_target:
+        return status, None
+    if authenticated and final_url.path == "/auth/login":
+        return 401, "authentication_lost"
+    return None, "unexpected_redirect"
+
+
 def _worker(
     base_url: str,
     endpoints: list[str],
     stop_event: threading.Event,
     stats: Stats,
     timeout: float,
-    start_delay: float,
+    start_at: float,
     think_min: float,
     think_max: float,
     login_credentials: tuple[str, str] | None,
+    rng_seed: int,
 ) -> None:
-    rng = random.Random()
+    rng = random.Random(rng_seed)
+    start_delay = max(0.0, start_at - time.perf_counter())
     if start_delay and stop_event.wait(start_delay):
         return
+    stats.activate(time.perf_counter())
     opener = urllib.request.build_opener(
+        _SameOriginRedirectHandler(base_url),
         urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar())
     )
     if login_credentials:
@@ -372,6 +468,7 @@ def _worker(
                     csrf_status = 401
                     csrf_error = "csrf_token_missing"
         except urllib.error.HTTPError as exc:
+            _drain_http_error(exc)
             csrf_status = int(exc.code)
         except Exception as exc:
             csrf_error = _error_kind(exc)
@@ -399,12 +496,13 @@ def _worker(
                 headers={"User-Agent": "race-day-load-test/1.0"},
             )
             with opener.open(login_request, timeout=timeout) as response:
-                _ = response.read(256)
+                response.read()
                 login_status = int(response.status)
-                if "/auth/login" in response.geturl():
+                if urllib.parse.urlsplit(response.geturl()).path == "/auth/login":
                     login_status = 401
                     login_error = "authentication_failed"
         except urllib.error.HTTPError as exc:
+            _drain_http_error(exc)
             login_status = int(exc.code)
         except Exception as exc:
             login_error = _error_kind(exc)
@@ -416,6 +514,7 @@ def _worker(
         )
         if login_status is None or not 200 <= login_status < 400:
             return
+        stats.authenticate()
 
     while not stop_event.is_set():
         path = rng.choice(endpoints)
@@ -423,17 +522,60 @@ def _worker(
         status = None
         error_kind = None
         try:
-            req = urllib.request.Request(f"{base_url}{path}", headers={"User-Agent": "race-day-load-test/1.0"})
+            request_url = f"{base_url}{path}"
+            req = urllib.request.Request(request_url, headers={"User-Agent": "race-day-load-test/1.0"})
             with opener.open(req, timeout=timeout) as resp:
-                _ = resp.read(256)
-                status = int(resp.status)
+                status, error_kind = _consume_measured_response(
+                    resp,
+                    request_url,
+                    authenticated=login_credentials is not None,
+                )
         except urllib.error.HTTPError as exc:
+            _drain_http_error(exc)
             status = int(exc.code)
         except Exception as exc:
             error_kind = _error_kind(exc)
         latency_ms = (time.perf_counter() - start) * 1000.0
         stats.add(latency_ms, status, error_kind=error_kind, path=f"GET {path}")
         stop_event.wait(rng.uniform(think_min, think_max))
+
+
+def _guarded_worker(
+    worker_errors: list[str],
+    worker_errors_lock: threading.Lock,
+    ready_barrier: threading.Barrier,
+    launch_event: threading.Event,
+    launch_clock: list[float],
+    start_delay: float,
+    base_url: str,
+    endpoints: list[str],
+    stop_event: threading.Event,
+    stats: Stats,
+    timeout: float,
+    think_min: float,
+    think_max: float,
+    login_credentials: tuple[str, str] | None,
+    rng_seed: int,
+) -> None:
+    try:
+        ready_barrier.wait(timeout=60)
+        launch_event.wait()
+        _worker(
+            base_url,
+            endpoints,
+            stop_event,
+            stats,
+            timeout,
+            launch_clock[0] + start_delay,
+            think_min,
+            think_max,
+            login_credentials,
+            rng_seed,
+        )
+    except Exception as exc:
+        with worker_errors_lock:
+            worker_errors.append(f"{type(exc).__name__}: {exc}")
+        stop_event.set()
 
 
 def _percentile(values: list[float], p: float) -> float:
@@ -448,9 +590,19 @@ def _passes_gate(
     report: dict,
     *,
     target_p95_ms: float,
+    target_role_p95_ms: float | None = None,
     max_error_rate: float,
     max_server_errors: int = 0,
 ) -> bool:
+    role_results = _role_gate_results(
+        report,
+        target_role_p95_ms=(
+            target_p95_ms
+            if target_role_p95_ms is None
+            else target_role_p95_ms
+        ),
+        max_error_rate=max_error_rate,
+    )
     server_errors = sum(
         count
         for code, count in report.get("status_codes", {}).items()
@@ -460,7 +612,85 @@ def _passes_gate(
         report["requests"]["error_rate"] <= max_error_rate
         and report["latency_ms"]["p95"] <= target_p95_ms
         and server_errors <= max_server_errors
+        and all(result["passed"] for result in role_results.values())
     )
+
+
+def _role_gate_results(
+    report: dict,
+    *,
+    target_role_p95_ms: float,
+    max_error_rate: float,
+) -> dict[str, dict]:
+    results = {}
+    users = report.get("users", {})
+    for role, summary in report.get("by_role", {}).items():
+        user_count = int(users.get(role, 0))
+        if user_count <= 0:
+            continue
+        minimum_requests = user_count * (3 if role == "judges" else 1)
+        request_count = int(summary.get("requests", 0))
+        error_count = int(summary.get("errors", 0))
+        activation_count = int(summary.get("activations", 0))
+        authentication_count = int(summary.get("authentications", 0))
+        error_rate = error_count / request_count if request_count else 1.0
+        p95_ms = float(summary.get("p95_ms", 0.0))
+        endpoint_results = {}
+        for path in report.get("load_shape", {}).get(
+            "expected_paths",
+            {},
+        ).get(role, []):
+            path_summary = summary.get("by_path", {}).get(path, {})
+            path_requests = int(path_summary.get("requests", 0))
+            path_errors = int(path_summary.get("errors", 0))
+            path_error_rate = (
+                path_errors / path_requests if path_requests else 1.0
+            )
+            path_p95_ms = float(path_summary.get("p95_ms", 0.0))
+            minimum_path_requests = (
+                user_count
+                if role == "judges" and path in {
+                    "GET /auth/login",
+                    "POST /auth/login",
+                }
+                else 1
+            )
+            endpoint_results[path] = {
+                "requests": path_requests,
+                "minimum_requests": minimum_path_requests,
+                "error_rate": path_error_rate,
+                "p95_ms": path_p95_ms,
+                "passed": (
+                    path_requests >= minimum_path_requests
+                    and path_error_rate <= max_error_rate
+                    and path_p95_ms <= target_role_p95_ms
+                ),
+            }
+        results[role] = {
+            "requests": request_count,
+            "minimum_requests": minimum_requests,
+            "configured_users": user_count,
+            "activations": activation_count,
+            "authentications": authentication_count,
+            "error_rate": error_rate,
+            "p95_ms": p95_ms,
+            "endpoints": endpoint_results,
+            "passed": (
+                request_count >= minimum_requests
+                and activation_count == user_count
+                and (
+                    role != "judges"
+                    or authentication_count == user_count
+                )
+                and error_rate <= max_error_rate
+                and p95_ms <= target_role_p95_ms
+                and all(
+                    result["passed"]
+                    for result in endpoint_results.values()
+                )
+            ),
+        }
+    return results
 
 
 def _run_load_test(
@@ -477,6 +707,8 @@ def _run_load_test(
     spectator_think: tuple[float, float] = (25.0, 35.0),
     competitor_think: tuple[float, float] = (20.0, 60.0),
     judge_think: tuple[float, float] = (3.0, 8.0),
+    judge_credentials: list[tuple[str, str]] | None = None,
+    seed: int = 2027,
 ) -> dict:
     user_counts = {
         "spectators": spectator_users,
@@ -513,53 +745,103 @@ def _run_load_test(
 
     stop_event = threading.Event()
     user_specs = []
+    judge_accounts = (
+        [(JUDGE_USERNAME, JUDGE_PASSWORD)]
+        if judge_credentials is None
+        else judge_credentials
+    )
+    if judge_users and not judge_accounts:
+        raise ValueError("At least one judge account is required for judge users.")
     role_specs = (
         (spectator_users, spectator_paths, spectator_stats, spectator_think, None),
         (competitor_users, competitor_paths, competitor_stats, competitor_think, None),
-        (
-            judge_users,
-            judge_paths,
-            judge_stats,
-            judge_think,
-            ("judge_loadtest_1", "LoadTest123!"),
-        ),
     )
     for count, paths, stats, (think_min, think_max), credentials in role_specs:
         for _ in range(count):
             user_specs.append((paths, stats, think_min, think_max, credentials))
+    for index in range(judge_users):
+        user_specs.append((
+            judge_paths,
+            judge_stats,
+            judge_think[0],
+            judge_think[1],
+            judge_accounts[index % len(judge_accounts)],
+        ))
 
-    random.shuffle(user_specs)
+    workload_rng = random.Random(seed)
+    workload_rng.shuffle(user_specs)
     users = []
+    worker_errors = []
+    worker_errors_lock = threading.Lock()
+    ready_barrier = threading.Barrier(len(user_specs) + 1)
+    launch_event = threading.Event()
+    launch_clock = [0.0]
     for index, (paths, stats, think_min, think_max, credentials) in enumerate(user_specs):
         start_delay = ramp_up_s * index / max(1, len(user_specs) - 1)
         users.append(threading.Thread(
-                target=_worker,
+                target=_guarded_worker,
                 args=(
+                    worker_errors,
+                    worker_errors_lock,
+                    ready_barrier,
+                    launch_event,
+                    launch_clock,
+                    start_delay,
                     base_url,
                     paths,
                     stop_event,
                     stats,
                     timeout_s,
-                    start_delay,
                     think_min,
                     think_max,
                     credentials,
+                    workload_rng.randrange(2**63),
                 ),
+                daemon=True,
+                name=f"race-day-user-{index + 1}",
             ))
 
-    start = time.time()
-    for thread in users:
-        thread.start()
-    remaining_ramp = max(0.0, ramp_up_s - (time.time() - start))
-    if remaining_ramp:
-        time.sleep(remaining_ramp)
-    ramp_finished = time.time()
-    if duration_s:
-        time.sleep(duration_s)
-    stop_event.set()
-    for thread in users:
-        thread.join()
-    elapsed = max(0.001, time.time() - start)
+    started_users = []
+    start = None
+    ramp_finished = None
+    try:
+        for thread in users:
+            thread.start()
+            started_users.append(thread)
+        ready_barrier.wait(timeout=60)
+        start = time.perf_counter()
+        launch_clock[0] = start
+        launch_event.set()
+        stop_event.wait(max(0.0, start + ramp_up_s - time.perf_counter()))
+        ramp_finished = time.perf_counter()
+        stop_event.wait(max(0.0, duration_s))
+    finally:
+        stop_event.set()
+        launch_event.set()
+        if start is None:
+            try:
+                ready_barrier.abort()
+            except threading.BrokenBarrierError:
+                pass
+        join_deadline = (
+            time.perf_counter()
+            + timeout_s
+            + max(maximum for _, maximum in think_times.values())
+            + 5.0
+        )
+        for thread in started_users:
+            thread.join(timeout=max(0.0, join_deadline - time.perf_counter()))
+        stuck = [thread.name for thread in started_users if thread.is_alive()]
+        if stuck:
+            raise RuntimeError(
+                f"{len(stuck)} load workers did not stop before the shutdown deadline."
+            )
+    if worker_errors:
+        raise RuntimeError(
+            "Load worker failed unexpectedly: " + "; ".join(worker_errors[:3])
+        )
+    assert start is not None and ramp_finished is not None
+    elapsed = max(0.001, time.perf_counter() - start)
 
     all_latencies = spectator_stats.latencies + competitor_stats.latencies + judge_stats.latencies
     total_requests = spectator_stats.total + competitor_stats.total + judge_stats.total
@@ -577,13 +859,37 @@ def _run_load_test(
             error_path_totals[path] = error_path_totals.get(path, 0) + count
 
     def role_summary(stats: Stats) -> dict:
+        path_summaries = {}
+        for path, requests in sorted(stats.path_requests.items()):
+            errors = stats.path_errors.get(path, 0)
+            path_summaries[path] = {
+                "requests": requests,
+                "errors": errors,
+                "error_rate": errors / requests if requests else 1.0,
+                "p95_ms": _percentile(stats.path_latencies.get(path, []), 0.95),
+            }
         return {
             "requests": stats.total,
             "errors": stats.errors,
+            "activations": len(stats.activations),
+            "authentications": stats.authentications,
+            "error_rate": (stats.errors / stats.total) if stats.total else 1.0,
             "p95_ms": _percentile(stats.latencies, 0.95),
             "error_kinds": dict(sorted(stats.error_kinds.items())),
             "error_paths": dict(sorted(stats.error_paths.items())),
+            "by_path": path_summaries,
         }
+
+    activation_times = (
+        spectator_stats.activations
+        + competitor_stats.activations
+        + judge_stats.activations
+    )
+    actual_ramp = (
+        max(activation_times) - min(activation_times)
+        if len(activation_times) > 1
+        else 0.0
+    )
 
     return {
         "duration_seconds": elapsed,
@@ -594,7 +900,18 @@ def _run_load_test(
         "load_shape": {
             "configured_steady_state_seconds": duration_s,
             "configured_ramp_up_seconds": ramp_up_s,
-            "actual_ramp_up_seconds": ramp_finished - start,
+            "actual_ramp_up_seconds": actual_ramp,
+            "ramp_wait_seconds": ramp_finished - start,
+            "seed": seed,
+            "expected_paths": {
+                "spectators": [f"GET {path}" for path in spectator_paths],
+                "competitors": [f"GET {path}" for path in competitor_paths],
+                "judges": [
+                    "GET /auth/login",
+                    "POST /auth/login",
+                    *[f"GET {path}" for path in judge_paths],
+                ],
+            },
             "think_time_seconds": {
                 role: list(values)
                 for role, values in think_times.items()
@@ -669,6 +986,7 @@ def _start_server(
         suffix=".log",
         delete=False,
     )
+    log_path = Path(log_handle.name)
     try:
         proc = subprocess.Popen(
             cmd,
@@ -677,9 +995,15 @@ def _start_server(
             stderr=subprocess.STDOUT,
             creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
         )
-    finally:
+    except Exception:
         log_handle.close()
-    return proc, Path(log_handle.name)
+        try:
+            log_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+    log_handle.close()
+    return proc, log_path
 
 
 def _server_log_tail(path: Path, limit: int = 4000) -> str:
@@ -732,6 +1056,82 @@ def _resolve_synthetic_database(raw_path: str | None) -> tuple[Path, bool]:
     return Path(generated).resolve(), True
 
 
+def _report_path_aliases_database(
+    output_path: Path,
+    database_path: Path,
+) -> bool:
+    protected_paths = (PRODUCTION_DB_PATH, database_path.resolve())
+    for protected_path in protected_paths:
+        if output_path.resolve() == protected_path:
+            return True
+        if output_path.exists() and protected_path.exists():
+            try:
+                if os.path.samefile(output_path, protected_path):
+                    return True
+            except OSError:
+                pass
+    return False
+
+
+def _resolve_report_output(
+    raw_path: str,
+    *,
+    database_path: Path,
+    overwrite: bool,
+) -> Path:
+    """Resolve a report target without allowing database aliases."""
+    output_path = Path(os.path.abspath(Path(raw_path).expanduser()))
+    if _report_path_aliases_database(output_path, database_path):
+        raise ValueError("The report output path cannot be a database path.")
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(
+            f"Report output already exists; refusing to overwrite: {output_path}"
+        )
+    return output_path
+
+
+def _write_report(
+    path: Path,
+    report: dict,
+    *,
+    overwrite: bool,
+    database_path: Path,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if _report_path_aliases_database(path, database_path):
+        raise ValueError("The report output path cannot be a database path.")
+
+    temp_handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        delete=False,
+    )
+    temp_path = Path(temp_handle.name)
+    try:
+        handle = temp_handle
+        json.dump(report, handle, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        handle.close()
+        if _report_path_aliases_database(path, database_path):
+            raise ValueError("The report output path cannot be a database path.")
+        if overwrite:
+            os.replace(temp_path, path)
+        else:
+            os.link(temp_path, path)
+    finally:
+        if not temp_handle.closed:
+            temp_handle.close()
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
 def _prepare_synthetic_database(path: Path) -> None:
     """Migrate an isolated SQLite database before importing app state."""
     for name in (
@@ -745,7 +1145,6 @@ def _prepare_synthetic_database(path: Path) -> None:
     os.environ["FLASK_ENV"] = "testing"
     os.environ["TESTING"] = "1"
     os.environ["SECRET_KEY"] = "race-day-load-rehearsal-only"
-    os.environ["WTF_CSRF_ENABLED"] = "False"
 
     from flask_migrate import upgrade
 
@@ -795,6 +1194,12 @@ def main() -> int:
         help="Worker process count for multiprocess mode (default: 4).",
     )
     parser.add_argument("--target-p95-ms", type=float, default=800.0, help="Pass/fail target for p95 latency.")
+    parser.add_argument(
+        "--target-role-p95-ms",
+        type=float,
+        default=800.0,
+        help="Pass/fail p95 target applied independently to each active role.",
+    )
     parser.add_argument("--max-error-rate", type=float, default=0.005, help="Pass/fail max error rate.")
     parser.add_argument(
         "--max-server-errors",
@@ -812,9 +1217,20 @@ def main() -> int:
     parser.add_argument("--judge-think-min", type=float, default=3.0)
     parser.add_argument("--judge-think-max", type=float, default=8.0)
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=2027,
+        help="Deterministic workload ordering and pacing seed (default: 2027).",
+    )
+    parser.add_argument(
         "--output",
         default=str(PROJECT_ROOT / "instance" / "load_test_report.json"),
         help="Path for JSON report output.",
+    )
+    parser.add_argument(
+        "--overwrite-output",
+        action="store_true",
+        help="Allow replacing an existing non-database report file.",
     )
     parser.add_argument(
         "--database",
@@ -838,6 +1254,13 @@ def main() -> int:
     database_path, generated = _resolve_synthetic_database(args.database)
     retain_database = bool(args.database or args.keep_database or args.seed_only)
     try:
+        output_path = None
+        if not args.seed_only:
+            output_path = _resolve_report_output(
+                args.output,
+                database_path=database_path,
+                overwrite=args.overwrite_output,
+            )
         _prepare_synthetic_database(database_path)
         seed = _seed_race_day_data()
 
@@ -845,7 +1268,6 @@ def main() -> int:
             print(json.dumps({
                 "database": str(database_path),
                 "synthetic": True,
-                "judge_password": "LoadTest123!",
                 **seed,
             }, indent=2))
             return 0
@@ -883,6 +1305,11 @@ def main() -> int:
                     args.competitor_think_max,
                 ),
                 judge_think=(args.judge_think_min, args.judge_think_max),
+                judge_credentials=[
+                    (username, seed["judge_password"])
+                    for username in seed["judge_usernames"]
+                ],
+                seed=args.seed,
             )
         finally:
             server.terminate()
@@ -900,6 +1327,7 @@ def main() -> int:
         passed = _passes_gate(
             report,
             target_p95_ms=args.target_p95_ms,
+            target_role_p95_ms=args.target_role_p95_ms,
             max_error_rate=args.max_error_rate,
             max_server_errors=args.max_server_errors,
         )
@@ -907,8 +1335,14 @@ def main() -> int:
             "server_mode": args.server,
             "workers": args.workers if args.server == "werkzeug-multiprocess" else 1,
             "target_p95_ms": args.target_p95_ms,
+            "target_role_p95_ms": args.target_role_p95_ms,
             "max_error_rate": args.max_error_rate,
             "max_server_errors": args.max_server_errors,
+            "role_results": _role_gate_results(
+                report,
+                target_role_p95_ms=args.target_role_p95_ms,
+                max_error_rate=args.max_error_rate,
+            ),
             "passed": passed,
         }
         report["fixture"] = {
@@ -920,9 +1354,13 @@ def main() -> int:
         if report["requests"]["errors"]:
             report["diagnostics"] = {"server_log_tail": server_log_tail}
 
-        output_path = Path(args.output)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        assert output_path is not None
+        _write_report(
+            output_path,
+            report,
+            overwrite=args.overwrite_output,
+            database_path=database_path,
+        )
 
         print(json.dumps(report, indent=2))
         print(f"\nReport written to: {output_path}")

--- a/scripts/load_test_race_day.py
+++ b/scripts/load_test_race_day.py
@@ -1,38 +1,60 @@
 """Race-day load test for Missoula Pro Am Manager.
 
 Creates/ensures representative seed data, starts the Flask app locally, and
-executes a mixed-role concurrent HTTP test:
+executes a mixed-role concurrent HTTP test with configurable ramp and pacing:
 - 200 spectator users
 - 50 competitor users
 - 10 judge users
+
+The spectator default tracks the application's 30-second standings poll. Use
+``--ramp-up 0`` and shorter think times explicitly for a cold-burst stress run.
 """
 
 from __future__ import annotations
 
 import argparse
+import http.cookiejar
 import json
+import os
 import random
 import statistics
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass, field
+from html.parser import HTMLParser
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_DB_PATH = (PROJECT_ROOT / "instance" / "proam.db").resolve()
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 
-def _seed_race_day_data() -> int:
+def _release_app(app) -> None:
+    """Release DB handles and the SQLite process fence before a child starts."""
+    from database import db
+
+    with app.app_context():
+        db.session.remove()
+        db.engine.dispose()
+    finalizer = app.extensions.get("sqlite_process_fence_finalizer")
+    if finalizer is not None and finalizer.alive:
+        finalizer()
+
+
+def _seed_race_day_data() -> dict:
     from app import create_app
     from database import db
-    from models import Event, EventResult, Team, Tournament, User
+    from models import Event, EventResult, Heat, Team, Tournament, User
     from models.competitor import CollegeCompetitor, ProCompetitor
 
+    seed_rng = random.Random(2027)
     app = create_app()
     with app.app_context():
         tournament = (
@@ -43,7 +65,11 @@ def _seed_race_day_data() -> int:
             .first()
         )
         if not tournament:
-            tournament = Tournament(name="Missoula Pro Am Load Test", year=2026, status="college_active")
+            tournament = Tournament(
+                name="[REHEARSAL] Missoula Pro Am",
+                year=2027,
+                status="college_active",
+            )
             db.session.add(tournament)
             db.session.flush()
         else:
@@ -72,7 +98,7 @@ def _seed_race_day_data() -> int:
                 team_id=teams[idx % len(teams)].id,
                 name=f"College LoadTest {idx}",
                 gender="M" if idx % 2 else "F",
-                individual_points=random.randint(0, 30),
+                individual_points=seed_rng.randint(0, 30),
                 status="active",
             )
             db.session.add(comp)
@@ -88,7 +114,7 @@ def _seed_race_day_data() -> int:
                 phone=f"406555{1000 + idx}",
                 email=f"pro{idx}@loadtest.local",
                 status="active",
-                total_earnings=float(random.randint(0, 1500)),
+                total_earnings=float(seed_rng.randint(0, 1500)),
             )
             db.session.add(comp)
             db.session.flush()
@@ -185,8 +211,60 @@ def _seed_race_day_data() -> int:
                     )
                     db.session.add(result)
 
+        live_event = Event.query.filter_by(
+            tournament_id=tournament.id,
+            name="Rehearsal Timed Heat",
+        ).first()
+        if live_event is None:
+            live_event = Event(
+                tournament_id=tournament.id,
+                name="Rehearsal Timed Heat",
+                event_type="pro",
+                scoring_type="time",
+                scoring_order="lowest_wins",
+                stand_type="underhand",
+                max_stands=2,
+                status="in_progress",
+                is_finalized=False,
+            )
+            db.session.add(live_event)
+            db.session.flush()
+
+            for competitor in pro[:4]:
+                entered = competitor.get_events_entered()
+                if live_event.id not in entered:
+                    entered.append(live_event.id)
+                    competitor.set_events_entered(entered)
+
+            for heat_number, competitors in enumerate((pro[:2], pro[2:4]), start=1):
+                heat = Heat(
+                    event_id=live_event.id,
+                    heat_number=heat_number,
+                    run_number=1,
+                    status="pending",
+                )
+                db.session.add(heat)
+                heat.set_roster(
+                    "pro",
+                    [competitor.id for competitor in competitors],
+                    {
+                        str(competitor.id): stand
+                        for stand, competitor in enumerate(competitors, start=1)
+                    },
+                )
+
         db.session.commit()
-        return int(tournament.id)
+        seed = {
+            "tournament_id": int(tournament.id),
+            "live_event_id": int(live_event.id),
+            "heat_ids": [
+                int(heat.id)
+                for heat in live_event.heats.order_by(Heat.heat_number).all()
+            ],
+            "judge_username": "judge_loadtest_1",
+        }
+    _release_app(app)
+    return seed
 
 
 @dataclass
@@ -196,41 +274,166 @@ class Stats:
     success: int = 0
     total: int = 0
     status_codes: dict[int, int] = field(default_factory=dict)
+    error_kinds: dict[str, int] = field(default_factory=dict)
+    error_paths: dict[str, int] = field(default_factory=dict)
     lock: threading.Lock = field(default_factory=threading.Lock)
 
-    def add(self, latency: float, status: int | None) -> None:
+    def add(
+        self,
+        latency: float,
+        status: int | None,
+        *,
+        error_kind: str | None = None,
+        path: str | None = None,
+    ) -> None:
         with self.lock:
             self.total += 1
             if latency >= 0:
                 self.latencies.append(latency)
             if status is None:
                 self.errors += 1
+                kind = error_kind or "request_error"
+                self.error_kinds[kind] = self.error_kinds.get(kind, 0) + 1
+                if path:
+                    self.error_paths[path] = self.error_paths.get(path, 0) + 1
             elif 200 <= status < 400:
                 self.success += 1
                 self.status_codes[status] = self.status_codes.get(status, 0) + 1
             else:
                 self.errors += 1
                 self.status_codes[status] = self.status_codes.get(status, 0) + 1
+                kind = error_kind or f"http_{status}"
+                self.error_kinds[kind] = self.error_kinds.get(kind, 0) + 1
+                if path:
+                    self.error_paths[path] = self.error_paths.get(path, 0) + 1
 
 
-def _worker(base_url: str, endpoints: list[str], end_time: float, stats: Stats, timeout: float) -> None:
+def _error_kind(exc: Exception) -> str:
+    reason = exc.reason if isinstance(exc, urllib.error.URLError) else exc
+    if isinstance(reason, TimeoutError):
+        return "timeout"
+    if isinstance(reason, ConnectionRefusedError):
+        return "connection_refused"
+    if isinstance(reason, ConnectionResetError):
+        return "connection_reset"
+    if isinstance(reason, OSError):
+        return f"network_{type(reason).__name__.lower()}"
+    return type(reason).__name__.lower()
+
+
+class _CsrfTokenParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.token: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "input":
+            return
+        attributes = dict(attrs)
+        if attributes.get("name") == "csrf_token" and attributes.get("value"):
+            self.token = attributes["value"]
+
+
+def _worker(
+    base_url: str,
+    endpoints: list[str],
+    stop_event: threading.Event,
+    stats: Stats,
+    timeout: float,
+    start_delay: float,
+    think_min: float,
+    think_max: float,
+    login_credentials: tuple[str, str] | None,
+) -> None:
     rng = random.Random()
-    while time.time() < end_time:
+    if start_delay and stop_event.wait(start_delay):
+        return
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPCookieProcessor(http.cookiejar.CookieJar())
+    )
+    if login_credentials:
+        username, password = login_credentials
+        login_url = f"{base_url}/auth/login"
+        csrf_token = None
+        csrf_start = time.perf_counter()
+        csrf_status = None
+        csrf_error = None
+        try:
+            csrf_request = urllib.request.Request(
+                login_url,
+                headers={"User-Agent": "race-day-load-test/1.0"},
+            )
+            with opener.open(csrf_request, timeout=timeout) as response:
+                parser = _CsrfTokenParser()
+                parser.feed(response.read().decode("utf-8", errors="replace"))
+                csrf_status = int(response.status)
+                csrf_token = parser.token
+                if not csrf_token:
+                    csrf_status = 401
+                    csrf_error = "csrf_token_missing"
+        except urllib.error.HTTPError as exc:
+            csrf_status = int(exc.code)
+        except Exception as exc:
+            csrf_error = _error_kind(exc)
+        stats.add(
+            (time.perf_counter() - csrf_start) * 1000.0,
+            csrf_status,
+            error_kind=csrf_error,
+            path="GET /auth/login",
+        )
+        if csrf_status is None or not 200 <= csrf_status < 400:
+            return
+
+        login_start = time.perf_counter()
+        login_status = None
+        login_error = None
+        try:
+            login_data = urllib.parse.urlencode({
+                "username": username,
+                "password": password,
+                "csrf_token": csrf_token,
+            }).encode("ascii")
+            login_request = urllib.request.Request(
+                login_url,
+                data=login_data,
+                headers={"User-Agent": "race-day-load-test/1.0"},
+            )
+            with opener.open(login_request, timeout=timeout) as response:
+                _ = response.read(256)
+                login_status = int(response.status)
+                if "/auth/login" in response.geturl():
+                    login_status = 401
+                    login_error = "authentication_failed"
+        except urllib.error.HTTPError as exc:
+            login_status = int(exc.code)
+        except Exception as exc:
+            login_error = _error_kind(exc)
+        stats.add(
+            (time.perf_counter() - login_start) * 1000.0,
+            login_status,
+            error_kind=login_error,
+            path="POST /auth/login",
+        )
+        if login_status is None or not 200 <= login_status < 400:
+            return
+
+    while not stop_event.is_set():
         path = rng.choice(endpoints)
         start = time.perf_counter()
         status = None
+        error_kind = None
         try:
             req = urllib.request.Request(f"{base_url}{path}", headers={"User-Agent": "race-day-load-test/1.0"})
-            with urllib.request.urlopen(req, timeout=timeout) as resp:
+            with opener.open(req, timeout=timeout) as resp:
                 _ = resp.read(256)
                 status = int(resp.status)
         except urllib.error.HTTPError as exc:
             status = int(exc.code)
-        except Exception:
-            status = None
+        except Exception as exc:
+            error_kind = _error_kind(exc)
         latency_ms = (time.perf_counter() - start) * 1000.0
-        stats.add(latency_ms, status)
-        time.sleep(rng.uniform(0.2, 1.0))
+        stats.add(latency_ms, status, error_kind=error_kind, path=f"GET {path}")
+        stop_event.wait(rng.uniform(think_min, think_max))
 
 
 def _percentile(values: list[float], p: float) -> float:
@@ -241,7 +444,56 @@ def _percentile(values: list[float], p: float) -> float:
     return ordered[index]
 
 
-def _run_load_test(base_url: str, tournament_id: int, duration_s: int, timeout_s: float) -> dict:
+def _passes_gate(
+    report: dict,
+    *,
+    target_p95_ms: float,
+    max_error_rate: float,
+    max_server_errors: int = 0,
+) -> bool:
+    server_errors = sum(
+        count
+        for code, count in report.get("status_codes", {}).items()
+        if int(code) >= 500
+    )
+    return (
+        report["requests"]["error_rate"] <= max_error_rate
+        and report["latency_ms"]["p95"] <= target_p95_ms
+        and server_errors <= max_server_errors
+    )
+
+
+def _run_load_test(
+    base_url: str,
+    tournament_id: int,
+    duration_s: int,
+    timeout_s: float,
+    *,
+    spectator_users: int = 200,
+    competitor_users: int = 50,
+    judge_users: int = 10,
+    judge_heat_ids: list[int] | None = None,
+    ramp_up_s: float = 15.0,
+    spectator_think: tuple[float, float] = (25.0, 35.0),
+    competitor_think: tuple[float, float] = (20.0, 60.0),
+    judge_think: tuple[float, float] = (3.0, 8.0),
+) -> dict:
+    user_counts = {
+        "spectators": spectator_users,
+        "competitors": competitor_users,
+        "judges": judge_users,
+    }
+    if duration_s < 0 or ramp_up_s < 0 or any(count < 0 for count in user_counts.values()):
+        raise ValueError("Duration, ramp-up, and virtual-user counts must be non-negative.")
+    think_times = {
+        "spectators": spectator_think,
+        "competitors": competitor_think,
+        "judges": judge_think,
+    }
+    for role, (minimum, maximum) in think_times.items():
+        if minimum < 0 or maximum < minimum:
+            raise ValueError(f"Invalid think-time range for {role}: {minimum}, {maximum}")
+
     spectator_paths = [
         f"/portal/spectator/{tournament_id}",
         f"/portal/spectator/{tournament_id}/college",
@@ -249,25 +501,62 @@ def _run_load_test(base_url: str, tournament_id: int, duration_s: int, timeout_s
         f"/api/public/tournaments/{tournament_id}/standings-poll",
     ]
     competitor_paths = ["/portal/competitor-access", "/"]
-    judge_paths = ["/auth/login", "/"]
+    judge_paths = [f"/scoring/{tournament_id}/offline-ops"]
+    judge_paths.extend(
+        f"/scoring/{tournament_id}/heat/{heat_id}/enter"
+        for heat_id in (judge_heat_ids or [])
+    )
 
     spectator_stats = Stats()
     competitor_stats = Stats()
     judge_stats = Stats()
 
-    users = []
-    end_time = time.time() + duration_s
-    for _ in range(200):
-        users.append(threading.Thread(target=_worker, args=(base_url, spectator_paths, end_time, spectator_stats, timeout_s)))
-    for _ in range(50):
-        users.append(threading.Thread(target=_worker, args=(base_url, competitor_paths, end_time, competitor_stats, timeout_s)))
-    for _ in range(10):
-        users.append(threading.Thread(target=_worker, args=(base_url, judge_paths, end_time, judge_stats, timeout_s)))
+    stop_event = threading.Event()
+    user_specs = []
+    role_specs = (
+        (spectator_users, spectator_paths, spectator_stats, spectator_think, None),
+        (competitor_users, competitor_paths, competitor_stats, competitor_think, None),
+        (
+            judge_users,
+            judge_paths,
+            judge_stats,
+            judge_think,
+            ("judge_loadtest_1", "LoadTest123!"),
+        ),
+    )
+    for count, paths, stats, (think_min, think_max), credentials in role_specs:
+        for _ in range(count):
+            user_specs.append((paths, stats, think_min, think_max, credentials))
 
-    random.shuffle(users)
+    random.shuffle(user_specs)
+    users = []
+    for index, (paths, stats, think_min, think_max, credentials) in enumerate(user_specs):
+        start_delay = ramp_up_s * index / max(1, len(user_specs) - 1)
+        users.append(threading.Thread(
+                target=_worker,
+                args=(
+                    base_url,
+                    paths,
+                    stop_event,
+                    stats,
+                    timeout_s,
+                    start_delay,
+                    think_min,
+                    think_max,
+                    credentials,
+                ),
+            ))
+
     start = time.time()
     for thread in users:
         thread.start()
+    remaining_ramp = max(0.0, ramp_up_s - (time.time() - start))
+    if remaining_ramp:
+        time.sleep(remaining_ramp)
+    ramp_finished = time.time()
+    if duration_s:
+        time.sleep(duration_s)
+    stop_event.set()
     for thread in users:
         thread.join()
     elapsed = max(0.001, time.time() - start)
@@ -277,13 +566,40 @@ def _run_load_test(base_url: str, tournament_id: int, duration_s: int, timeout_s
     total_errors = spectator_stats.errors + competitor_stats.errors + judge_stats.errors
     total_success = spectator_stats.success + competitor_stats.success + judge_stats.success
     status_totals: dict[int, int] = {}
+    error_totals: dict[str, int] = {}
+    error_path_totals: dict[str, int] = {}
     for role_stats in (spectator_stats, competitor_stats, judge_stats):
         for code, count in role_stats.status_codes.items():
             status_totals[code] = status_totals.get(code, 0) + count
+        for kind, count in role_stats.error_kinds.items():
+            error_totals[kind] = error_totals.get(kind, 0) + count
+        for path, count in role_stats.error_paths.items():
+            error_path_totals[path] = error_path_totals.get(path, 0) + count
+
+    def role_summary(stats: Stats) -> dict:
+        return {
+            "requests": stats.total,
+            "errors": stats.errors,
+            "p95_ms": _percentile(stats.latencies, 0.95),
+            "error_kinds": dict(sorted(stats.error_kinds.items())),
+            "error_paths": dict(sorted(stats.error_paths.items())),
+        }
 
     return {
         "duration_seconds": elapsed,
-        "users": {"spectators": 200, "competitors": 50, "judges": 10, "total": 260},
+        "users": {
+            **user_counts,
+            "total": sum(user_counts.values()),
+        },
+        "load_shape": {
+            "configured_steady_state_seconds": duration_s,
+            "configured_ramp_up_seconds": ramp_up_s,
+            "actual_ramp_up_seconds": ramp_finished - start,
+            "think_time_seconds": {
+                role: list(values)
+                for role, values in think_times.items()
+            },
+        },
         "requests": {
             "total": total_requests,
             "success": total_success,
@@ -302,27 +618,22 @@ def _run_load_test(base_url: str, tournament_id: int, duration_s: int, timeout_s
             str(code): count
             for code, count in sorted(status_totals.items())
         },
+        "error_kinds": dict(sorted(error_totals.items())),
+        "error_paths": dict(sorted(error_path_totals.items())),
         "by_role": {
-            "spectators": {
-                "requests": spectator_stats.total,
-                "errors": spectator_stats.errors,
-                "p95_ms": _percentile(spectator_stats.latencies, 0.95),
-            },
-            "competitors": {
-                "requests": competitor_stats.total,
-                "errors": competitor_stats.errors,
-                "p95_ms": _percentile(competitor_stats.latencies, 0.95),
-            },
-            "judges": {
-                "requests": judge_stats.total,
-                "errors": judge_stats.errors,
-                "p95_ms": _percentile(judge_stats.latencies, 0.95),
-            },
+            "spectators": role_summary(spectator_stats),
+            "competitors": role_summary(competitor_stats),
+            "judges": role_summary(judge_stats),
         },
     }
 
 
-def _start_server(host: str, port: int, server_mode: str, workers: int) -> subprocess.Popen:
+def _start_server(
+    host: str,
+    port: int,
+    server_mode: str,
+    workers: int,
+) -> tuple[subprocess.Popen, Path]:
     if server_mode == "flask-threaded":
         cmd = [
             sys.executable,
@@ -353,19 +664,44 @@ def _start_server(host: str, port: int, server_mode: str, workers: int) -> subpr
     else:
         raise ValueError(f"Unsupported server mode: {server_mode}")
 
-    proc = subprocess.Popen(
-        cmd,
-        cwd=str(PROJECT_ROOT),
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+    log_handle = tempfile.NamedTemporaryFile(
+        prefix="proam-race-day-server-",
+        suffix=".log",
+        delete=False,
     )
-    return proc
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(PROJECT_ROOT),
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            creationflags=getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+        )
+    finally:
+        log_handle.close()
+    return proc, Path(log_handle.name)
 
 
-def _wait_for_server(base_url: str, timeout_s: float = 20.0) -> None:
+def _server_log_tail(path: Path, limit: int = 4000) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")[-limit:]
+    except OSError:
+        return "(server log unavailable)"
+
+
+def _wait_for_server(
+    base_url: str,
+    *,
+    process: subprocess.Popen,
+    log_path: Path,
+    timeout_s: float = 20.0,
+) -> None:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                "Server exited before becoming ready.\n" + _server_log_tail(log_path)
+            )
         try:
             with urllib.request.urlopen(f"{base_url}/", timeout=2.0) as resp:
                 if 200 <= resp.status < 500:
@@ -373,12 +709,76 @@ def _wait_for_server(base_url: str, timeout_s: float = 20.0) -> None:
         except Exception:
             pass
         time.sleep(0.3)
-    raise RuntimeError("Server did not become ready in time.")
+    raise RuntimeError(
+        "Server did not become ready in time.\n" + _server_log_tail(log_path)
+    )
+
+
+def _resolve_synthetic_database(raw_path: str | None) -> tuple[Path, bool]:
+    """Return a non-production SQLite path and whether this run created it."""
+    if raw_path:
+        path = Path(raw_path).expanduser().resolve()
+        if path == PRODUCTION_DB_PATH:
+            raise ValueError("The race-day load test refuses instance/proam.db.")
+        if path.exists():
+            raise FileExistsError(
+                f"Synthetic database already exists; refusing to overwrite: {path}"
+            )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path, False
+
+    handle, generated = tempfile.mkstemp(prefix="proam-race-day-rehearsal-", suffix=".db")
+    os.close(handle)
+    return Path(generated).resolve(), True
+
+
+def _prepare_synthetic_database(path: Path) -> None:
+    """Migrate an isolated SQLite database before importing app state."""
+    for name in (
+        "PRODUCTION",
+        "RAILWAY_ENVIRONMENT",
+        "STRATHMARK_SUPABASE_URL",
+        "STRATHMARK_SUPABASE_KEY",
+    ):
+        os.environ.pop(name, None)
+    os.environ["DATABASE_URL"] = f"sqlite:///{path.as_posix()}"
+    os.environ["FLASK_ENV"] = "testing"
+    os.environ["TESTING"] = "1"
+    os.environ["SECRET_KEY"] = "race-day-load-rehearsal-only"
+    os.environ["WTF_CSRF_ENABLED"] = "False"
+
+    from flask_migrate import upgrade
+
+    from app import create_app
+    from database import db
+
+    app = create_app()
+    try:
+        with app.app_context():
+            db.engine.dispose()
+            upgrade(directory=str(PROJECT_ROOT / "migrations"))
+            db.engine.dispose()
+    finally:
+        _release_app(app)
+
+
+def _remove_synthetic_database(path: Path) -> None:
+    for candidate in (path, Path(f"{path}-wal"), Path(f"{path}-shm")):
+        try:
+            candidate.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run race-day mixed-role load test.")
     parser.add_argument("--duration", type=int, default=45, help="Test duration in seconds (default: 45).")
+    parser.add_argument(
+        "--ramp-up",
+        type=float,
+        default=15.0,
+        help="Seconds over which virtual users start (default: 15).",
+    )
     parser.add_argument("--host", default="127.0.0.1", help="Host bind/target (default: 127.0.0.1).")
     parser.add_argument("--port", type=int, default=5050, help="Port bind/target (default: 5050).")
     parser.add_argument("--timeout", type=float, default=6.0, help="Per-request timeout seconds (default: 6).")
@@ -397,46 +797,140 @@ def main() -> int:
     parser.add_argument("--target-p95-ms", type=float, default=800.0, help="Pass/fail target for p95 latency.")
     parser.add_argument("--max-error-rate", type=float, default=0.005, help="Pass/fail max error rate.")
     parser.add_argument(
+        "--max-server-errors",
+        type=int,
+        default=0,
+        help="Pass/fail maximum HTTP 5xx responses (default: 0).",
+    )
+    parser.add_argument("--spectator-users", type=int, default=200)
+    parser.add_argument("--competitor-users", type=int, default=50)
+    parser.add_argument("--judge-users", type=int, default=10)
+    parser.add_argument("--spectator-think-min", type=float, default=25.0)
+    parser.add_argument("--spectator-think-max", type=float, default=35.0)
+    parser.add_argument("--competitor-think-min", type=float, default=20.0)
+    parser.add_argument("--competitor-think-max", type=float, default=60.0)
+    parser.add_argument("--judge-think-min", type=float, default=3.0)
+    parser.add_argument("--judge-think-max", type=float, default=8.0)
+    parser.add_argument(
         "--output",
         default=str(PROJECT_ROOT / "instance" / "load_test_report.json"),
         help="Path for JSON report output.",
     )
+    parser.add_argument(
+        "--database",
+        help=(
+            "New synthetic SQLite database path. Existing files and "
+            "instance/proam.db are always refused."
+        ),
+    )
+    parser.add_argument(
+        "--keep-database",
+        action="store_true",
+        help="Retain an automatically created synthetic database after the run.",
+    )
+    parser.add_argument(
+        "--seed-only",
+        action="store_true",
+        help="Migrate and seed the browser rehearsal database without running load.",
+    )
     args = parser.parse_args()
 
-    tournament_id = _seed_race_day_data()
-    base_url = f"http://{args.host}:{args.port}"
-
-    server = _start_server(args.host, args.port, args.server, args.workers)
+    database_path, generated = _resolve_synthetic_database(args.database)
+    retain_database = bool(args.database or args.keep_database or args.seed_only)
     try:
-        _wait_for_server(base_url)
-        report = _run_load_test(base_url, tournament_id, args.duration, args.timeout)
-    finally:
-        server.terminate()
+        _prepare_synthetic_database(database_path)
+        seed = _seed_race_day_data()
+
+        if args.seed_only:
+            print(json.dumps({
+                "database": str(database_path),
+                "synthetic": True,
+                "judge_password": "LoadTest123!",
+                **seed,
+            }, indent=2))
+            return 0
+
+        base_url = f"http://{args.host}:{args.port}"
+        server, server_log = _start_server(
+            args.host,
+            args.port,
+            args.server,
+            args.workers,
+        )
+        server_log_tail = ""
         try:
-            server.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            server.kill()
+            _wait_for_server(
+                base_url,
+                process=server,
+                log_path=server_log,
+            )
+            report = _run_load_test(
+                base_url,
+                seed["tournament_id"],
+                args.duration,
+                args.timeout,
+                spectator_users=args.spectator_users,
+                competitor_users=args.competitor_users,
+                judge_users=args.judge_users,
+                judge_heat_ids=seed["heat_ids"],
+                ramp_up_s=args.ramp_up,
+                spectator_think=(
+                    args.spectator_think_min,
+                    args.spectator_think_max,
+                ),
+                competitor_think=(
+                    args.competitor_think_min,
+                    args.competitor_think_max,
+                ),
+                judge_think=(args.judge_think_min, args.judge_think_max),
+            )
+        finally:
+            server.terminate()
+            try:
+                server.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                server.kill()
+                server.wait(timeout=5)
+            server_log_tail = _server_log_tail(server_log, limit=16000)
+            try:
+                server_log.unlink()
+            except FileNotFoundError:
+                pass
 
-    passed = (
-        report["requests"]["error_rate"] <= args.max_error_rate
-        and report["latency_ms"]["p95"] <= args.target_p95_ms
-    )
-    report["gate"] = {
-        "server_mode": args.server,
-        "workers": args.workers if args.server == "werkzeug-multiprocess" else 1,
-        "target_p95_ms": args.target_p95_ms,
-        "max_error_rate": args.max_error_rate,
-        "passed": passed,
-    }
+        passed = _passes_gate(
+            report,
+            target_p95_ms=args.target_p95_ms,
+            max_error_rate=args.max_error_rate,
+            max_server_errors=args.max_server_errors,
+        )
+        report["gate"] = {
+            "server_mode": args.server,
+            "workers": args.workers if args.server == "werkzeug-multiprocess" else 1,
+            "target_p95_ms": args.target_p95_ms,
+            "max_error_rate": args.max_error_rate,
+            "max_server_errors": args.max_server_errors,
+            "passed": passed,
+        }
+        report["fixture"] = {
+            "synthetic": True,
+            "tournament_id": seed["tournament_id"],
+            "live_event_id": seed["live_event_id"],
+            "heat_count": len(seed["heat_ids"]),
+        }
+        if report["requests"]["errors"]:
+            report["diagnostics"] = {"server_log_tail": server_log_tail}
 
-    output_path = Path(args.output)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
 
-    print(json.dumps(report, indent=2))
-    print(f"\nReport written to: {output_path}")
+        print(json.dumps(report, indent=2))
+        print(f"\nReport written to: {output_path}")
 
-    return 0
+        return 0 if passed else 1
+    finally:
+        if generated and not retain_database:
+            _remove_synthetic_database(database_path)
 
 
 if __name__ == "__main__":

--- a/services/report_cache.py
+++ b/services/report_cache.py
@@ -19,11 +19,15 @@ import builtins
 import logging
 import threading
 import time
+from collections.abc import Callable
+from typing import TypeVar
 
 logger = logging.getLogger(__name__)
 
 _cache: dict = {}
 _lock = threading.Lock()
+_fill_locks: dict[str, threading.Lock] = {}
+_T = TypeVar('_T')
 
 # A cache miss records the generation for that key in the reading thread. If
 # an invalidation affecting the key lands before the reader calls set(), the
@@ -185,6 +189,32 @@ def set(key: str, value, ttl_seconds: int) -> None:
                 'to plain data so cached values do not outlive their session.', key)
             return
         _shelf_set(key, value, expires_at)
+
+
+def get_or_compute(key: str, ttl_seconds: int, builder: Callable[[], _T]) -> _T:
+    """Return a cached value, coalescing concurrent fills for one key.
+
+    Public standings can receive a cold burst after a local restart. Without a
+    per-key fill lock, every reader repeats the same queries before the first
+    result reaches the cache. Different keys retain independent locks.
+    """
+    if not _cache_enabled():
+        return builder()
+
+    cached = get(key)
+    if cached is not None:
+        return cached
+
+    with _lock:
+        fill_lock = _fill_locks.setdefault(key, threading.Lock())
+
+    with fill_lock:
+        cached = get(key)
+        if cached is not None:
+            return cached
+        value = builder()
+        set(key, value, ttl_seconds)
+        return value
 
 
 def invalidate_prefix(prefix: str) -> None:

--- a/services/report_cache.py
+++ b/services/report_cache.py
@@ -19,6 +19,7 @@ import builtins
 import logging
 import threading
 import time
+import weakref
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -26,7 +27,9 @@ logger = logging.getLogger(__name__)
 
 _cache: dict = {}
 _lock = threading.Lock()
-_fill_locks: dict[str, threading.Lock] = {}
+_fill_locks: weakref.WeakValueDictionary[str, threading.Lock] = (
+    weakref.WeakValueDictionary()
+)
 _T = TypeVar('_T')
 
 # A cache miss records the generation for that key in the reading thread. If
@@ -215,6 +218,19 @@ def get_or_compute(key: str, ttl_seconds: int, builder: Callable[[], _T]) -> _T:
         value = builder()
         set(key, value, ttl_seconds)
         return value
+
+
+def reset_for_testing() -> None:
+    """Reset process-local state between isolated test applications."""
+    global _generation_counter, _shelf_path, _shelf_resolved
+    with _lock:
+        _cache.clear()
+        _fill_locks.clear()
+        _prefix_generations.clear()
+        _generation_counter = 0
+    _read_state.misses = {}
+    _shelf_path = None
+    _shelf_resolved = True
 
 
 def invalidate_prefix(prefix: str) -> None:

--- a/tests/db_test_utils.py
+++ b/tests/db_test_utils.py
@@ -59,6 +59,7 @@ def _isolate_report_cache():
 
     with report_cache._lock:
         report_cache._cache.clear()
+        report_cache._fill_locks.clear()
         report_cache._prefix_generations.clear()
         report_cache._generation_counter = 0
     report_cache._read_state.misses = {}
@@ -144,13 +145,9 @@ def _ensure_pg_template():
     if _pg_template_ready:
         return
     _pg_preflight()
-    # Sweep clones orphaned by earlier runs (callers that os.unlink() the
-    # handle no-op on PG names, so crashes leave databases behind).
-    stale = _pg_run(
-        "SELECT datname FROM pg_database WHERE datname LIKE 'proam_unit_%' "
-        f"AND datname <> '{_PG_TEMPLATE}'")
-    for name in stale.stdout.split():
-        _pg_run(f'DROP DATABASE IF EXISTS {name} (FORCE)')
+    # Never sweep by prefix here. Another checkout may be running the same
+    # suite, and this process cannot prove that an existing clone is orphaned.
+    # Each factory call drops only the unique database name it created.
     head = _chain_head()
     probe = _pg_run(
         f"SELECT 1 FROM pg_database WHERE datname='{_PG_TEMPLATE}'")
@@ -208,6 +205,7 @@ def _create_test_app_pg():
             'WTF_CSRF_CHECK_DEFAULT': False,
             'SERVER_NAME': None,
         })
+        os.makedirs(_app.instance_path, exist_ok=True)
         with _app.app_context():
             _db.engine.dispose()
         _isolate_report_cache()
@@ -272,6 +270,11 @@ def create_test_app(*, use_migrations=False):
             'WTF_CSRF_CHECK_DEFAULT': False,
             'SERVER_NAME': None,
         })
+        # Fresh clones do not contain Flask's ignored instance directory.
+        # Recovery/export tests may create isolated artifacts there, so make
+        # the directory part of the test-app contract instead of relying on a
+        # developer's previous local run to have created it.
+        os.makedirs(_app.instance_path, exist_ok=True)
 
         # Verify the app is NOT pointing at the production DB
         uri = _app.config.get('SQLALCHEMY_DATABASE_URI', '')

--- a/tests/db_test_utils.py
+++ b/tests/db_test_utils.py
@@ -10,11 +10,12 @@ Import this from any test file:
     from tests.db_test_utils import create_test_app
 
 D14-B: set PROAM_UNIT_PG=1 to back the same factory with PostgreSQL instead
-of SQLite. A schema template database (proam_unit_template) is built once
-per interpreter via migrations, then every create_test_app() call clones it
-(createdb -T, ~100ms) and returns a connection string to a private
-throwaway database. Same engine as production: same locking, same NULL
-ordering, same jsonb.
+of SQLite. A schema template database namespaced by the Alembic head is built
+once per interpreter via migrations, then every create_test_app() call clones
+it (createdb -T, ~100ms) and returns a connection string to a private throwaway
+database. Advisory locking serializes template construction across concurrent
+checkouts. Same engine as production: same locking, same NULL ordering, same
+jsonb.
 
 Which engine runs when, and why (c44):
 
@@ -33,8 +34,10 @@ exactly two skips, both in the backup/restore path, both deliberate and
 documented at skip_unless_sqlite(). Any new divergence is a bug in one of
 the two, not an accepted cost of the split.
 """
+import hashlib
 import os
 import tempfile
+from contextlib import contextmanager
 
 os.environ.setdefault('SECRET_KEY', 'test-secret-conftest')
 os.environ.setdefault('WTF_CSRF_ENABLED', 'False')
@@ -48,8 +51,9 @@ _PG_PORT = os.environ.get("PROAM_UNIT_PG_PORT", "5432")
 _PG_USER = os.environ.get("PROAM_UNIT_PG_USER", "proam")
 _PG_PASSWORD = os.environ.get("PROAM_UNIT_PG_PASSWORD", "proam")
 _PG_URL = f"postgresql://{_PG_USER}:{_PG_PASSWORD}@{_PG_HOST}:{_PG_PORT}"
-_PG_TEMPLATE = "proam_unit_template"
-_pg_template_ready = False
+_PG_TEMPLATE_PREFIX = "proam_unit_template"
+_PG_TEMPLATE_LOCK_ID = 0x50524F414D544D50
+_pg_template_ready: str | None = None
 _pg_counter = [0]
 
 
@@ -57,14 +61,7 @@ def _isolate_report_cache():
     """Clear process cache state and keep tests out of the production shelf."""
     from services import report_cache
 
-    with report_cache._lock:
-        report_cache._cache.clear()
-        report_cache._fill_locks.clear()
-        report_cache._prefix_generations.clear()
-        report_cache._generation_counter = 0
-    report_cache._read_state.misses = {}
-    report_cache._shelf_path = None
-    report_cache._shelf_resolved = True
+    report_cache.reset_for_testing()
 
 
 def _pg_run(sql, dbname="postgres"):
@@ -97,6 +94,38 @@ def _pg_preflight():
     )
 
 
+def _pg_template_name(head: str) -> str:
+    """Give each migration head an immutable, checkout-safe template."""
+    digest = hashlib.sha256(head.encode("utf-8")).hexdigest()[:12]
+    return f"{_PG_TEMPLATE_PREFIX}_{digest}"
+
+
+@contextmanager
+def _pg_template_lock():
+    """Serialize template inspection and construction across checkouts."""
+    import psycopg2
+
+    connection = psycopg2.connect(f"{_PG_URL}/postgres")
+    connection.autocommit = True
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT pg_advisory_lock(%s)", (_PG_TEMPLATE_LOCK_ID,))
+        yield
+    finally:
+        try:
+            cursor.execute("SELECT pg_advisory_unlock(%s)", (_PG_TEMPLATE_LOCK_ID,))
+        finally:
+            cursor.close()
+            connection.close()
+
+
+def _require_pg_success(result, action: str) -> None:
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{action} failed: {(result.stderr or '').strip() or '(no output)'}"
+        )
+
+
 _MIGRATIONS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'migrations')
 
@@ -111,8 +140,8 @@ def _chain_head():
     return ScriptDirectory(_MIGRATIONS_DIR).get_current_head()
 
 
-def _template_is_stale(head):
-    """True when proam_unit_template exists but is not stamped at `head`.
+def _template_is_stale(head, template_name):
+    """True when a template exists but is not stamped at `head`.
 
     The template is a real database that outlives the interpreter that built
     it, so "it exists" is not the same question as "it is the schema this
@@ -127,8 +156,10 @@ def _template_is_stale(head):
     all read as stale. Rebuilding costs one `flask db upgrade`; guessing
     wrong in the other direction costs a red lane nobody can explain.
     """
-    stamped = _pg_run("SELECT version_num FROM alembic_version",
-                      dbname=_PG_TEMPLATE)
+    stamped = _pg_run(
+        "SELECT version_num FROM alembic_version",
+        dbname=template_name,
+    )
     if stamped.returncode != 0:
         return True
     lines = stamped.stdout.split()
@@ -142,42 +173,63 @@ def _ensure_pg_template():
     stamped at anything other than the current chain head.
     """
     global _pg_template_ready
-    if _pg_template_ready:
-        return
+    head = _chain_head()
+    template_name = _pg_template_name(head)
+    if _pg_template_ready == template_name:
+        return template_name
     _pg_preflight()
     # Never sweep by prefix here. Another checkout may be running the same
     # suite, and this process cannot prove that an existing clone is orphaned.
     # Each factory call drops only the unique database name it created.
-    head = _chain_head()
-    probe = _pg_run(
-        f"SELECT 1 FROM pg_database WHERE datname='{_PG_TEMPLATE}'")
-    if probe.stdout.strip() == "1" and _template_is_stale(head):
-        _pg_run(f'DROP DATABASE IF EXISTS {_PG_TEMPLATE} (FORCE)')
+    with _pg_template_lock():
         probe = _pg_run(
-            f"SELECT 1 FROM pg_database WHERE datname='{_PG_TEMPLATE}'")
-    if probe.stdout.strip() != "1":
-        _pg_run(f'CREATE DATABASE {_PG_TEMPLATE}')
-        old = os.environ.get('DATABASE_URL')
-        os.environ['DATABASE_URL'] = f"{_PG_URL}/{_PG_TEMPLATE}"
-        try:
-            from flask_migrate import upgrade
+            f"SELECT 1 FROM pg_database WHERE datname='{template_name}'"
+        )
+        _require_pg_success(probe, f"probe template {template_name}")
+        if probe.stdout.strip() == "1" and _template_is_stale(
+            head,
+            template_name,
+        ):
+            dropped = _pg_run(
+                f'DROP DATABASE IF EXISTS {template_name} (FORCE)'
+            )
+            _require_pg_success(dropped, f"drop stale template {template_name}")
+            probe = _pg_run(
+                f"SELECT 1 FROM pg_database WHERE datname='{template_name}'"
+            )
+            _require_pg_success(probe, f"re-probe template {template_name}")
+        if probe.stdout.strip() != "1":
+            created = _pg_run(f'CREATE DATABASE {template_name}')
+            _require_pg_success(created, f"create template {template_name}")
+            old = os.environ.get('DATABASE_URL')
+            os.environ['DATABASE_URL'] = f"{_PG_URL}/{template_name}"
+            try:
+                from flask_migrate import upgrade
 
-            from app import create_app
-            _tapp = create_app()
-            with _tapp.app_context():
-                _db.engine.dispose()
-                upgrade(directory=_MIGRATIONS_DIR)
-                # createdb TEMPLATE requires zero connections to the source;
-                # drop ours and terminate any pooled stragglers.
-                _db.engine.dispose()
-            _pg_run("SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
-                    f"WHERE datname = '{_PG_TEMPLATE}' AND pid <> pg_backend_pid()")
-        finally:
-            if old is None:
-                os.environ.pop('DATABASE_URL', None)
-            else:
-                os.environ['DATABASE_URL'] = old
-    _pg_template_ready = True
+                from app import create_app
+                _tapp = create_app()
+                with _tapp.app_context():
+                    _db.engine.dispose()
+                    upgrade(directory=_MIGRATIONS_DIR)
+                    # createdb TEMPLATE requires zero connections to the source;
+                    # drop ours and terminate any pooled stragglers.
+                    _db.engine.dispose()
+                terminated = _pg_run(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    f"WHERE datname = '{template_name}' "
+                    "AND pid <> pg_backend_pid()"
+                )
+                _require_pg_success(
+                    terminated,
+                    f"disconnect template {template_name}",
+                )
+            finally:
+                if old is None:
+                    os.environ.pop('DATABASE_URL', None)
+                else:
+                    os.environ['DATABASE_URL'] = old
+    _pg_template_ready = template_name
+    return template_name
 
 
 def _create_test_app_pg():
@@ -185,14 +237,14 @@ def _create_test_app_pg():
 
     Returns (app, handle) where handle is the throwaway database NAME
     (callers that os.unlink(db_path) get a no-op via drop_test_db)."""
-    _ensure_pg_template()
+    template_name = _ensure_pg_template()
     _pg_counter[0] += 1
     name = f"proam_unit_{os.getpid()}_{_pg_counter[0]}"
     import atexit
     atexit.register(lambda n=name: _pg_run(f'DROP DATABASE IF EXISTS {n} (FORCE)'))
-    r = _pg_run(f'CREATE DATABASE {name} TEMPLATE {_PG_TEMPLATE}')
+    r = _pg_run(f'CREATE DATABASE {name} TEMPLATE {template_name}')
     if r.returncode != 0:
-        raise RuntimeError(f"clone of {_PG_TEMPLATE} failed: {r.stderr}")
+        raise RuntimeError(f"clone of {template_name} failed: {r.stderr}")
     old = os.environ.get('DATABASE_URL')
     os.environ['DATABASE_URL'] = f"{_PG_URL}/{name}"
     try:
@@ -225,7 +277,10 @@ def drop_test_db(handle):
         except OSError:
             pass
         return
-    if handle.startswith("proam_unit_"):
+    if (
+        handle.startswith("proam_unit_")
+        and not handle.startswith(_PG_TEMPLATE_PREFIX)
+    ):
         _pg_run(f'DROP DATABASE IF EXISTS {handle} (FORCE)')
 
 

--- a/tests/test_flask_reliability.py
+++ b/tests/test_flask_reliability.py
@@ -102,6 +102,21 @@ class TestAppFactory:
     def test_upload_folder_exists(self, app):
         assert os.path.isdir(app.config['UPLOAD_FOLDER'])
 
+    def test_internal_error_rolls_back_before_rendering(self, app):
+        from werkzeug.exceptions import InternalServerError
+
+        error = InternalServerError()
+        with app.test_request_context('/synthetic-failure'):
+            handler = app._find_error_handler(error, [])
+            with (
+                patch('app.db.session.rollback') as rollback,
+                patch('app.render_template', return_value='error-page'),
+            ):
+                response = handler(error)
+
+        rollback.assert_called_once_with()
+        assert response == ('error-page', 500)
+
 
 # ===========================================================================
 # 2. CONFIGURATION
@@ -521,7 +536,9 @@ class TestHeatLocking:
         from models.heat import Heat
         h = Heat(event_id=1, heat_number=1)
         h.acquire_lock(1)
+        locked_at = h.locked_at
         assert h.acquire_lock(1)
+        assert h.locked_at == locked_at
 
     def test_blocked_different_user(self):
         from models.heat import Heat
@@ -593,6 +610,45 @@ class TestContextProcessor:
 
         unscored_count.assert_not_called()
         assert ctx.get('unscored_heats') == 0
+
+    @pytest.mark.parametrize(
+        ('username', 'expected_calls', 'expected_badge'),
+        [
+            (None, 0, 0),
+            ('viewer_user', 0, 0),
+            ('scorer_user', 0, 0),
+            ('judge_user', 1, 7),
+            ('admin_user', 1, 7),
+        ],
+    )
+    def test_sidebar_query_is_limited_to_judges_and_admins(
+        self,
+        app,
+        username,
+        expected_calls,
+        expected_badge,
+    ):
+        tid = _tid()
+        with app.test_request_context(f'/tournament/{tid}'):
+            from flask import request as _req
+            from flask_login import login_user
+
+            from models.user import User
+
+            _req.view_args = {'tournament_id': tid}
+            if username is not None:
+                login_user(User.query.filter_by(username=username).one())
+
+            with patch(
+                'services.sidebar_aggregator.unscored_heats_count',
+                return_value=7,
+            ) as unscored_count:
+                ctx = {}
+                for fn in app.template_context_processors[None]:
+                    ctx.update(fn())
+
+        assert unscored_count.call_count == expected_calls
+        assert ctx.get('unscored_heats') == expected_badge
 
 
 # ===========================================================================

--- a/tests/test_flask_reliability.py
+++ b/tests/test_flask_reliability.py
@@ -579,6 +579,21 @@ class TestContextProcessor:
                 ctx.update(fn())
             assert ctx.get('unscored_heats', 0) == 0
 
+    def test_public_portal_skips_judge_sidebar_query(self, app):
+        tid = 99999
+        with app.test_request_context(f'/portal/spectator/{tid}'):
+            from flask import request as _req
+            _req.view_args = {'tournament_id': tid}
+            with patch(
+                'services.sidebar_aggregator.unscored_heats_count'
+            ) as unscored_count:
+                ctx = {}
+                for fn in app.template_context_processors[None]:
+                    ctx.update(fn())
+
+        unscored_count.assert_not_called()
+        assert ctx.get('unscored_heats') == 0
+
 
 # ===========================================================================
 # 12. EVENTRESULT METHODS

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -75,9 +75,11 @@ class TestReportCache:
         from services import report_cache
         with report_cache._lock:
             report_cache._cache.clear()
+            report_cache._fill_locks.clear()
         yield
         with report_cache._lock:
             report_cache._cache.clear()
+            report_cache._fill_locks.clear()
 
     # -- Disable disk layer for deterministic unit tests --
     @pytest.fixture(autouse=True)
@@ -98,6 +100,58 @@ class TestReportCache:
         payload = {'scores': [1, 2, 3]}
         set('test:round_trip', payload, ttl_seconds=60)
         assert get('test:round_trip') == payload
+
+    def test_get_or_compute_coalesces_concurrent_cache_miss(self):
+        from services import report_cache
+
+        reader_count = 8
+        ready = threading.Barrier(reader_count)
+        builder_started = threading.Event()
+        release_builder = threading.Event()
+        calls = 0
+        calls_lock = threading.Lock()
+        results = []
+
+        def builder():
+            nonlocal calls
+            with calls_lock:
+                calls += 1
+            builder_started.set()
+            assert release_builder.wait(timeout=2)
+            return {'standings': [1, 2, 3]}
+
+        def reader():
+            ready.wait(timeout=2)
+            results.append(
+                report_cache.get_or_compute('public:1', 60, builder)
+            )
+
+        readers = [threading.Thread(target=reader) for _ in range(reader_count)]
+        for reader_thread in readers:
+            reader_thread.start()
+        assert builder_started.wait(timeout=2)
+        release_builder.set()
+        for reader_thread in readers:
+            reader_thread.join(timeout=2)
+
+        assert all(not reader_thread.is_alive() for reader_thread in readers)
+        assert calls == 1
+        assert results == [{'standings': [1, 2, 3]}] * reader_count
+
+    def test_get_or_compute_releases_key_after_builder_error(self):
+        from services import report_cache
+
+        def broken_builder():
+            raise RuntimeError('synthetic builder failure')
+
+        with pytest.raises(RuntimeError, match='synthetic builder failure'):
+            report_cache.get_or_compute('public:error', 60, broken_builder)
+
+        assert report_cache.get_or_compute(
+            'public:error',
+            60,
+            lambda: {'recovered': True},
+        ) == {'recovered': True}
 
     def test_ttl_expiry(self):
         """Value should expire after TTL elapses."""

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -11,6 +11,7 @@ Requirements:
     pytest (pip install pytest)
     All app dependencies installed.
 """
+import gc
 import json
 import threading
 import time
@@ -73,13 +74,9 @@ class TestReportCache:
     def _reset_cache(self):
         """Clear the module-level cache dict before each test."""
         from services import report_cache
-        with report_cache._lock:
-            report_cache._cache.clear()
-            report_cache._fill_locks.clear()
+        report_cache.reset_for_testing()
         yield
-        with report_cache._lock:
-            report_cache._cache.clear()
-            report_cache._fill_locks.clear()
+        report_cache.reset_for_testing()
 
     # -- Disable disk layer for deterministic unit tests --
     @pytest.fixture(autouse=True)
@@ -111,32 +108,50 @@ class TestReportCache:
         calls = 0
         calls_lock = threading.Lock()
         results = []
+        worker_errors = []
 
         def builder():
             nonlocal calls
             with calls_lock:
                 calls += 1
             builder_started.set()
-            assert release_builder.wait(timeout=2)
+            assert release_builder.wait(timeout=10)
             return {'standings': [1, 2, 3]}
 
         def reader():
-            ready.wait(timeout=2)
-            results.append(
-                report_cache.get_or_compute('public:1', 60, builder)
-            )
+            try:
+                ready.wait(timeout=10)
+                results.append(
+                    report_cache.get_or_compute('public:1', 60, builder)
+                )
+            except Exception as exc:
+                worker_errors.append(exc)
 
         readers = [threading.Thread(target=reader) for _ in range(reader_count)]
         for reader_thread in readers:
             reader_thread.start()
-        assert builder_started.wait(timeout=2)
+        assert builder_started.wait(timeout=10)
         release_builder.set()
         for reader_thread in readers:
-            reader_thread.join(timeout=2)
+            reader_thread.join(timeout=10)
 
         assert all(not reader_thread.is_alive() for reader_thread in readers)
+        assert worker_errors == []
         assert calls == 1
         assert results == [{'standings': [1, 2, 3]}] * reader_count
+
+    def test_get_or_compute_retires_idle_fill_lock(self):
+        from services import report_cache
+
+        assert report_cache.get_or_compute(
+            'public:retired',
+            60,
+            lambda: {'ready': True},
+        ) == {'ready': True}
+        gc.collect()
+
+        with report_cache._lock:
+            assert 'public:retired' not in report_cache._fill_locks
 
     def test_get_or_compute_releases_key_after_builder_error(self):
         from services import report_cache

--- a/tests/test_integration_qa.py
+++ b/tests/test_integration_qa.py
@@ -12,7 +12,9 @@ The fixture below now SKIPs cleanly when SOURCE_DB is absent (CI default).
 from __future__ import annotations
 
 import re
+import threading
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -653,6 +655,71 @@ def test_concurrent_scoring_simulation_documents_optimistic_locking(qa_env):
             .all()
         ]
         assert values == [21.5, 22.5, 23.5]
+
+
+def test_concurrent_heat_gets_atomically_acquire_one_edit_lock(qa_env):
+    """Same-account page opens must not race the heat version update."""
+    app = qa_env["app"]
+    seeded = _seed_heat_with_results(app)
+    worker_count = 8
+
+    with app.app_context():
+        from models import Heat, User
+
+        user_id = User.query.order_by(User.id).first().id
+        initial_version = db.session.get(Heat, seeded["heat_id"]).version_id
+
+    barrier = threading.Barrier(worker_count)
+
+    def open_heat():
+        client = app.test_client()
+        with client.session_transaction() as session:
+            session["_user_id"] = str(user_id)
+            session["_fresh"] = True
+        barrier.wait(timeout=10)
+        response = client.get(
+            f"/scoring/{seeded['tournament_id']}/heat/"
+            f"{seeded['heat_id']}/enter"
+        )
+        return response.status_code
+
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        statuses = list(executor.map(lambda _index: open_heat(), range(worker_count)))
+
+    assert statuses == [200] * worker_count
+    with app.app_context():
+        from models import Heat
+
+        heat = db.session.get(Heat, seeded["heat_id"])
+        assert heat.locked_by_user_id == user_id
+        assert heat.version_id == initial_version + 1
+
+
+def test_heat_deleted_during_lock_acquisition_returns_not_found(qa_env, monkeypatch):
+    app = qa_env["app"]
+    seeded = _seed_heat_with_results(app)
+
+    with app.app_context():
+        from werkzeug.exceptions import NotFound
+
+        from models import Heat, User
+        from models.heat import HeatAssignment
+        from routes.scoring import _acquire_heat_edit_lock
+
+        heat = db.session.get(Heat, seeded["heat_id"])
+        user_id = User.query.order_by(User.id).first().id
+        original_commit = db.session.commit
+
+        def commit_then_delete():
+            original_commit()
+            HeatAssignment.query.filter_by(heat_id=seeded["heat_id"]).delete()
+            Heat.query.filter_by(id=seeded["heat_id"]).delete()
+            original_commit()
+
+        monkeypatch.setattr(db.session, "commit", commit_then_delete)
+
+        with pytest.raises(NotFound):
+            _acquire_heat_edit_lock(heat, user_id)
 
 
 def test_day_of_operations_workflow(qa_env):

--- a/tests/test_pg_migration_safety.py
+++ b/tests/test_pg_migration_safety.py
@@ -445,20 +445,47 @@ class TestEngineConnectListenerHygiene:
     These tests are cheap and need no database.
     """
 
-    def test_listener_registered_once_regardless_of_app_count(self):
-
-
+    def test_listener_registered_once_regardless_of_app_count(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        isolated_db = tmp_path / 'listener-hygiene.db'
+        monkeypatch.setenv('DATABASE_URL', f'sqlite:///{isolated_db.as_posix()}')
+        monkeypatch.setenv('TESTING', '1')
         import app as app_module
+        from database import db
+
+        default_db = PROJECT_ROOT / 'instance' / 'proam.db'
+        default_before = (
+            default_db.exists(),
+            default_db.stat().st_size if default_db.exists() else 0,
+            default_db.stat().st_mtime_ns if default_db.exists() else 0,
+        )
 
         # Build several apps first: the leak this guards against only shows
         # up once more than one app exists in the process.
-        for _ in range(3):
-            try:
-                app_module.create_app()
-            except Exception:
-                # A build failure is a different test's problem; the listener
-                # is registered at import time either way.
-                pass
+        apps = []
+        try:
+            for _ in range(3):
+                apps.append(app_module.create_app())
+        finally:
+            for built_app in apps:
+                with built_app.app_context():
+                    db.session.remove()
+                    db.engine.dispose()
+                finalizer = built_app.extensions.get(
+                    'sqlite_process_fence_finalizer'
+                )
+                if finalizer is not None and finalizer.alive:
+                    finalizer()
+
+        default_after = (
+            default_db.exists(),
+            default_db.stat().st_size if default_db.exists() else 0,
+            default_db.stat().st_mtime_ns if default_db.exists() else 0,
+        )
+        assert default_after == default_before
 
         # 'connect' is a PoolEvents event; listening on Engine routes it to
         # the pool class hierarchy. Count our listener at the base class.

--- a/tests/test_pg_migration_safety.py
+++ b/tests/test_pg_migration_safety.py
@@ -442,7 +442,7 @@ class TestEngineConnectListenerHygiene:
     ``syntax error at or near "PRAGMA"`` on PG. It accounted for all 1,758
     divergences in the first full PG run of the unit suite.
 
-    These tests are cheap and need no database.
+    These tests are cheap and use only isolated temporary SQLite state.
     """
 
     def test_listener_registered_once_regardless_of_app_count(

--- a/tests/test_postgres_runtime_smoke.py
+++ b/tests/test_postgres_runtime_smoke.py
@@ -104,6 +104,8 @@ def test_scratch_cascade_row_lock_uses_postgresql_nowait(app):
 
         assert any('FOR UPDATE NOWAIT' in statement for statement in statements)
 
-        _db.session.delete(competitor)
+        # Tournament owns competitor lifecycle through delete-orphan. Deleting
+        # both rows explicitly makes SQLAlchemy issue duplicate DELETEs for the
+        # competitor and its identity spine on PostgreSQL.
         _db.session.delete(tournament)
         _db.session.commit()

--- a/tests/test_rehearsal_safety.py
+++ b/tests/test_rehearsal_safety.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
@@ -45,6 +45,133 @@ def test_generated_rehearsal_database_is_disposable():
     assert not path.exists()
 
 
+def test_report_output_refuses_database_aliases_without_touching_bytes(tmp_path):
+    database_path = tmp_path / "retained-fixture.db"
+    database_path.write_bytes(b"synthetic-database")
+
+    for protected_path in (
+        load_test_race_day.PRODUCTION_DB_PATH,
+        database_path,
+    ):
+        with pytest.raises(ValueError, match="cannot be a database path"):
+            load_test_race_day._resolve_report_output(
+                str(protected_path),
+                database_path=database_path,
+                overwrite=True,
+            )
+
+    assert database_path.read_bytes() == b"synthetic-database"
+
+
+def test_report_output_requires_explicit_overwrite(tmp_path):
+    database_path = tmp_path / "fixture.db"
+    output_path = tmp_path / "report.json"
+    output_path.write_bytes(b"keep-this-report")
+
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        load_test_race_day._resolve_report_output(
+            str(output_path),
+            database_path=database_path,
+            overwrite=False,
+        )
+
+    assert output_path.read_bytes() == b"keep-this-report"
+
+
+def test_report_output_refuses_hard_link_database_alias(tmp_path):
+    database_path = tmp_path / "fixture.db"
+    database_path.write_bytes(b"database-bytes")
+    output_path = tmp_path / "report.json"
+    output_path.hardlink_to(database_path)
+
+    with pytest.raises(ValueError, match="cannot be a database path"):
+        load_test_race_day._resolve_report_output(
+            str(output_path),
+            database_path=database_path,
+            overwrite=True,
+        )
+
+    assert database_path.read_bytes() == b"database-bytes"
+
+
+def test_report_write_rechecks_path_after_validation(tmp_path):
+    database_path = tmp_path / "fixture.db"
+    database_path.write_bytes(b"database-bytes")
+    output_path = load_test_race_day._resolve_report_output(
+        str(tmp_path / "report.json"),
+        database_path=database_path,
+        overwrite=True,
+    )
+    output_path.hardlink_to(database_path)
+
+    with pytest.raises(ValueError, match="cannot be a database path"):
+        load_test_race_day._write_report(
+            output_path,
+            {"passed": True},
+            overwrite=True,
+            database_path=database_path,
+        )
+
+    assert database_path.read_bytes() == b"database-bytes"
+
+
+def test_report_overwrite_uses_atomic_replacement(tmp_path):
+    database_path = tmp_path / "fixture.db"
+    database_path.write_bytes(b"database-bytes")
+    output_path = tmp_path / "report.json"
+    output_path.write_text("old-report", encoding="utf-8")
+
+    load_test_race_day._write_report(
+        output_path,
+        {"passed": True},
+        overwrite=True,
+        database_path=database_path,
+    )
+
+    assert output_path.read_text(encoding="utf-8") == '{\n  "passed": true\n}\n'
+    assert database_path.read_bytes() == b"database-bytes"
+
+
+def test_report_creation_is_atomic_and_no_clobber(tmp_path):
+    database_path = tmp_path / "fixture.db"
+    database_path.write_bytes(b"database-bytes")
+    output_path = tmp_path / "report.json"
+
+    load_test_race_day._write_report(
+        output_path,
+        {"passed": True},
+        overwrite=False,
+        database_path=database_path,
+    )
+
+    assert output_path.read_text(encoding="utf-8") == '{\n  "passed": true\n}\n'
+    with pytest.raises(FileExistsError):
+        load_test_race_day._write_report(
+            output_path,
+            {"passed": False},
+            overwrite=False,
+            database_path=database_path,
+        )
+    assert output_path.read_text(encoding="utf-8") == '{\n  "passed": true\n}\n'
+
+
+def test_report_serialization_failure_leaves_no_partial_output(tmp_path):
+    database_path = tmp_path / "fixture.db"
+    database_path.write_bytes(b"database-bytes")
+    output_path = tmp_path / "report.json"
+
+    with pytest.raises(TypeError):
+        load_test_race_day._write_report(
+            output_path,
+            {"not_json": object()},
+            overwrite=False,
+            database_path=database_path,
+        )
+
+    assert not output_path.exists()
+    assert list(tmp_path.glob(".report.json.*.tmp")) == []
+
+
 @pytest.mark.parametrize(
     ("error_rate", "p95_ms", "expected"),
     [
@@ -81,6 +208,296 @@ def test_load_rehearsal_gate_rejects_server_error_below_rate_limit():
     ) is False
 
 
+def test_load_rehearsal_gate_rejects_slow_judge_role_hidden_by_aggregate():
+    report = {
+        "users": {"spectators": 200, "competitors": 50, "judges": 10},
+        "requests": {"error_rate": 0.0},
+        "latency_ms": {"p95": 120.0},
+        "status_codes": {"200": 1000},
+        "by_role": {
+            "spectators": {
+                "requests": 800,
+                "errors": 0,
+                "activations": 200,
+                "p95_ms": 100.0,
+            },
+            "competitors": {
+                "requests": 150,
+                "errors": 0,
+                "activations": 50,
+                "p95_ms": 110.0,
+            },
+            "judges": {
+                "requests": 50,
+                "errors": 0,
+                "activations": 10,
+                "authentications": 10,
+                "p95_ms": 900.0,
+            },
+        },
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        target_role_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is False
+
+
+def test_load_rehearsal_gate_requires_each_judge_to_authenticate_and_request():
+    report = {
+        "users": {"judges": 10},
+        "requests": {"error_rate": 0.0},
+        "latency_ms": {"p95": 100.0},
+        "status_codes": {"200": 29},
+        "by_role": {
+            "judges": {
+                "requests": 29,
+                "errors": 0,
+                "activations": 10,
+                "authentications": 10,
+                "p95_ms": 100.0,
+            },
+        },
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        target_role_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is False
+
+
+def test_load_rehearsal_gate_rejects_slow_endpoint_hidden_by_role():
+    report = {
+        "users": {"judges": 1},
+        "load_shape": {
+            "expected_paths": {
+                "judges": [
+                    "GET /auth/login",
+                    "POST /auth/login",
+                    "GET /scoring/1/offline-ops",
+                ],
+            },
+        },
+        "requests": {"error_rate": 0.0},
+        "latency_ms": {"p95": 100.0},
+        "status_codes": {"200": 102},
+        "by_role": {
+            "judges": {
+                "requests": 102,
+                "errors": 0,
+                "activations": 1,
+                "authentications": 1,
+                "p95_ms": 100.0,
+                "by_path": {
+                    "GET /auth/login": {
+                        "requests": 1,
+                        "errors": 0,
+                        "p95_ms": 20.0,
+                    },
+                    "POST /auth/login": {
+                        "requests": 1,
+                        "errors": 0,
+                        "p95_ms": 30.0,
+                    },
+                    "GET /scoring/1/offline-ops": {
+                        "requests": 100,
+                        "errors": 0,
+                        "p95_ms": 900.0,
+                    },
+                },
+            },
+        },
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        target_role_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is False
+
+
+class _FakeResponse:
+    def __init__(self, final_url, body=b"complete-body", status=200):
+        self.status = status
+        self._final_url = final_url
+        self._body = body
+        self.read_calls = []
+
+    def read(self, *args):
+        self.read_calls.append(args)
+        return self._body
+
+    def geturl(self):
+        return self._final_url
+
+
+def test_authenticated_measurement_rejects_login_redirect_and_reads_full_body():
+    response = _FakeResponse("http://127.0.0.1:5050/auth/login")
+
+    status, error = load_test_race_day._consume_measured_response(
+        response,
+        "http://127.0.0.1:5050/scoring/1/offline-ops",
+        authenticated=True,
+    )
+
+    assert (status, error) == (401, "authentication_lost")
+    assert response.read_calls == [()]
+
+
+def test_authenticated_measurement_accepts_requested_scoring_page():
+    response = _FakeResponse("http://127.0.0.1:5050/scoring/1/offline-ops")
+
+    assert load_test_race_day._consume_measured_response(
+        response,
+        "http://127.0.0.1:5050/scoring/1/offline-ops",
+        authenticated=True,
+    ) == (200, None)
+
+
+def test_public_measurement_rejects_redirect_to_wrong_page():
+    response = _FakeResponse("http://127.0.0.1:5050/auth/login")
+
+    assert load_test_race_day._consume_measured_response(
+        response,
+        "http://127.0.0.1:5050/portal/spectator/1",
+        authenticated=False,
+    ) == (None, "unexpected_redirect")
+
+
+def test_measurement_rejects_same_path_on_different_origin():
+    response = _FakeResponse("http://127.0.0.1:5999/portal/spectator/1")
+
+    assert load_test_race_day._consume_measured_response(
+        response,
+        "http://127.0.0.1:5050/portal/spectator/1",
+        authenticated=False,
+    ) == (None, "unexpected_redirect")
+
+
+def test_redirect_handler_blocks_cross_origin_before_following():
+    handler = load_test_race_day._SameOriginRedirectHandler(
+        "http://127.0.0.1:5050"
+    )
+    request = load_test_race_day.urllib.request.Request(
+        "http://127.0.0.1:5050/portal/spectator/1"
+    )
+
+    with pytest.raises(load_test_race_day.CrossOriginRedirectError):
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "http://127.0.0.1:5999/portal/spectator/1",
+        )
+
+
+@pytest.mark.parametrize(
+    ("activations", "authentications"),
+    [(1, 2), (2, 1)],
+)
+def test_role_gate_rejects_surplus_requests_masking_missing_users(
+    activations,
+    authentications,
+):
+    report = {
+        "users": {"judges": 2},
+        "load_shape": {
+            "expected_paths": {
+                "judges": [
+                    "GET /auth/login",
+                    "POST /auth/login",
+                    "GET /scoring/1/offline-ops",
+                ],
+            },
+        },
+        "requests": {"error_rate": 0.0},
+        "latency_ms": {"p95": 100.0},
+        "status_codes": {"200": 100},
+        "by_role": {
+            "judges": {
+                "requests": 100,
+                "errors": 0,
+                "activations": activations,
+                "authentications": authentications,
+                "p95_ms": 100.0,
+                "by_path": {
+                    "GET /auth/login": {
+                        "requests": 2,
+                        "errors": 0,
+                        "p95_ms": 20.0,
+                    },
+                    "POST /auth/login": {
+                        "requests": 2,
+                        "errors": 0,
+                        "p95_ms": 30.0,
+                    },
+                    "GET /scoring/1/offline-ops": {
+                        "requests": 96,
+                        "errors": 0,
+                        "p95_ms": 40.0,
+                    },
+                },
+            },
+        },
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        target_role_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is False
+
+
+def test_role_gate_requires_one_successful_login_sample_per_judge():
+    report = {
+        "users": {"judges": 2},
+        "load_shape": {
+            "expected_paths": {
+                "judges": ["GET /auth/login", "POST /auth/login"],
+            },
+        },
+        "requests": {"error_rate": 0.0},
+        "latency_ms": {"p95": 100.0},
+        "status_codes": {"200": 100},
+        "by_role": {
+            "judges": {
+                "requests": 100,
+                "errors": 0,
+                "activations": 2,
+                "authentications": 2,
+                "p95_ms": 100.0,
+                "by_path": {
+                    "GET /auth/login": {
+                        "requests": 2,
+                        "errors": 0,
+                        "p95_ms": 20.0,
+                    },
+                    "POST /auth/login": {
+                        "requests": 1,
+                        "errors": 0,
+                        "p95_ms": 30.0,
+                    },
+                },
+            },
+        },
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        target_role_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is False
+
+
 def test_postgres_template_setup_never_sweeps_unowned_clones(monkeypatch):
     calls = []
     was_ready = db_test_utils._pg_template_ready
@@ -92,10 +509,15 @@ def test_postgres_template_setup_never_sweeps_unowned_clones(monkeypatch):
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(db_test_utils, "_pg_preflight", lambda: None)
+    monkeypatch.setattr(db_test_utils, "_pg_template_lock", nullcontext)
     monkeypatch.setattr(db_test_utils, "_pg_run", fake_pg_run)
     monkeypatch.setattr(db_test_utils, "_chain_head", lambda: "head")
-    monkeypatch.setattr(db_test_utils, "_template_is_stale", lambda _head: False)
-    db_test_utils._pg_template_ready = False
+    monkeypatch.setattr(
+        db_test_utils,
+        "_template_is_stale",
+        lambda _head, _template_name: False,
+    )
+    db_test_utils._pg_template_ready = None
     try:
         db_test_utils._ensure_pg_template()
     finally:
@@ -104,6 +526,16 @@ def test_postgres_template_setup_never_sweeps_unowned_clones(monkeypatch):
     rendered = "\n".join(sql for sql, _dbname in calls)
     assert "LIKE 'proam_unit_%'" not in rendered
     assert "DROP DATABASE" not in rendered
+
+
+def test_postgres_template_name_is_namespaced_by_migration_head():
+    first = db_test_utils._pg_template_name("revision-a")
+    second = db_test_utils._pg_template_name("revision-b")
+
+    assert first.startswith("proam_unit_template_")
+    assert second.startswith("proam_unit_template_")
+    assert first != second
+    assert len(first) <= 63
 
 
 def test_load_stats_reports_timeout_categories():
@@ -132,12 +564,13 @@ def test_load_shape_uses_requested_virtual_user_counts(monkeypatch):
         stop_event,
         stats,
         timeout,
-        start_delay,
+        start_at,
         think_min,
         think_max,
         login_credentials,
+        rng_seed,
     ):
-        del base_url, endpoints, timeout, start_delay, think_min, think_max
+        del base_url, endpoints, timeout, start_at, think_min, think_max, rng_seed
         worker_calls.append(login_credentials)
         stats.add(1.0, 200)
         stop_event.wait()
@@ -151,22 +584,128 @@ def test_load_shape_uses_requested_virtual_user_counts(monkeypatch):
         timeout_s=1.0,
         spectator_users=2,
         competitor_users=1,
-        judge_users=1,
+        judge_users=2,
         judge_heat_ids=[7, 8],
         ramp_up_s=0.0,
         spectator_think=(25.0, 35.0),
         competitor_think=(20.0, 60.0),
         judge_think=(3.0, 8.0),
+        judge_credentials=[("judge-a", "password"), ("judge-b", "password")],
     )
 
     assert report["users"] == {
         "spectators": 2,
         "competitors": 1,
-        "judges": 1,
-        "total": 4,
+        "judges": 2,
+        "total": 5,
     }
-    assert report["requests"]["total"] == 4
+    assert report["requests"]["total"] == 5
     assert report["load_shape"]["configured_ramp_up_seconds"] == 0.0
     assert report["load_shape"]["think_time_seconds"]["spectators"] == [25.0, 35.0]
-    assert worker_calls.count(("judge_loadtest_1", "LoadTest123!")) == 1
+    assert report["load_shape"]["seed"] == 2027
+    assert worker_calls.count(("judge-a", "password")) == 1
+    assert worker_calls.count(("judge-b", "password")) == 1
     assert worker_calls.count(None) == 3
+
+
+def test_load_shape_seed_replays_worker_random_streams(monkeypatch):
+    captured = []
+
+    def fake_worker(
+        base_url,
+        endpoints,
+        stop_event,
+        stats,
+        timeout,
+        start_at,
+        think_min,
+        think_max,
+        login_credentials,
+        rng_seed,
+    ):
+        del base_url, timeout, start_at, think_min, think_max
+        captured.append((tuple(endpoints), login_credentials, rng_seed))
+        stats.activate(load_test_race_day.time.perf_counter())
+        stats.add(1.0, 200, path=f"GET {endpoints[0]}")
+        stop_event.wait()
+
+    monkeypatch.setattr(load_test_race_day, "_worker", fake_worker)
+
+    def run_once():
+        captured.clear()
+        load_test_race_day._run_load_test(
+            "http://127.0.0.1:1",
+            tournament_id=1,
+            duration_s=0,
+            timeout_s=1.0,
+            spectator_users=2,
+            competitor_users=1,
+            judge_users=1,
+            judge_heat_ids=[7],
+            ramp_up_s=0.0,
+            seed=77,
+        )
+        return sorted(repr(item) for item in captured)
+
+    assert run_once() == run_once()
+
+
+def test_load_runner_stops_started_threads_when_startup_fails(monkeypatch):
+    created = []
+
+    class FakeThread:
+        def __init__(self, target, args, **kwargs):
+            del kwargs
+            self.target = target
+            self.args = args
+            self.name = f"fake-{len(created)}"
+            self.joined = False
+            created.append(self)
+
+        def start(self):
+            if self.name == "fake-1":
+                raise RuntimeError("synthetic thread-start failure")
+
+        def join(self, timeout=None):
+            del timeout
+            assert self.args[8].is_set()
+            self.joined = True
+
+        def is_alive(self):
+            return not self.joined
+
+    monkeypatch.setattr(load_test_race_day.threading, "Thread", FakeThread)
+
+    with pytest.raises(RuntimeError, match="synthetic thread-start failure"):
+        load_test_race_day._run_load_test(
+            "http://127.0.0.1:1",
+            tournament_id=1,
+            duration_s=0,
+            timeout_s=1.0,
+            spectator_users=2,
+            competitor_users=0,
+            judge_users=0,
+            ramp_up_s=0.0,
+        )
+
+    assert created[0].joined is True
+
+
+def test_load_runner_surfaces_unexpected_worker_failure(monkeypatch):
+    def broken_worker(*args):
+        del args
+        raise RuntimeError("synthetic worker failure")
+
+    monkeypatch.setattr(load_test_race_day, "_worker", broken_worker)
+
+    with pytest.raises(RuntimeError, match="synthetic worker failure"):
+        load_test_race_day._run_load_test(
+            "http://127.0.0.1:1",
+            tournament_id=1,
+            duration_s=0,
+            timeout_s=1.0,
+            spectator_users=1,
+            competitor_users=0,
+            judge_users=0,
+            ramp_up_s=0.0,
+        )

--- a/tests/test_rehearsal_safety.py
+++ b/tests/test_rehearsal_safety.py
@@ -1,0 +1,172 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import load_test_race_day
+from tests import db_test_utils
+
+
+def test_csrf_parser_reads_login_token():
+    parser = load_test_race_day._CsrfTokenParser()
+    parser.feed(
+        '<form><input value="session-token" type="hidden" '
+        'name="csrf_token"></form>'
+    )
+
+    assert parser.token == "session-token"
+
+
+def test_load_rehearsal_refuses_production_database():
+    with pytest.raises(ValueError, match="refuses instance/proam.db"):
+        load_test_race_day._resolve_synthetic_database(
+            str(load_test_race_day.PRODUCTION_DB_PATH)
+        )
+
+
+def test_load_rehearsal_refuses_existing_database(tmp_path):
+    existing = tmp_path / "existing.db"
+    existing.write_bytes(b"do-not-overwrite")
+
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        load_test_race_day._resolve_synthetic_database(str(existing))
+
+    assert existing.read_bytes() == b"do-not-overwrite"
+
+
+def test_generated_rehearsal_database_is_disposable():
+    path, generated = load_test_race_day._resolve_synthetic_database(None)
+    try:
+        assert generated is True
+        assert path.is_file()
+        assert path != load_test_race_day.PRODUCTION_DB_PATH
+    finally:
+        load_test_race_day._remove_synthetic_database(path)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize(
+    ("error_rate", "p95_ms", "expected"),
+    [
+        (0.0, 250.0, True),
+        (0.01, 250.0, False),
+        (0.0, 900.0, False),
+    ],
+)
+def test_load_rehearsal_gate_is_truthful(error_rate, p95_ms, expected):
+    report = {
+        "requests": {"error_rate": error_rate},
+        "latency_ms": {"p95": p95_ms},
+        "status_codes": {},
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is expected
+
+
+def test_load_rehearsal_gate_rejects_server_error_below_rate_limit():
+    report = {
+        "requests": {"error_rate": 0.001},
+        "latency_ms": {"p95": 100.0},
+        "status_codes": {"200": 999, "500": 1},
+    }
+
+    assert load_test_race_day._passes_gate(
+        report,
+        target_p95_ms=800.0,
+        max_error_rate=0.005,
+    ) is False
+
+
+def test_postgres_template_setup_never_sweeps_unowned_clones(monkeypatch):
+    calls = []
+    was_ready = db_test_utils._pg_template_ready
+
+    def fake_pg_run(sql, dbname="postgres"):
+        calls.append((sql, dbname))
+        if "SELECT 1 FROM pg_database" in sql:
+            return SimpleNamespace(returncode=0, stdout="1\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(db_test_utils, "_pg_preflight", lambda: None)
+    monkeypatch.setattr(db_test_utils, "_pg_run", fake_pg_run)
+    monkeypatch.setattr(db_test_utils, "_chain_head", lambda: "head")
+    monkeypatch.setattr(db_test_utils, "_template_is_stale", lambda _head: False)
+    db_test_utils._pg_template_ready = False
+    try:
+        db_test_utils._ensure_pg_template()
+    finally:
+        db_test_utils._pg_template_ready = was_ready
+
+    rendered = "\n".join(sql for sql, _dbname in calls)
+    assert "LIKE 'proam_unit_%'" not in rendered
+    assert "DROP DATABASE" not in rendered
+
+
+def test_load_stats_reports_timeout_categories():
+    stats = load_test_race_day.Stats()
+
+    stats.add(25.0, 200)
+    stats.add(6000.0, None, error_kind="timeout", path="GET /slow")
+    stats.add(40.0, 503, path="GET /unavailable")
+
+    assert stats.total == 3
+    assert stats.success == 1
+    assert stats.errors == 2
+    assert stats.error_kinds == {"timeout": 1, "http_503": 1}
+    assert stats.error_paths == {
+        "GET /slow": 1,
+        "GET /unavailable": 1,
+    }
+
+
+def test_load_shape_uses_requested_virtual_user_counts(monkeypatch):
+    worker_calls = []
+
+    def fake_worker(
+        base_url,
+        endpoints,
+        stop_event,
+        stats,
+        timeout,
+        start_delay,
+        think_min,
+        think_max,
+        login_credentials,
+    ):
+        del base_url, endpoints, timeout, start_delay, think_min, think_max
+        worker_calls.append(login_credentials)
+        stats.add(1.0, 200)
+        stop_event.wait()
+
+    monkeypatch.setattr(load_test_race_day, "_worker", fake_worker)
+
+    report = load_test_race_day._run_load_test(
+        "http://127.0.0.1:1",
+        tournament_id=1,
+        duration_s=0,
+        timeout_s=1.0,
+        spectator_users=2,
+        competitor_users=1,
+        judge_users=1,
+        judge_heat_ids=[7, 8],
+        ramp_up_s=0.0,
+        spectator_think=(25.0, 35.0),
+        competitor_think=(20.0, 60.0),
+        judge_think=(3.0, 8.0),
+    )
+
+    assert report["users"] == {
+        "spectators": 2,
+        "competitors": 1,
+        "judges": 1,
+        "total": 4,
+    }
+    assert report["requests"]["total"] == 4
+    assert report["load_shape"]["configured_ramp_up_seconds"] == 0.0
+    assert report["load_shape"]["think_time_seconds"]["spectators"] == [25.0, 35.0]
+    assert worker_calls.count(("judge_loadtest_1", "LoadTest123!")) == 1
+    assert worker_calls.count(None) == 3


### PR DESCRIPTION
## Summary
- make the 2027 load rehearsal migration-built, synthetic, authenticated, deterministic, and fail-closed for latency, aggregate errors, and any HTTP 5xx
- coalesce concurrent cold public-cache fills and skip judge-only sidebar work for anonymous traffic
- remove unsafe PostgreSQL prefix cleanup and isolate migration/runtime test resources
- record the 2026-08-19 full-dress evidence without claiming final 2027 certification

## Verification
- 220 focused SQLite/API/migration tests passed
- 160 SQLite operations tests passed; both offline JavaScript suites passed
- 10 disposable PostgreSQL adversarial tests and 4 runtime smoke tests passed
- authenticated 260-user load: 342/342 HTTP 200, p95 134.74 ms, zero 5xx
- desktop 1440x900 and phone 390x844 browser QA passed; stale judge save was blocked; 15/15 offline assets survived an origin-down cold reload
- full Ruff, compileall, and git diff checks passed

## Boundary
This is local synthetic evidence. Owner decisions, physical-device rehearsal, hosted CI, production mirror, deployment smoke, and backup key-custody evidence remain open certification gates.