### PR TITLE
Harden 2027 release evidence and scratch recovery

### DIFF
--- a/docs/2027_OWNER_DECISION_PACKET.md
+++ b/docs/2027_OWNER_DECISION_PACKET.md
@@ -1,0 +1,229 @@
+# 2027 Owner Decision Packet
+
+Status: **NOT APPROVED**
+
+This packet records the annual business choices that code and test evidence
+cannot make. Completing a field does not change the system by itself. The
+approved packet must be reconciled into `docs/DOMAIN_CONTRACT.md`, tournament
+configuration, tests, and the release checklist before 2027 race-day
+certification can be claimed.
+
+Owner: Alex Kaper
+
+Approval date: ____________________
+
+Approved configuration revision or commit: ____________________
+
+## 1. Event Window And Recovery Objectives
+
+All times use `America/Denver` unless the owner records a different zone.
+
+| Decision | Owner selection |
+|---|---|
+| Friday competition date and operating window | ____________________ |
+| Saturday competition date and operating window | ____________________ |
+| Friday Night Feature window, if used | ____________________ |
+| Backup high-frequency window | ____________________ |
+| Maximum acceptable data loss during live competition (RPO) | ____________________ |
+| Maximum acceptable recovery time during live competition (RTO) | ____________________ |
+| Maximum acceptable data loss outside the live window | ____________________ |
+| Maximum acceptable recovery time outside the live window | ____________________ |
+
+Recommended conservative baseline: daily encrypted backups outside the event
+window, hourly encrypted backups from 24 hours before the first competition
+window until 24 hours after the last window, live local/offline operator
+continuity, and an owner-approved one-hour RPO and one-hour RTO for hosted
+recovery. Approving a target does not prove it; the exact cadence and a timed
+restore rehearsal must still meet it.
+
+## 2. College Event Matrix
+
+For each traditionally open event, select whether it is OPEN or CLOSED in
+2027. A CLOSED selection counts against the six-event athlete limit.
+
+| Event | OPEN | CLOSED | Field limit or notes |
+|---|:---:|:---:|---|
+| Axe Throw | [ ] | [ ] | ____________________ |
+| Peavey Log Roll | [ ] | [ ] | ____________________ |
+| Caber Toss | [ ] | [ ] | ____________________ |
+| Pulp Toss | [ ] | [ ] | ____________________ |
+
+Select each scheduled closed event and record any field limit. Unchecked means
+not offered in 2027.
+
+| Event | Include | Field limit or notes |
+|---|:---:|---|
+| Underhand Hard Hit, men and women | [ ] | ____________________ |
+| Underhand Speed, men and women | [ ] | ____________________ |
+| Standing Block Hard Hit, men and women | [ ] | ____________________ |
+| Standing Block Speed, men and women | [ ] | ____________________ |
+| Single Buck, men and women | [ ] | ____________________ |
+| Double Buck, men and women | [ ] | ____________________ |
+| Jack and Jill Sawing | [ ] | ____________________ |
+| Stock Saw, men and women | [ ] | ____________________ |
+| Speed Climb, men and women | [ ] | ____________________ |
+| Obstacle Pole, men and women | [ ] | ____________________ |
+| Chokerman's Race, men and women | [ ] | ____________________ |
+| College Birling, separate men and women | [ ] | ____________________ |
+| 1-Board Springboard, men and women | [ ] | ____________________ |
+
+College closed-event cap for 2027: ______ events per athlete.
+
+Recommended selection: retain the owner-authored maximum of six unless the
+event matrix and show-duration rehearsal prove a different cap is required.
+
+## 3. Pro Event Matrix
+
+Pro events are selected annually based on wood and field availability. Check
+only the variants that will be offered.
+
+| Event | Include/variants | Field limit or notes |
+|---|---|---|
+| Springboard | ____________________ | ____________________ |
+| Pro 1-Board | ____________________ | ____________________ |
+| 3-Board Jigger | ____________________ | ____________________ |
+| Underhand | ____________________ | ____________________ |
+| Standing Block | ____________________ | ____________________ |
+| Stock Saw | ____________________ | ____________________ |
+| Hot Saw | ____________________ | ____________________ |
+| Single Buck | ____________________ | ____________________ |
+| Double Buck | ____________________ | ____________________ |
+| Jack and Jill | ____________________ | ____________________ |
+| Partnered Axe Throw | ____________________ | ____________________ |
+| Obstacle Pole | ____________________ | ____________________ |
+| Cookie Stack | ____________________ | ____________________ |
+| Pole Climb | ____________________ | ____________________ |
+
+Friday Night Feature selections: ____________________
+
+Saturday college spillover selections, in priority order: ____________________
+
+Mandatory baseline unless expressly changed: College Chokerman Run 2 closes
+Saturday spillover; Pro Obstacle Pole has one run; College Obstacle Pole has
+two runs.
+
+## 4. Springboard Resource Policy
+
+Current contract behavior is fail-closed: left-handed cutters use the
+configured left-handed dummy, are spread across heats, and generation expands
+the heat count until no heat needs that dummy more than once. Existing owner
+requirements also state that four dummies may each be used three times, which
+needs an explicit 2027 interpretation.
+
+Select one:
+
+- [ ] **Keep fail-closed expansion (recommended).** Add heats as needed and
+  reject generation if the configured stand set cannot represent the field.
+- [ ] **Authorize a bounded exception.** State the maximum uses per dummy,
+  required crew acknowledgment, and the exact condition under which the
+  operator may proceed: ________________________________________________
+- [ ] **Use another rule:** _____________________________________________
+
+Approved left-handed dummy stand number: ______
+
+Approved maximum uses per dummy for each Springboard event: ______
+
+## 5. Birling
+
+College Birling is currently modeled as separate men's and women's
+double-elimination brackets. The owner-authored pro rules say Pro Birling is
+not gender-separated and, when held, is last; the current pro event list does
+not enable it by default.
+
+| Decision | Owner selection |
+|---|---|
+| Hold College Birling in 2027? | Yes / No |
+| College Birling remains last on Friday? | Yes / No |
+| Hold Pro Birling in 2027? | Yes / No |
+| If held, Pro Birling is one mixed bracket? | Yes / No |
+| If held, Pro Birling is the final pro event before mandatory spillover? | Yes / No |
+| Bracket format and places awarded | ____________________ |
+
+Recommended baseline: retain gender-separated College Birling as a pre-seeded
+double-elimination bracket through sixth place; leave Pro Birling disabled
+unless its field, bracket format, and Saturday closing-order impact are
+explicitly approved and rehearsed.
+
+## 6. Pro-Am Relay
+
+The following owner-authored rules are treated as fixed unless explicitly
+amended here: each team has exactly eight competitors, with two Professional
+Men, two Professional Women, two College Men, and two College Women; event
+order is Partnered Sawing, Standing Butcher Block, Underhand Butcher Block,
+then Team Axe Throw; the fee is $5 whether or not the entrant is drawn;
+participation is not guaranteed; and Relay results do not affect College team
+or individual points.
+
+| Annual decision | Owner selection |
+|---|---|
+| Enable the Relay in 2027? | Yes / No |
+| Number of teams, or rule for deriving it | ____________________ |
+| Any eligibility exclusions | ____________________ |
+| One Relay flight or another show placement | ____________________ |
+| Prize money and payout places | ____________________ |
+| Lottery draw deadline and approving operator | ____________________ |
+
+Recommended baseline: derive the maximum number of complete teams from the
+smallest eligible cohort, draw only complete eight-person teams, place the
+Relay in the final normal pro flight before Saturday college spillover, and
+never imply that paying the fee guarantees a draw.
+
+## 7. Ties And Two-Timer Scoring
+
+Current code averages two valid timer readings and leaves a one-timer row
+partial. Tie splitting exists in the scoring surface, but the repository lacks
+a strong dated owner authorization for the 2027 policy.
+
+| Decision | Owner selection |
+|---|---|
+| Use the arithmetic mean of two timers? | Yes / No |
+| Rounding precision and displayed precision | ____________________ |
+| One missing/invalid timer blocks completion? | Yes / No |
+| Exact tie in College points events | Split / Throw-off / Other: __________ |
+| Exact tie in Pro payout events | Split / Throw-off / Other: __________ |
+| Events that always require a throw-off or event-specific tiebreak | ____________________ |
+| Payout remainder/rounding rule after a split | ____________________ |
+
+Recommended baseline: require both timers, use their arithmetic mean at the
+system's retained precision, and require an explicit event-specific throw-off
+where the event rules define one. Approve the split and rounding rule before
+money or College points are published.
+
+## 8. Backup Custody, Retention, And Audit
+
+The hosted workflow remains scheduled but fails closed until all required
+values and custody roles are approved. The recovery private identity must not
+be stored in GitHub, Railway, the repository, or the application environment.
+
+| Decision | Owner selection |
+|---|---|
+| Read-only production dump-role administrator | ____________________ |
+| `age` public recipient approver | ____________________ |
+| Separate private-key custodian | ____________________ |
+| Backup workflow/audit owner | ____________________ |
+| Encrypted artifact retention | ______ days |
+| Failed/obsolete artifact deletion owner | ____________________ |
+| Restore rehearsal operator | ____________________ |
+| Restore rehearsal cadence | ____________________ |
+| Download/access review cadence | ____________________ |
+
+Recommended baseline: keep the current 90-day encrypted-artifact retention,
+use separate people or separately controlled accounts for workflow
+administration and private-key custody, rehearse a retained-artifact restore
+before the event window and after any backup-workflow change, and review every
+artifact download.
+
+## 9. Final Owner Disposition
+
+- [ ] Approved exactly as completed above.
+- [ ] Approved with these exceptions: __________________________________
+- [ ] Not approved; return for revision.
+
+Owner signature or recorded approval reference: ____________________
+
+Implementation reviewer: ____________________
+
+Certification evidence reviewer: ____________________
+
+No unchecked or blank decision is implied by this packet. This packet alone
+does not determine deployability and cannot grant 2027 race-day certification.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -124,11 +124,24 @@ After merge to `main` and Railway deploy start:
 1. Confirm Railway runs `preDeployCommand = "flask db upgrade"`
 2. Confirm deploy logs show migration output
 3. Confirm app boot completes without config/runtime crash
-4. Confirm health check:
+4. Record the exact 40-character merge SHA, application version, and Alembic
+   head expected from the deployed release.
+5. Run the commit-pinned public smoke check without `--allow-unpinned`:
+
+   ```powershell
+   python scripts/smoke_test.py --expected-commit <merge-sha> --expected-version <version> --expected-migration <alembic-head>
+   ```
+
+6. Confirm health check:
    - `GET /health` returns `200`
    - `db` is `true`
-5. Confirm one authenticated judge page loads
-6. Confirm one public spectator/API page loads
+   - `migration_current` is `true`
+   - `migration_rev` matches the expected Alembic head
+   - `git_commit` matches the exact merge SHA
+7. Confirm one authenticated judge page loads. The public smoke script checks
+   the login form but does not satisfy this authenticated check.
+8. Confirm one public spectator/API page loads with the expected tournament
+   binding and standings schema.
 
 For a deliberately enabled STRATHMARK shadow deployment, also confirm:
 
@@ -160,4 +173,6 @@ For a deliberately enabled STRATHMARK shadow deployment, also confirm:
 - [ ] separately held recovery identity rehearsal recorded, or release blocked
 - [ ] rollback path documented
 - [ ] deploy verified in Railway logs
-- [ ] `/health` verified after deploy
+- [ ] exact commit, version, and migration smoke verified after deploy
+- [ ] authenticated judge page verified after deploy
+- [ ] tournament-bound public spectator/API response verified after deploy

--- a/proam_regression/test_2026_observed_failures.py
+++ b/proam_regression/test_2026_observed_failures.py
@@ -741,11 +741,17 @@ def _scratch_through_the_real_route(client, comp_id, comp_type):
         headers={"Accept": "application/json"},
     )
     assert r.status_code == 200, r.status_code
-    effects = r.get_json()["effects"]
-    form = {"effect_count": str(len(effects)), "competitor_type": comp_type}
+    payload = r.get_json()
+    effects = payload["effects"]
+    form = {
+        "effect_count": str(len(effects)),
+        "competitor_type": comp_type,
+        "expected_effect_digest": payload["effect_digest"],
+    }
     for i, e in enumerate(effects):
         form[f"effect_type_{i}"] = e["effect_type"]
         form[f"affected_entity_id_{i}"] = str(e["affected_entity_id"])
+        form[f"affected_entity_type_{i}"] = e["affected_entity_type"]
         form[f"effect_checked_{i}"] = "on"
     r2 = client.post(
         f"/scoring/{TID}/competitor/{comp_id}/scratch-confirm", data=form

--- a/proam_regression/test_sev1_remaining.py
+++ b/proam_regression/test_sev1_remaining.py
@@ -42,12 +42,17 @@ def _loads(value):
 
 def _relay_state(sql):
     """Read the normalized relay projection through the race-day service."""
+    del sql
+    return _relay_service().relay_data
+
+
+def _relay_service():
+    """Return the current normalized relay service for digest-aware writes."""
     from database import db
     from models import Tournament
     from services.proam_relay import get_proam_relay
 
-    del sql
-    return get_proam_relay(db.session.get(Tournament, TID)).relay_data
+    return get_proam_relay(db.session.get(Tournament, TID))
 
 
 # ---------------------------------------------------------------------------
@@ -159,8 +164,10 @@ def test_failed_relay_redraw_leaves_the_announced_teams_intact(client, sql):
 
     # Ask for a draw the eligible pool cannot possibly fill. 99 teams needs
     # 198 pro men; the tournament has 25 eligible pros in total.
+    expected_digest = _relay_service().state_digest()
     r = client.post(f"/tournament/{TID}/proam-relay/redraw",
-                    data={"num_teams": "99"})
+                    data={"num_teams": "99",
+                          "expected_relay_digest": expected_digest})
     assert r.status_code in (200, 302), r.data[:400]
 
     after = _relay_state(sql)
@@ -193,8 +200,10 @@ def test_a_redraw_that_can_succeed_still_replaces_the_teams(client, sql):
     before = _relay_state(sql)
     assert len(before.get("teams", [])) == 3, before.get("status")
 
+    expected_digest = _relay_service().state_digest()
     r = client.post(f"/tournament/{TID}/proam-relay/redraw",
-                    data={"num_teams": "2"})
+                    data={"num_teams": "2",
+                          "expected_relay_digest": expected_digest})
     assert r.status_code in (200, 302), r.data[:400]
 
     after = _relay_state(sql)
@@ -252,9 +261,11 @@ def test_public_relay_results_page_survives_recorded_total_times(app, client, sq
     for team in teams:
         number = team["team_number"]
         seconds = RELAY_TOTAL_TIMES.get(number, "420.00")
+        expected_digest = _relay_service().team_state_digest(number)
         r = client.post(f"/tournament/{TID}/proam-relay/results",
                         data={"team_number": str(number),
-                              "time_seconds": seconds})
+                              "time_seconds": seconds,
+                              "expected_relay_digest": expected_digest})
         assert r.status_code in (200, 302), r.data[:400]
 
     recorded = [t.get("total_time") for t in _relay_state(sql).get("teams", [])]
@@ -315,9 +326,11 @@ def test_public_relay_desktop_view_prints_the_times_it_actually_has(app, client,
     for team in teams:
         number = team["team_number"]
         seconds = RELAY_TOTAL_TIMES.get(number, "420.00")
+        expected_digest = _relay_service().team_state_digest(number)
         r = client.post(f"/tournament/{TID}/proam-relay/results",
                         data={"team_number": str(number),
-                              "time_seconds": seconds})
+                              "time_seconds": seconds,
+                              "expected_relay_digest": expected_digest})
         assert r.status_code in (200, 302), r.data[:400]
 
     # view=desktop is explicit because _resolve_view_mode(prefer_mobile=True)

--- a/proam_regression/test_sev2_confirmed.py
+++ b/proam_regression/test_sev2_confirmed.py
@@ -2722,25 +2722,19 @@ def _insert_result(app, event_id, comp_id, name, ctype="pro"):
 @pytest.mark.sev2
 def test_generating_heats_says_out_loud_that_an_entered_competitor_was_left_out(
         client, sql, flashes):
-    """26 people are entered in event 32. 25 get a stand. Nobody is told.
-
-    Measured against v2026.final: the only flash is
-    ('success', "Generated 5 heat(s) for Men's Underhand.") and caplog holds
-    no heat_generator warning either.
-    """
+    """An explicit wrong-gender entry blocks replacement and names the entrant."""
+    before = event_rosters(sql, UH_M)
     said = _gen(client, flashes, UH_M)
 
-    # Vacuity guard: generation must actually have succeeded, or "no success
-    # flash" would satisfy this test for the wrong reason.
-    assert [m for cat, m in said if cat == "success"], (
-        f"heat generation did not succeed at all, so this test proves "
-        f"nothing about what it reports: {said}")
-    assert len(_placed_ids(sql, UH_M)) == 25, "the roster changed under the test"
+    assert not [m for cat, m in said if cat == "success"], (
+        f"generation reported success despite an invalid explicit entry: {said}")
+    assert event_rosters(sql, UH_M) == before, (
+        "the invalid entry replaced or modified the existing heat layout")
 
     warned = _named_in_a_warning(said, "Kate Page")
     assert warned, (
-        f"Kate Page is entered in event {UH_M} and was left out of every heat, "
-        f"and the operator was told nothing about it. Flashes: {said}")
+        f"Kate Page is explicitly entered in event {UH_M} with the wrong "
+        f"gender, but the blocking message did not name her. Flashes: {said}")
 
 
 @pytest.mark.sev2
@@ -2772,7 +2766,7 @@ def test_the_add_competitor_dropdown_does_not_offer_someone_the_server_refuses(
 
 
 @pytest.mark.sev2
-def test_the_generator_records_the_excluded_entrant_when_called_directly(app):
+def test_the_generator_records_the_excluded_entrant_when_called_directly(app, sql):
     """A route-only fix leaves every other caller of the service blind.
 
     services/schedule_generation.py, routes/scheduling/flights.py,
@@ -2782,6 +2776,7 @@ def test_the_generator_records_the_excluded_entrant_when_called_directly(app):
     from database import db
     from models import Event
     from services.heat_generator import (
+        HeatGenerationSafetyError,
         generate_event_heats,
         get_last_gender_excluded,
     )
@@ -2792,8 +2787,12 @@ def test_the_generator_records_the_excluded_entrant_when_called_directly(app):
         "WHERE event_id = :event_id"
     ), {"event_id": UH_M})
     db.session.commit()
-    generate_event_heats(event)
-    db.session.commit()
+    before = event_rosters(sql, UH_M)
+    with pytest.raises(HeatGenerationSafetyError, match="Kate Page"):
+        generate_event_heats(event)
+    db.session.rollback()
+    after = event_rosters(sql, UH_M)
+    assert after == before, "direct generation replaced the prior heat layout"
 
     recorded = get_last_gender_excluded(UH_M)
     ids = [r["comp_id"] for r in recorded]
@@ -2864,10 +2863,13 @@ def test_when_every_entrant_is_the_wrong_gender_the_operator_is_told_who(
 @pytest.mark.sev2
 def test_the_eligible_men_are_still_placed_when_a_wrong_gender_entrant_is_present(
         client, sql, flashes):
-    """The fix must report the excluded entrant, not start dropping people."""
-    _gen(client, flashes, UH_M)
+    """Blocking an invalid entry must preserve every eligible existing start."""
+    before = _placed_ids(sql, UH_M)
+    said = _gen(client, flashes, UH_M)
 
     placed = _placed_ids(sql, UH_M)
+    assert placed == before, "the blocked regeneration changed eligible starts"
+    assert not [m for cat, m in said if cat == "success"], said
     heats = sql("SELECT count(*) FROM heats WHERE event_id = :e", e=UH_M)[0][0]
     assert heats == 5, f"expected 5 heats of 5, got {heats}"
     assert len(placed) == 25, f"expected 25 men placed, got {len(placed)}"

--- a/proam_regression/test_sev3_confirmed.py
+++ b/proam_regression/test_sev3_confirmed.py
@@ -393,17 +393,12 @@ def test_dropped_gear_partner_is_not_scheduled_into_the_same_heat(client, sql):
 
 
 # ---------------------------------------------------------------------------
-# c08. The report cache's disk layer pickles live SQLAlchemy rows, so the
-#      college standings page 500s for a full TTL after a worker respawns
-#      services/report_cache.py, routes/reporting.py college_standings
+# c08. Historical defect: the former report-cache disk layer pickled live
+#      SQLAlchemy rows, so college standings could 500 after a worker respawn.
+#      The disk layer is now retired and PostgreSQL deliberately rebuilds.
 #
-#      Filed SEV2. Verified SEV3: the outage is self-limiting (it clears on
-#      the next TTL expiry or on any invalidate_tournament_caches call), the
-#      blast radius is one admin screen, and the /print variant and the
-#      spectator portal both stay 200 throughout. It is still a hard 500 on a
-#      page a judge reads between events, and the trigger, a gunicorn worker
-#      dying and respawning onto an already warm shelve file, needs nothing
-#      from the operator to happen.
+#      These regressions now prove the resolution: no disk persistence, no ORM
+#      payload leakage, and a fresh PostgreSQL rebuild after process reset.
 # ---------------------------------------------------------------------------
 
 RPT_URL = f"/reporting/{TID}/college/standings"
@@ -418,151 +413,82 @@ RPT_TOP_MAN_TEAM = "FVC-A"
 RPT_TOP_TEAM_SCHOOL = "Colorado State University"
 
 
-def _rpt_isolate(tmp_path):
-    """Point the report cache at a private shelve file and hand back a restore.
-
-    report_cache keeps its state in module globals, so without this a test
-    would write into the checkout's instance/ directory and leak entries into
-    whatever test runs next in the same process.
-    """
-    import services.report_cache as rc
-
-    saved = (rc._shelf_path, rc._shelf_resolved, dict(rc._cache))
-    rc._shelf_path = str(tmp_path / "cache")
-    rc._shelf_resolved = True
-    with rc._lock:
-        rc._cache.clear()
-
-    def _restore():
-        with rc._lock:
-            rc._cache.clear()
-            rc._cache.update(saved[2])
-        rc._shelf_path, rc._shelf_resolved = saved[0], saved[1]
-
-    return rc, _restore
-
-
-def _rpt_break_builders(monkeypatch):
-    """Make every database-side builder for this page explode.
-
-    Without this the test is vacuous: if the disk layer fails to serve the
-    second request, the route just rebuilds the payload from the database and
-    renders a perfectly good page, and the assertion passes while measuring
-    nothing.
-    """
+@pytest.mark.sev3
+def test_postgres_college_standings_rebuilds_after_process_reset_without_cache(
+        client, app, monkeypatch):
+    """PostgreSQL standings rebuild safely instead of sharing stale state."""
     from models.tournament import Tournament
+    from services import report_cache
 
-    def _boom(*args, **kwargs):
-        raise AssertionError(
-            "the route rebuilt the payload from the database; the disk cache "
-            "layer never served this request, so this test proves nothing")
+    calls = 0
+    original = Tournament.get_team_standings
 
-    for name in ('get_bull_of_woods', 'get_belle_of_woods',
-                 'get_bull_belle_with_tiebreak_data', 'get_team_standings'):
-        monkeypatch.setattr(Tournament, name, _boom)
+    def _counted(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(self, *args, **kwargs)
 
+    monkeypatch.setattr(Tournament, 'get_team_standings', _counted)
+    report_cache.reset_for_testing()
 
-@pytest.mark.sev3
-def test_college_standings_survives_a_worker_respawn_onto_a_warm_disk_cache(
-        client, app, tmp_path, monkeypatch):
-    """A judge reloading standings after a worker restart must get standings.
+    first = client.get(RPT_URL)
+    assert first.status_code == 200, first.status_code
+    body_before = first.get_data(as_text=True)
+    assert RPT_TOP_MAN in body_before
+    assert RPT_TOP_MAN_TEAM in body_before
+    assert RPT_TOP_TEAM_SCHOOL in body_before
+    assert client.get(RPT_PRINT_URL).status_code == 200
 
-    gunicorn runs the app with a single worker. When that worker dies and is
-    respawned, the module-level L1 dict dies with the process and the shelve
-    file in instance/report_cache does not. The new worker's first request for
-    this page reads the disk entry, gets back CollegeCompetitor objects that
-    are detached from every session, and dies in the template on c.team.
-    """
-    rc, restore = _rpt_isolate(tmp_path)
-    try:
-        first = client.get(RPT_URL)
-        assert first.status_code == 200, first.status_code
-        body_before = first.get_data(as_text=True)
-
-        # Controls. The page really renders competitor and team data, so a
-        # failure below is a cache failure and not an empty-roster artifact.
-        assert RPT_TOP_MAN in body_before
-        assert RPT_TOP_MAN_TEAM in body_before
-        assert RPT_TOP_TEAM_SCHOOL in body_before
-
-        # Control. The uncached print variant of the same data is fine, which
-        # localizes any failure below to the caching path.
-        assert client.get(RPT_PRINT_URL).status_code == 200
-
-        # Control. The disk layer actually engaged. On a machine where the
-        # instance directory is unwritable this assertion is the only thing
-        # standing between a green run and a meaningless one.
-        assert rc._shelf_get(RPT_KEY) is not None, (
-            "nothing reached the disk cache, so the worker-respawn path below "
-            "is not being exercised")
-
-        # The worker dies and respawns.
-        with rc._lock:
-            rc._cache.clear()
-        _rpt_break_builders(monkeypatch)
-
-        second = client.get(RPT_URL)
-        assert second.status_code == 200, (
-            f"standings returned {second.status_code} on the first request "
-            f"after a worker respawn, and will keep doing it until the cache "
-            f"entry expires")
-        body_after = second.get_data(as_text=True)
-        assert RPT_TOP_MAN in body_after
-        assert RPT_TOP_MAN_TEAM in body_after, (
-            "the page came back but the team column did not; a cached payload "
-            "that renders 'N/A' where a team code belongs is not a fix")
-        assert RPT_TOP_TEAM_SCHOOL in body_after
-        assert body_after.count("N/A") == body_before.count("N/A")
-    finally:
-        restore()
+    report_cache.reset_for_testing()
+    second = client.get(RPT_URL)
+    assert second.status_code == 200, second.status_code
+    body_after = second.get_data(as_text=True)
+    assert RPT_TOP_MAN in body_after
+    assert RPT_TOP_MAN_TEAM in body_after
+    assert RPT_TOP_TEAM_SCHOOL in body_after
+    assert body_after.count("N/A") == body_before.count("N/A")
+    assert calls == 3  # standings route twice, uncached print route once
+    assert report_cache.get(RPT_KEY) is None
+    with report_cache._lock:
+        assert RPT_KEY not in report_cache._cache
 
 
 @pytest.mark.sev3
-def test_the_cached_standings_payload_holds_no_live_database_rows(
-        client, app, tmp_path):
-    """Whatever is cached has to be able to outlive the session that built it."""
-    rc, restore = _rpt_isolate(tmp_path)
-    try:
-        assert client.get(RPT_URL).status_code == 200
-        with rc._lock:
-            payload = rc._cache[RPT_KEY]['value']
+def test_the_standings_payload_holds_no_live_database_rows(app):
+    """The serializer contract stays plain even when PostgreSQL bypasses cache."""
+    from database import db
+    from models.tournament import Tournament
+    from routes.reporting import _build_college_standings_payload
+    from services import report_cache
 
-        # Control: the payload is the real thing, not an empty dict that would
-        # trivially contain no entities.
-        assert payload['bull_tiebreak'], "no Bull rows to check"
-        assert payload['team_standings'], "no team rows to check"
-
-        assert not rc._contains_orm_entity(payload), (
-            "the standings payload still carries SQLAlchemy rows, so the disk "
-            "layer will hand a detached copy to the next worker")
-    finally:
-        restore()
+    tournament = db.session.get(Tournament, TID)
+    payload = _build_college_standings_payload(tournament)
+    assert payload['bull_tiebreak'], "no Bull rows to check"
+    assert payload['team_standings'], "no team rows to check"
+    assert not report_cache._contains_orm_entity(payload)
 
 
 @pytest.mark.sev3
-def test_the_report_cache_refuses_to_put_database_rows_on_disk(app, tmp_path):
-    """The guard, tested directly, so the next caller cannot repeat c08."""
+def test_postgres_report_cache_persists_neither_database_rows_nor_plain_data(
+        app, tmp_path):
+    """PostgreSQL never stores process-local or cross-process report state."""
     from models.competitor import CollegeCompetitor
+    from services import report_cache
 
-    rc, restore = _rpt_isolate(tmp_path)
-    try:
-        row = CollegeCompetitor.query.filter_by(tournament_id=TID).first()
-        assert row is not None, "no college competitor to build the probe from"
+    report_cache.reset_for_testing()
+    row = CollegeCompetitor.query.filter_by(tournament_id=TID).first()
+    assert row is not None, "no college competitor to build the probe from"
 
-        rc.set("reports:c08probe:entities", {"rows": [{"competitor": row}]}, 60)
-        assert rc._shelf_get("reports:c08probe:entities") is None, (
-            "a payload carrying a live database row reached the disk layer")
-        # L1 is not implicated and must keep working: the objects never leave
-        # the process that loaded them.
-        assert rc.get("reports:c08probe:entities") is not None
+    report_cache.set("reports:c08probe:entities", {"rows": [{"competitor": row}]}, 60)
+    report_cache.set("reports:c08probe:plain", {"rows": [{"name": row.name}]}, 60)
 
-        # Control: the guard is not a blanket refusal. Plain data still lands.
-        rc.set("reports:c08probe:plain", {"rows": [{"name": row.name}]}, 60)
-        assert rc._shelf_get("reports:c08probe:plain") is not None, (
-            "the disk layer stopped accepting plain data, which breaks the "
-            "whole point of having an L2")
-    finally:
-        restore()
+    assert report_cache.get("reports:c08probe:entities") is None
+    assert report_cache.get("reports:c08probe:plain") is None
+    assert report_cache._shelf_get("reports:c08probe:entities") is None
+    assert report_cache._shelf_get("reports:c08probe:plain") is None
+    with report_cache._lock:
+        assert report_cache._cache == {}
+    assert list(tmp_path.iterdir()) == []
 
 
 # ---------------------------------------------------------------------------
@@ -1578,7 +1504,8 @@ def _c21_scratch(client, competitor_id, competitor_type):
         f"{r.status_code} and no JSON: {r.data[:300]}")
     effects = body["effects"]
     form = {"effect_count": str(len(effects)),
-            "competitor_type": competitor_type}
+            "competitor_type": competitor_type,
+            "expected_effect_digest": body["effect_digest"]}
     for i, e in enumerate(effects):
         form[f"effect_type_{i}"] = e["effect_type"]
         form[f"affected_entity_id_{i}"] = str(e["affected_entity_id"])
@@ -1591,9 +1518,19 @@ def _c21_scratch(client, competitor_id, competitor_type):
 
 
 def _c21_undo(client, competitor_id, competitor_type):
+    preview = client.get(
+        f"/scoring/{TID}/competitor/{competitor_id}/scratch-preview"
+        f"?format=json&competitor_type={competitor_type}")
+    body = preview.get_json()
+    assert preview.status_code == 200 and body is not None, (
+        f"scratch-preview before undo returned {preview.status_code}: "
+        f"{preview.data[:300]}")
+    undo_token = body.get("undo_token")
+    assert undo_token, f"scratch-preview did not return an undo token: {body}"
     p = client.post(
         f"/scoring/{TID}/competitor/{competitor_id}/scratch-undo"
-        f"?competitor_type={competitor_type}")
+        f"?competitor_type={competitor_type}",
+        data={"expected_undo_token": undo_token})
     assert p.status_code in (200, 302), p.data[:400]
 
 
@@ -1782,12 +1719,12 @@ def test_a_heat_that_already_shipped_empty_is_not_touched_by_a_scratch(
 @pytest.mark.sev3
 def test_an_undo_does_not_reopen_a_heat_the_operator_scored_afterwards(
         client, sql):
-    """Positive control on the undo, and it is the sharp one.
+    """Undo must fail closed after the judge changes a scratched heat.
 
     Scratch one of a pair, score the survivor, then undo. The heat is
     'completed' because the JUDGE completed it, not because the cascade did.
-    A restore that blindly writes the snapshotted status back would reopen a
-    scored heat and throw away the completion the operator earned.
+    Restoring the scratched competitor would leave that person unscored in a
+    completed heat, so the correction must use an explicit operator workflow.
     """
     _, pair_ids = _c21_heat(sql, _C21_PAIR_HEAT)
     assert len(pair_ids) == 2, pair_ids
@@ -1800,17 +1737,30 @@ def test_an_undo_does_not_reopen_a_heat_the_operator_scored_afterwards(
         f"vacuity: the judge's own scoring did not complete heat "
         f"{_C21_PAIR_HEAT}: {scored_status}")
     assert scored_ids == [survivor], scored_ids
+    scored_result = sql(
+        "SELECT status, result_value FROM event_results "
+        "WHERE event_id = :e AND competitor_id = :c",
+        e=_C21_PAIR_EVENT,
+        c=survivor,
+    )[0]
 
     _c21_undo(client, scratched, "pro")
 
     after_status, after_ids = _c21_heat(sql, _C21_PAIR_HEAT)
-    assert scratched in after_ids, (
-        f"vacuity: the undo did not restore competitor {scratched}: "
-        f"{after_ids}")
+    assert after_ids == [survivor], (
+        f"unsafe undo restored competitor {scratched} after scoring: {after_ids}")
+    assert sql(
+        "SELECT status FROM pro_competitors WHERE id = :c",
+        c=scratched,
+    )[0][0] == "scratched"
     assert after_status == "completed", (
-        f"the undo reopened heat {_C21_PAIR_HEAT} to {after_status!r}. The "
-        f"judge completed that heat after the scratch and the undo threw it "
-        f"away.")
+        f"refused undo changed heat {_C21_PAIR_HEAT} to {after_status!r}.")
+    assert sql(
+        "SELECT status, result_value FROM event_results "
+        "WHERE event_id = :e AND competitor_id = :c",
+        e=_C21_PAIR_EVENT,
+        c=survivor,
+    )[0] == scored_result
 
 
 # ---------------------------------------------------------------------------
@@ -2890,6 +2840,39 @@ def _heat_rosters(sql, event_id):
     return event_rosters(sql, event_id)
 
 
+def _assert_no_cross_unit_gear_conflicts(sql, event_id):
+    """Prove that no two distinct stand units share declared gear in a heat."""
+    import services.heat_generator as hg
+    from database import db
+    from models import Event
+
+    event = db.session.get(Event, event_id)
+    competitors = {
+        comp["id"]: comp for comp in hg._get_event_competitors(event)
+    }
+    for heat_number, roster in enumerate(_heat_rosters(sql, event_id), start=1):
+        units = hg._rebuild_pair_units(
+            [competitors[comp_id] for comp_id in roster],
+            event,
+        )
+        for index, unit in enumerate(units):
+            other_members = [
+                comp
+                for other_index, other_unit in enumerate(units)
+                if other_index != index
+                for comp in other_unit
+            ]
+            for comp in unit:
+                assert not hg._has_gear_sharing_conflict(
+                    comp,
+                    other_members,
+                    event,
+                ), (
+                    f"event {event_id} heat {heat_number} placed "
+                    f"{comp['name']} with a distinct unit that shares gear"
+                )
+
+
 @pytest.mark.sev3
 def test_regenerating_double_buck_leaves_no_entrant_out_of_the_event(client, sql):
     """DEFECT. Two competitors vanish from the event on a plain regenerate.
@@ -2912,28 +2895,18 @@ def test_regenerating_double_buck_leaves_no_entrant_out_of_the_event(client, sql
 
 
 @pytest.mark.sev3
-def test_regenerating_double_buck_fills_the_third_heat(client, sql):
-    """DEFECT. 12 pairs over 3 heats of 4 stands is 4/4/4, not 4/4/3.
-
-    The filed symptom was an unbalanced field. The balance is a shadow of the
-    real event: the missing stand is missing because the pair that belonged on
-    it was thrown away, not because the draft distributed badly.
-    """
+def test_regenerating_double_buck_uses_the_minimal_gear_safe_layout(client, sql):
+    """Twelve pairs expand from three full heats to four conflict-free heats."""
     _generate_heats(client, sql, DB_EVENT)
     sizes = [len(r) for r in _heat_rosters(sql, DB_EVENT)]
-    assert sizes == [8, 8, 8], sizes
+    assert sizes == [6, 6, 6, 6], sizes
+    _assert_no_cross_unit_gear_conflicts(sql, DB_EVENT)
 
 
 @pytest.mark.sev3
-def test_a_pair_that_cannot_dodge_a_gear_conflict_is_flagged_not_deleted(client, sql, flashes):
-    """DEFECT. The fallback exists to place a unit ANYWAY and warn the judge.
-
-    services/heat_generator.py already carries that machinery: the fallback
-    records every forced gear-sharing conflict in gear_violations and the
-    generate-heats route turns it into a WARNING flash. The operator never
-    sees it, because the walk gives up before reaching the heat with room, so
-    nothing is placed and nothing is recorded. Silence here reads as success.
-    """
+def test_a_pair_that_cannot_fit_three_heats_expands_without_a_conflict(
+        client, sql, flashes):
+    """A constrained pair is conserved by expansion, never forced to share."""
     _generate_heats(client, sql, DB_EVENT)
 
     placed = [c for roster in _heat_rosters(sql, DB_EVENT) for c in roster]
@@ -2941,7 +2914,8 @@ def test_a_pair_that_cannot_dodge_a_gear_conflict_is_flagged_not_deleted(client,
         f"{[c for c in DB_DROPPED if c not in placed]} still not in any heat")
 
     msgs = [m for _c, m in flashes()]
-    assert any("gear-sharing conflict" in m for m in msgs), msgs
+    assert not any("gear-sharing conflict" in m for m in msgs), msgs
+    _assert_no_cross_unit_gear_conflicts(sql, DB_EVENT)
 
 
 # --- CONTROLS: the snake draft itself must not move ------------------------
@@ -2953,6 +2927,20 @@ def test_a_pair_that_cannot_dodge_a_gear_conflict_is_flagged_not_deleted(client,
 @pytest.mark.sev3
 def test_the_underhand_snake_draft_is_unchanged(client, sql):
     """CONTROL. 25 pros, 5 heats of 5, one gear conflict dodged in the draft."""
+    from database import db
+    from models import ProCompetitor
+
+    # The historical mirror contains one explicit wrong-gender entry in this
+    # men's event. Remove only that invalid entry in the disposable clone so
+    # this test isolates the snake ordering contract rather than the safety
+    # gate that correctly blocks regeneration on the unmodified mirror.
+    competitor = db.session.get(ProCompetitor, 2)
+    competitor.set_events_entered([
+        event_id for event_id in competitor.get_events_entered()
+        if int(event_id) != 32
+    ])
+    db.session.commit()
+
     _generate_heats(client, sql, 32)
     assert _heat_rosters(sql, 32) == [
         [1, 30, 32, 43, 44],
@@ -3021,13 +3009,7 @@ def _synthetic(n):
 
 @pytest.mark.sev3
 def test_a_unit_is_placed_while_any_heat_still_has_a_free_stand(monkeypatch):
-    """DEFECT, staged. The event 38 shape with the data taken out of it.
-
-    12 units, 3 heats, 4 stands. By the last unit the pointer sits on heat 0
-    heading down, so the first pass bounces (h0, h0, h1) and the fallback
-    bounces the other way (h2, h2, h1). Heat 0 has a free stand the whole
-    time and neither walk ever looks at it again.
-    """
+    """A constrained field expands instead of discarding or forcing a unit."""
     import services.heat_generator as hg
 
     safe = {0, 5, 6}
@@ -3042,8 +3024,8 @@ def test_a_unit_is_placed_while_any_heat_still_has_a_free_stand(monkeypatch):
 
     placed = sorted(c["id"] for h in heats for c in h)
     assert placed == list(range(12)), f"unit(s) {sorted(set(range(12)) - set(placed))} discarded"
-    assert sorted(len(h) for h in heats) == [4, 4, 4]
-    assert [v["comp_id"] for v in violations] == [11], violations
+    assert [len(h) for h in heats] == [3, 3, 3, 3]
+    assert violations == []
 
 
 @pytest.mark.sev3
@@ -3124,7 +3106,7 @@ def test_mens_underhand_speed_does_not_open_on_the_short_heat(client, sql):
     violates the rule. 13 cutters at the same cap would have produced 5/4/4
     and been reordered, because one heat would have touched the cap.
     """
-    _generate_heats(client, 9)
+    _generate_heats(client, sql, 9)
     rosters = _heat_rosters(sql, 9)
     assert sorted(c for r in rosters for c in r) == sorted(
         [100030, 100042, 100044, 100032, 100041, 100058, 100077,
@@ -3141,7 +3123,7 @@ def test_mens_underhand_speed_does_not_open_on_the_short_heat(client, sql):
 @pytest.mark.sev3
 def test_womens_underhand_speed_does_not_open_on_the_short_heat(client, sql):
     """DEFECT. The women's half of the same event, same shape, same cause."""
-    _generate_heats(client, 10)
+    _generate_heats(client, sql, 10)
     rosters = _heat_rosters(sql, 10)
     assert sorted(c for r in rosters for c in r) == sorted(
         [100034, 100071, 100072, 100048, 100070, 100083, 100092,
@@ -3246,31 +3228,31 @@ def test_the_cap_hitting_events_keep_their_shipped_order(client, sql):
     could only be reproduced by a database whose heap accident matched
     April 2026's.
     """
-    _generate_heats(client, 7)
+    _generate_heats(client, sql, 7)
     assert _heat_rosters(sql, 7) == [
         [100032, 100050, 100051, 100080, 100085], [100033, 100043, 100059, 100079, 100086],
         [100037, 100042, 100060, 100078], [100038, 100039, 100061, 100074]]
 
-    _generate_heats(client, 11)
+    _generate_heats(client, sql, 11)
     assert _heat_rosters(sql, 11) == [
         [100035, 100059, 100066, 100086, 100087], [100044, 100058, 100067, 100085], [100050, 100051, 100078, 100079]]
 
-    _generate_heats(client, 33)
+    _generate_heats(client, sql, 33)
     assert _heat_rosters(sql, 33) == [
         [2, 11, 12, 18, 19], [5, 9, 13, 17], [7, 8, 15, 16]]
 
-    _generate_heats(client, 43)
+    _generate_heats(client, sql, 43)
     assert _heat_rosters(sql, 43) == [
         [1, 26, 27, 42, 43], [8, 24, 29, 40, 47], [14, 23, 30, 38, 48],
         [6, 25, 28, 44], [15, 22, 31, 37], [18, 21, 32, 36],
         [19, 20, 33, 34]]
 
-    _generate_heats(client, 20)
+    _generate_heats(client, sql, 20)
     assert _heat_rosters(sql, 20) == [
         [100035, 100080], [100037, 100079], [100038, 100077], [100041, 100076], [100043, 100074],
         [100044, 100069], [100046, 100066], [100051, 100062], [100058, 100059], [100030]]
 
-    _generate_heats(client, 25)
+    _generate_heats(client, sql, 25)
     assert _heat_rosters(sql, 25) == [
         [100031, 100092], [100055, 100089], [100057, 100071], [100029]]
 
@@ -3284,7 +3266,7 @@ def test_the_uniform_all_partial_events_are_untouched(client, sql):
     """
     for eid, expect in ((17, [3, 3, 3]), (18, [3, 3]),
                         (30, [3, 3, 3]), (35, [3, 3, 3])):
-        _generate_heats(client, eid)
+        _generate_heats(client, sql, eid)
         rosters = _heat_rosters(sql, eid)
         sizes = [len(r) for r in rosters]
         assert not _opens_short(sizes), (eid, sizes)

--- a/routes/main.py
+++ b/routes/main.py
@@ -3,6 +3,7 @@ Main routes for dashboard and navigation.
 """
 import json
 import logging
+import os
 import time
 from urllib.parse import urlsplit
 
@@ -50,8 +51,6 @@ def health():
         db_ok = True
         # Check if DB is at migration HEAD
         try:
-            import os
-
             from alembic.config import Config as AlembicConfig
             from alembic.script import ScriptDirectory
             from flask_migrate import current as alembic_current
@@ -77,6 +76,8 @@ def health():
         'migration_head': migration_head,
         'migration_rev': migration_current_rev,
         'version': '2.14.16',
+        'git_commit': os.environ.get('RAILWAY_GIT_COMMIT_SHA')
+                      or os.environ.get('GIT_COMMIT_SHA'),
     })
 
 
@@ -590,13 +591,14 @@ def pro_dashboard(tournament_id):
             })
     live_event_leaders = live_event_leaders[:5]
 
-    # Which scratched competitors can still be undone.  Without this the
+    # Current undo capabilities for scratched competitors.  Without this the
     # 30-minute undo window is unreachable from anywhere in the product:
     # scratch_confirm redirects here, the Scratch button is gated on
     # status == 'active', and the only Undo control that existed lived on the
-    # confirmation page that button leads to.  One bulk query, not one per row.
-    from services.scratch_cascade import find_undoable_scratches
-    undoable_scratch_ids = find_undoable_scratches(
+    # confirmation page that button leads to.  Batched reads avoid one query
+    # per roster row while giving each form the server-required token.
+    from services.scratch_cascade import find_undoable_scratch_tokens
+    undo_tokens_by_competitor_id = find_undoable_scratch_tokens(
         [c.id for c in competitors if c.status == 'scratched'], 'pro'
     )
 
@@ -607,7 +609,7 @@ def pro_dashboard(tournament_id):
                            total_fees=total_fees,
                            collected_fees=collected_fees,
                            top_earners=top_earners,
-                           undoable_scratch_ids=undoable_scratch_ids,
+                           undo_tokens_by_competitor_id=undo_tokens_by_competitor_id,
                            live_event_leaders=live_event_leaders)
 
 

--- a/routes/registration.py
+++ b/routes/registration.py
@@ -287,8 +287,8 @@ def team_detail(tournament_id, team_id):
     # Same reachability repair as the pro dashboard: scratch_confirm redirects
     # a college judge back here, and the Scratch button is gated on
     # status == 'active', so without this the undo window cannot be reached.
-    from services.scratch_cascade import find_undoable_scratches
-    undoable_scratch_ids = find_undoable_scratches(
+    from services.scratch_cascade import find_undoable_scratch_tokens
+    undo_tokens_by_competitor_id = find_undoable_scratch_tokens(
         [m.id for m in members if m.status == 'scratched'], 'college'
     )
 
@@ -298,7 +298,7 @@ def team_detail(tournament_id, team_id):
                            members=members,
                            college_events=college_events,
                            member_event_labels=member_event_labels,
-                           undoable_scratch_ids=undoable_scratch_ids,
+                           undo_tokens_by_competitor_id=undo_tokens_by_competitor_id,
                            member_event_details=member_event_details)
 
 

--- a/routes/reporting.py
+++ b/routes/reporting.py
@@ -32,8 +32,7 @@ from models import Event, Tournament
 from services.audit import log_action
 from services.background_jobs import get as get_job
 from services.print_catalog import record_print
-from services.report_cache import get as cache_get
-from services.report_cache import set as cache_set
+from services.report_cache import get_or_compute as cache_get_or_compute
 from services.reporting_backup import sqlite_backup_download_plan, submit_database_backup_job
 from services.reporting_export import (
     ExportArtifactError,
@@ -60,26 +59,15 @@ def _sqlite_schema_info(path: str) -> dict:
 
 def _cached_payload(key: str, builder):
     ttl = int(current_app.config.get('REPORT_CACHE_TTL_SECONDS', 60))
-    cached = cache_get(key)
-    if cached is not None:
-        return cached
-    payload = builder()
-    cache_set(key, payload, ttl)
-    return payload
+    return cache_get_or_compute(key, ttl, builder)
 
 
 def _serialize_bull_belle(rows: list) -> list:
     """Flatten get_bull_belle_with_tiebreak_data output into plain data.
 
-    This used to hand the cache the CollegeCompetitor rows themselves. The
-    cache has a disk layer, the disk layer pickles, and a mapped instance
-    comes back from a pickle detached from every session. Nothing complains
-    at write time and nothing complains at read time. It breaks later, in the
-    template, on the first attribute that was not already loaded when the
-    pickle was taken: ``c.team`` was never touched before ``cache_set`` ran,
-    so the standings page raised DetachedInstanceError and returned 500 on
-    every request from the moment a gunicorn worker respawned onto a warm
-    shelf until the entry aged out.
+    Report payloads must remain plain data. SQLite keeps them briefly in the
+    current process, while PostgreSQL intentionally rebuilds them because a
+    rolling deployment has no shared invalidation generation.
 
     The key names below match what the template already reads, so the flatten
     is invisible to it: Jinja resolves ``c.team.team_code`` against a dict by
@@ -106,7 +94,7 @@ def _serialize_bull_belle(rows: list) -> list:
 
 
 def _serialize_teams(teams: list) -> list:
-    """Flatten Team rows for the same reason as _serialize_bull_belle."""
+    """Flatten Team rows so the payload never retains mapped instances."""
     return [
         {
             'id': team.id,
@@ -138,6 +126,19 @@ def _serialize_competitors(competitors: list) -> list:
     ]
 
 
+def _build_college_standings_payload(tournament: Tournament) -> dict:
+    """Build a cache-safe standings payload from one attached tournament."""
+    return {
+        'bull': _serialize_competitors(tournament.get_bull_of_woods(10)),
+        'belle': _serialize_competitors(tournament.get_belle_of_woods(10)),
+        'bull_tiebreak': _serialize_bull_belle(
+            tournament.get_bull_belle_with_tiebreak_data('M', 10)),
+        'belle_tiebreak': _serialize_bull_belle(
+            tournament.get_bull_belle_with_tiebreak_data('F', 10)),
+        'team_standings': _serialize_teams(tournament.get_team_standings()),
+    }
+
+
 @reporting_bp.route('/<int:tournament_id>/college/standings')
 def college_standings(tournament_id):
     """View college standings (Bull/Belle of Woods and Team Standings).
@@ -152,15 +153,7 @@ def college_standings(tournament_id):
 
     payload = _cached_payload(
         f'reports:{tournament_id}:college_standings',
-        lambda: {
-            'bull': _serialize_competitors(tournament.get_bull_of_woods(10)),
-            'belle': _serialize_competitors(tournament.get_belle_of_woods(10)),
-            'bull_tiebreak': _serialize_bull_belle(
-                tournament.get_bull_belle_with_tiebreak_data('M', 10)),
-            'belle_tiebreak': _serialize_bull_belle(
-                tournament.get_bull_belle_with_tiebreak_data('F', 10)),
-            'team_standings': _serialize_teams(tournament.get_team_standings()),
-        }
+        lambda: _build_college_standings_payload(tournament),
     )
 
     # Events that are not finalized but have at least one completed result —

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,102 +1,314 @@
 #!/usr/bin/env python3
-"""Post-deploy smoke test.
+"""Read-only post-deploy smoke test for the public production surface.
 
-Hits key endpoints on the production URL and verifies they return expected
-status codes. Run after every Railway deploy to catch "deployed but broken."
-
-Usage:
-    python scripts/smoke_test.py                          # uses PRODUCTION_URL env var
-    python scripts/smoke_test.py https://example.up.railway.app
-
-Exit code 0 = all checks passed, 1 = one or more failed.
+The smoke proves application, database, migration, spectator HTML, and public
+API availability. It does not authenticate a judge or mutate tournament data.
 """
 from __future__ import annotations
 
+import argparse
 import json
+import os
+import re
+import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urljoin, urlsplit
+
+DEFAULT_PRODUCTION_URL = (
+    "https://missoula-pro-am-manager-production.up.railway.app"
+)
+_SPECTATOR_PATH_RE = re.compile(r"^/portal/spectator/(\d+)$")
 
 
-def check(base_url: str, path: str, expected_status: int = 200,
-          json_key: str | None = None, json_value=None) -> dict:
-    """Hit one endpoint and return a result dict."""
-    url = base_url.rstrip('/') + path
-    start = time.time()
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlsplit(url)
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port
+
+
+def same_origin(base_url: str, target_url: str) -> bool:
+    """Return whether a target, including a relative target, stays on origin."""
+    return _origin(base_url) == _origin(urljoin(base_url.rstrip("/") + "/", target_url))
+
+
+class SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject redirects before urllib can send a request to another origin."""
+
+    def __init__(self, base_url: str):
+        super().__init__()
+        self.base_url = base_url
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        resolved = urljoin(req.full_url, newurl)
+        if not same_origin(self.base_url, resolved):
+            raise urllib.error.HTTPError(
+                req.full_url,
+                code,
+                "cross-origin redirect refused",
+                headers,
+                fp,
+            )
+        return super().redirect_request(req, fp, code, msg, headers, resolved)
+
+
+def validate_health_payload(
+    payload,
+    *,
+    expected_version: str | None = None,
+    expected_migration: str | None = None,
+    expected_commit: str | None = None,
+) -> str | None:
+    if not isinstance(payload, dict):
+        return "health response JSON is not an object"
+    if payload.get("status") != "ok":
+        return "status is not ok"
+    if payload.get("db") is not True:
+        return "database is not healthy"
+    if payload.get("migration_current") is not True:
+        return "migration is not current"
+    migration_head = payload.get("migration_head")
+    migration_rev = payload.get("migration_rev")
+    if not isinstance(migration_head, str) or not migration_head:
+        return "migration head is missing"
+    if not isinstance(migration_rev, str) or not migration_rev:
+        return "migration revision is missing"
+    if migration_rev != migration_head:
+        return "migration revision does not match head"
+    if expected_version and payload.get("version") != expected_version:
+        return "version does not match expected release"
+    if expected_migration and migration_rev != expected_migration:
+        return "migration does not match expected revision"
+    if expected_commit and payload.get("git_commit") != expected_commit:
+        return "Git commit does not match expected deployment"
+    return None
+
+
+def extract_spectator_tournament_id(url: str) -> int | None:
+    match = _SPECTATOR_PATH_RE.fullmatch(urlsplit(url).path.rstrip("/"))
+    return int(match.group(1)) if match else None
+
+
+def validate_public_standings(
+    body: str,
+    content_type: str,
+    tournament_id: int,
+) -> str | None:
+    if "json" not in content_type.lower():
+        return "response is not JSON"
     try:
-        req = urllib.request.Request(url, headers={'User-Agent': 'ProAm-SmokeTest/1.0'})
-        resp = urllib.request.urlopen(req, timeout=15)
-        status = resp.status
-        body = resp.read().decode('utf-8', errors='replace')
-        elapsed = time.time() - start
-    except urllib.error.HTTPError as e:
-        status = e.code
-        body = ''
-        elapsed = time.time() - start
-    except Exception as exc:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return "response is not valid JSON"
+    if not isinstance(payload, dict):
+        return "response JSON is not an object"
+    if payload.get("error"):
+        return "response contains an error"
+    tournament = payload.get("tournament")
+    if not isinstance(tournament, dict) or tournament.get("id") != tournament_id:
+        return "response tournament does not match the active tournament"
+    for key in ("teams", "bull", "belle", "pro_earnings"):
+        if not isinstance(payload.get(key), list):
+            return f"response field {key} is missing or not a list"
+    return None
+
+
+def local_git_head() -> str | None:
+    """Return the checkout commit used as the default release-gate target."""
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_root, "rev-parse", "HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    commit = result.stdout.strip().lower()
+    return commit if re.fullmatch(r"[0-9a-f]{40}", commit) else None
+
+
+def fetch(opener, base_url: str, path: str) -> dict:
+    url = urljoin(base_url.rstrip("/") + "/", path.lstrip("/"))
+    started = time.monotonic()
+    try:
+        request = urllib.request.Request(
+            url,
+            headers={"User-Agent": "ProAm-PostDeploy-Smoke/2.0"},
+        )
+        with opener.open(request, timeout=15) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return {
+                "path": path,
+                "status": response.status,
+                "body": body,
+                "content_type": response.headers.get("Content-Type", ""),
+                "final_url": response.geturl(),
+                "elapsed_ms": int((time.monotonic() - started) * 1000),
+                "error": None,
+            }
+    except urllib.error.HTTPError as exc:
         return {
-            'path': path, 'ok': False, 'status': 0,
-            'error': str(exc), 'elapsed_ms': int((time.time() - start) * 1000),
+            "path": path,
+            "status": exc.code,
+            "body": "",
+            "content_type": "",
+            "final_url": exc.geturl(),
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "error": str(exc.reason),
+        }
+    except Exception as exc:  # pragma: no cover - network-specific error types
+        return {
+            "path": path,
+            "status": 0,
+            "body": "",
+            "content_type": "",
+            "final_url": url,
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "error": str(exc),
         }
 
-    ok = (status == expected_status)
 
-    # Optional JSON field check
-    if ok and json_key is not None:
+def _finish(result: dict, validation_error: str | None = None) -> dict:
+    result["validation_error"] = validation_error
+    result["ok"] = (
+        result["status"] == 200
+        and result["error"] is None
+        and validation_error is None
+    )
+    result.pop("body", None)
+    result.pop("content_type", None)
+    return result
+
+
+def run_smoke(
+    base_url: str,
+    *,
+    expected_version: str | None = None,
+    expected_migration: str | None = None,
+    expected_commit: str | None = None,
+) -> list[dict]:
+    opener = urllib.request.build_opener(SameOriginRedirectHandler(base_url))
+    results = []
+
+    health = fetch(opener, base_url, "/health")
+    health_error = health["error"]
+    if health["status"] == 200 and health_error is None:
         try:
-            data = json.loads(body)
-            if data.get(json_key) != json_value:
-                ok = False
-        except (json.JSONDecodeError, KeyError):
-            ok = False
+            payload = json.loads(health["body"])
+        except json.JSONDecodeError:
+            health_error = "health response is not valid JSON"
+        else:
+            health_error = validate_health_payload(
+                payload,
+                expected_version=expected_version,
+                expected_migration=expected_migration,
+                expected_commit=expected_commit,
+            )
+    results.append(_finish(health, health_error))
 
-    return {
-        'path': path, 'ok': ok, 'status': status,
-        'elapsed_ms': int(elapsed * 1000), 'error': None,
-    }
+    portal = fetch(opener, base_url, "/portal/")
+    tournament_id = extract_spectator_tournament_id(portal["final_url"])
+    portal_error = portal["error"]
+    if portal["status"] == 200 and portal_error is None:
+        if not same_origin(base_url, portal["final_url"]):
+            portal_error = "portal left the configured origin"
+        elif tournament_id is None:
+            portal_error = "portal did not resolve to an active spectator tournament"
+        elif not portal["body"].strip():
+            portal_error = "spectator page is empty"
+    results.append(_finish(portal, portal_error))
+
+    if tournament_id is not None:
+        api_path = f"/api/public/tournaments/{tournament_id}/standings"
+        standings = fetch(opener, base_url, api_path)
+        standings_error = standings["error"]
+        if standings["status"] == 200 and standings_error is None:
+            standings_error = validate_public_standings(
+                standings["body"], standings["content_type"], tournament_id
+            )
+        results.append(_finish(standings, standings_error))
+    else:
+        results.append({
+            "path": "/api/public/tournaments/<active>/standings",
+            "status": 0,
+            "final_url": "",
+            "elapsed_ms": 0,
+            "error": None,
+            "validation_error": "active tournament was not discovered",
+            "ok": False,
+        })
+
+    login = fetch(opener, base_url, "/auth/login")
+    login_error = login["error"]
+    if login["status"] == 200 and login_error is None:
+        body = login["body"]
+        if 'name="username"' not in body or 'name="password"' not in body:
+            login_error = "login page does not contain the sign-in form"
+    results.append(_finish(login, login_error))
+    return results
 
 
-def main():
-    import os
-    base_url = (
-        sys.argv[1] if len(sys.argv) > 1
-        else os.environ.get('PRODUCTION_URL', 'https://missoula-pro-am-manager-production.up.railway.app')
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "base_url",
+        nargs="?",
+        default=os.environ.get("PRODUCTION_URL", DEFAULT_PRODUCTION_URL),
+    )
+    parser.add_argument(
+        "--expected-version",
+        default=os.environ.get("EXPECTED_PRODUCTION_VERSION"),
+    )
+    parser.add_argument(
+        "--expected-migration",
+        default=os.environ.get("EXPECTED_MIGRATION_HEAD"),
+    )
+    parser.add_argument(
+        "--expected-commit",
+        default=os.environ.get("EXPECTED_GIT_COMMIT") or local_git_head(),
+        help="Exact 40-character Git SHA expected from the deployment.",
+    )
+    parser.add_argument(
+        "--allow-unpinned",
+        action="store_true",
+        help="Run an exploratory smoke without binding it to a Git commit.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    if not args.allow_unpinned and not args.expected_commit:
+        parser.error(
+            "release smoke requires --expected-commit (or EXPECTED_GIT_COMMIT); "
+            "use --allow-unpinned only for an exploratory health check"
+        )
+    results = run_smoke(
+        args.base_url,
+        expected_version=args.expected_version,
+        expected_migration=args.expected_migration,
+        expected_commit=None if args.allow_unpinned else args.expected_commit,
     )
 
-    print(f'Smoke testing: {base_url}')
-    print('=' * 60)
-
-    checks = [
-        {'path': '/health'},  # 200 = app is running (db/migration status checked separately)
-        {'path': '/'},
-        {'path': '/portal/'},
-    ]
-
-    results = []
-    for c in checks:
-        result = check(base_url, **c)
-        results.append(result)
-        icon = 'PASS' if result['ok'] else 'FAIL'
-        status_str = f"HTTP {result['status']}" if result['status'] else result['error']
-        print(f"  [{icon}] {result['path']:40s} {status_str:10s} ({result['elapsed_ms']}ms)")
-
-    print('=' * 60)
-    passed = sum(1 for r in results if r['ok'])
-    total = len(results)
-    print(f'Result: {passed}/{total} checks passed')
-
-    if passed < total:
-        print('\nFAILED CHECKS:')
-        for r in results:
-            if not r['ok']:
-                status_msg = r.get('error') or f"HTTP {r['status']}"
-                print(f"  - {r['path']}: {status_msg}")
-        sys.exit(1)
-    else:
-        print('All smoke tests passed.')
-        sys.exit(0)
+    print(f"Smoke testing: {args.base_url}")
+    print("=" * 72)
+    for result in results:
+        marker = "PASS" if result["ok"] else "FAIL"
+        detail = result["error"] or result["validation_error"] or ""
+        print(
+            f"  [{marker}] {result['path']:<48} "
+            f"HTTP {result['status']:<3} {result['elapsed_ms']:>5}ms {detail}"
+        )
+    passed = sum(result["ok"] for result in results)
+    print("=" * 72)
+    print(f"Result: {passed}/{len(results)} checks passed")
+    return 0 if passed == len(results) else 1
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/heat_generator.py
+++ b/services/heat_generator.py
@@ -780,7 +780,11 @@ def _get_event_competitors(event: Event) -> list:
         excluded = [
             c for c in all_comps
             if c.gender != event.gender
-            and _competitor_entered_event(event, c.get_events_entered())
+            and _competitor_entered_event(
+                event,
+                c.get_events_entered(),
+                competitor_gender=c.gender,
+            )
         ]
         if excluded:
             _last_gender_excluded[event.id] = [
@@ -800,7 +804,11 @@ def _get_event_competitors(event: Event) -> list:
         all_comps = [c for c in all_comps if c.gender == event.gender]
 
     for comp in all_comps:
-        if not _competitor_entered_event(event, comp.get_events_entered()):
+        if not _competitor_entered_event(
+            event,
+            comp.get_events_entered(),
+            competitor_gender=comp.gender,
+        ):
             continue
         if comp.id in seen_ids:
             continue
@@ -1381,12 +1389,37 @@ def _normalize_name(value: str) -> str:
     return ''.join(ch for ch in str(value or '').lower() if ch.isalnum())
 
 
-def _competitor_entered_event(event: Event, entered_events: list) -> bool:
+def _college_event_name_is_gender_ambiguous(event: Event) -> bool:
+    """Return whether this neutral college name has both M and F event rows."""
+    if event.event_type != 'college' or event.gender not in {'M', 'F'}:
+        return False
+
+    target_name = _normalize_name(event.name)
+    matching_genders = {
+        candidate.gender
+        for candidate in _get_tournament_events(event)
+        if candidate.event_type == 'college'
+        and _normalize_name(candidate.name) == target_name
+    }
+    return {'M', 'F'}.issubset(matching_genders)
+
+
+def _competitor_entered_event(
+    event: Event,
+    entered_events: list,
+    *,
+    competitor_gender: str | None = None,
+) -> bool:
+    """Resolve IDs, qualified names, and legacy neutral college names."""
     entered = entered_events if isinstance(entered_events, list) else []
     target_id = str(event.id)
     target_name = _normalize_name(event.name)
     target_display_name = _normalize_name(event.display_name)
     aliases = {target_name, target_display_name}
+    use_competitor_gender = (
+        competitor_gender in {'M', 'F'}
+        and _college_event_name_is_gender_ambiguous(event)
+    )
 
     if event.event_type == 'pro':
         if target_name == 'springboard':
@@ -1407,6 +1440,12 @@ def _competitor_entered_event(event: Event, entered_events: list) -> bool:
         if value == target_id:
             return True
         normalized = _normalize_name(value)
+        if normalized == target_display_name and target_display_name != target_name:
+            return True
+        if normalized == target_name:
+            if use_competitor_gender:
+                return event.gender == competitor_gender
+            return True
         if normalized in aliases:
             return True
     return False

--- a/services/scratch_cascade.py
+++ b/services/scratch_cascade.py
@@ -100,7 +100,239 @@ def _stable_number(raw_value):
         return str(raw_value)
 
 
-def _scratch_post_state_sha256(competitor, snapshot: dict) -> str:
+def _scratch_relay_post_state(
+    competitor,
+    snapshot: dict,
+    prefetched: dict | None = None,
+) -> list:
+    """Fingerprint relay draws while ignoring this competitor's reassignment."""
+    from database import db
+    from models.competitor import CollegeCompetitor
+    from models.event import Event
+    from models.relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
+
+    relay_snapshots = [
+        entry
+        for entry in snapshot.get("relay_teams", [])
+        if isinstance(entry, dict)
+    ]
+    state_ids = sorted({
+        int(entry["relay_state_id"])
+        for entry in relay_snapshots
+        if entry.get("source") == "normalized"
+        and entry.get("relay_state_id") is not None
+    })
+    relay_state = []
+    for state_id in state_ids:
+        state = (
+            db.session.get(RelayState, state_id)
+            if prefetched is None
+            else prefetched["relay_states"].get(state_id)
+        )
+        if state is None:
+            relay_state.append({"relay_state_id": state_id, "state": None})
+            continue
+
+        if prefetched is None:
+            teams = (
+                RelayTeam.query.filter_by(relay_state_id=state_id)
+                .order_by(RelayTeam.team_number, RelayTeam.id)
+                .all()
+            )
+        else:
+            teams = prefetched["relay_teams_by_state"].get(state_id, [])
+        team_ids = [team.id for team in teams]
+        members_by_team = {team_id: [] for team_id in team_ids}
+        events_by_team = {team_id: [] for team_id in team_ids}
+        if team_ids:
+            if prefetched is None:
+                members = (
+                    RelayTeamMember.query.filter(
+                        RelayTeamMember.relay_team_id.in_(team_ids),
+                        RelayTeamMember.uid != competitor.uid,
+                    )
+                    .order_by(RelayTeamMember.relay_team_id, RelayTeamMember.uid)
+                    .all()
+                )
+            else:
+                members = [
+                    member
+                    for team_id in team_ids
+                    for member in prefetched["relay_members_by_team"].get(
+                        team_id, []
+                    )
+                    if member.uid != competitor.uid
+                ]
+            for member in members:
+                members_by_team[member.relay_team_id].append(member.uid)
+
+            if prefetched is None:
+                team_events = (
+                    RelayTeamEvent.query.filter(
+                        RelayTeamEvent.relay_team_id.in_(team_ids),
+                    )
+                    .order_by(RelayTeamEvent.relay_team_id, RelayTeamEvent.event_key)
+                    .all()
+                )
+            else:
+                team_events = [
+                    team_event
+                    for team_id in team_ids
+                    for team_event in prefetched["relay_events_by_team"].get(
+                        team_id, []
+                    )
+                ]
+            for team_event in team_events:
+                events_by_team[team_event.relay_team_id].append({
+                    "event_key": team_event.event_key,
+                    "result": _stable_number(team_event.result),
+                    "status": team_event.status,
+                })
+
+        relay_state.append({
+            "relay_state_id": state.id,
+            "event_id": state.event_id,
+            "status": state.status,
+            "teams": [
+                {
+                    "id": team.id,
+                    "team_number": team.team_number,
+                    "name": team.name,
+                    "total_time": _stable_number(team.total_time),
+                    "payout_settled": team.payout_settled,
+                    "version_id": team.version_id,
+                    "member_uids": members_by_team[team.id],
+                    "events": events_by_team[team.id],
+                }
+                for team in teams
+            ],
+        })
+
+    legacy_member_key = (
+        "college_members"
+        if isinstance(competitor, CollegeCompetitor)
+        else "pro_members"
+    )
+    legacy_event_ids = sorted({
+        int(entry["relay_event_id"])
+        for entry in relay_snapshots
+        if entry.get("source") == "legacy"
+        and entry.get("relay_event_id") is not None
+    })
+    for event_id in legacy_event_ids:
+        relay_event = (
+            db.session.get(Event, event_id)
+            if prefetched is None
+            else prefetched["legacy_events"].get(event_id)
+        )
+        try:
+            state = json.loads(relay_event.event_state or "{}")
+        except (AttributeError, json.JSONDecodeError, TypeError):
+            state = None
+        if isinstance(state, dict):
+            for team in state.get("teams", []):
+                if not isinstance(team, dict):
+                    continue
+                team[legacy_member_key] = [
+                    member
+                    for member in team.get(legacy_member_key, [])
+                    if not isinstance(member, dict)
+                    or member.get("id") != competitor.id
+                ]
+        relay_state.append({
+            "relay_event_id": event_id,
+            "legacy_state": state,
+        })
+
+    return relay_state
+
+
+def _prefetch_scratch_post_state(snapshots: list[dict]) -> dict:
+    """Load every row needed by a roster's scratch fingerprints in batches."""
+    from models.event import Event, EventResult
+    from models.heat import Heat
+    from models.relay import RelayState, RelayTeam, RelayTeamEvent, RelayTeamMember
+
+    def entries_for(key):
+        output = []
+        for snapshot in snapshots:
+            entries = snapshot.get(key, [])
+            if isinstance(entries, list):
+                output.extend(entry for entry in entries if isinstance(entry, dict))
+        return output
+
+    result_entries = entries_for("results")
+    heat_entries = entries_for("heats")
+    relay_entries = entries_for("relay_teams")
+    result_ids = {
+        entry.get("id") for entry in result_entries if entry.get("id") is not None
+    }
+    heat_ids = {
+        entry.get("heat_id")
+        for entry in heat_entries
+        if entry.get("heat_id") is not None
+    }
+    relay_state_ids = {
+        entry.get("relay_state_id")
+        for entry in relay_entries
+        if entry.get("source") == "normalized"
+        and entry.get("relay_state_id") is not None
+    }
+    legacy_event_ids = {
+        entry.get("relay_event_id")
+        for entry in relay_entries
+        if entry.get("source") == "legacy"
+        and entry.get("relay_event_id") is not None
+    }
+
+    def by_id(model, ids):
+        if not ids:
+            return {}
+        return {row.id: row for row in model.query.filter(model.id.in_(ids)).all()}
+
+    relay_states = by_id(RelayState, relay_state_ids)
+    relay_teams = (
+        RelayTeam.query.filter(RelayTeam.relay_state_id.in_(relay_state_ids))
+        .order_by(RelayTeam.relay_state_id, RelayTeam.team_number, RelayTeam.id)
+        .all()
+        if relay_state_ids else []
+    )
+    team_ids = {team.id for team in relay_teams}
+    relay_members = (
+        RelayTeamMember.query.filter(RelayTeamMember.relay_team_id.in_(team_ids))
+        .order_by(RelayTeamMember.relay_team_id, RelayTeamMember.uid)
+        .all()
+        if team_ids else []
+    )
+    relay_events = (
+        RelayTeamEvent.query.filter(RelayTeamEvent.relay_team_id.in_(team_ids))
+        .order_by(RelayTeamEvent.relay_team_id, RelayTeamEvent.event_key)
+        .all()
+        if team_ids else []
+    )
+
+    def grouped(rows, key):
+        output = {}
+        for row in rows:
+            output.setdefault(getattr(row, key), []).append(row)
+        return output
+
+    return {
+        "results": by_id(EventResult, result_ids),
+        "heats": by_id(Heat, heat_ids),
+        "relay_states": relay_states,
+        "relay_teams_by_state": grouped(relay_teams, "relay_state_id"),
+        "relay_members_by_team": grouped(relay_members, "relay_team_id"),
+        "relay_events_by_team": grouped(relay_events, "relay_team_id"),
+        "legacy_events": by_id(Event, legacy_event_ids),
+    }
+
+
+def _scratch_post_state_sha256(
+    competitor,
+    snapshot: dict,
+    prefetched: dict | None = None,
+) -> str:
     """Fingerprint state that reverse_cascade would otherwise overwrite."""
     from database import db
     from models.competitor import CollegeCompetitor
@@ -111,7 +343,12 @@ def _scratch_post_state_sha256(competitor, snapshot: dict) -> str:
     for result_snapshot in sorted(
         snapshot.get("results", []), key=lambda item: item.get("id") or 0,
     ):
-        result = db.session.get(EventResult, result_snapshot.get("id"))
+        result_id = result_snapshot.get("id")
+        result = (
+            db.session.get(EventResult, result_id)
+            if prefetched is None
+            else prefetched["results"].get(result_id)
+        )
         if result is None:
             result_state.append(None)
             continue
@@ -140,16 +377,21 @@ def _scratch_post_state_sha256(competitor, snapshot: dict) -> str:
     for heat_snapshot in sorted(
         snapshot.get("heats", []), key=lambda item: item.get("heat_id") or 0,
     ):
-        heat = db.session.get(Heat, heat_snapshot.get("heat_id"))
+        heat_id = heat_snapshot.get("heat_id")
+        heat = (
+            db.session.get(Heat, heat_id)
+            if prefetched is None
+            else prefetched["heats"].get(heat_id)
+        )
         if heat is None:
             heat_state.append(None)
             continue
         heat_state.append({
             "id": heat.id,
-            "version_id": heat.version_id,
-            "status": heat.status,
             "competitors": heat.get_competitors(),
             "stand_assignments": heat.get_stand_assignments(),
+            "version_id": heat.version_id,
+            "status": heat.status,
         })
 
     payload = {
@@ -168,6 +410,7 @@ def _scratch_post_state_sha256(competitor, snapshot: dict) -> str:
         },
         "results": result_state,
         "heats": heat_state,
+        "relay": _scratch_relay_post_state(competitor, snapshot, prefetched),
     }
     encoded = json.dumps(
         payload,
@@ -795,19 +1038,28 @@ def execute_cascade(competitor, effects, judge_user_id, tournament) -> dict:
                         continue
                     relay = ProAmRelay(tournament)
                     # Remove the competitor from all member lists in all teams.
+                    member_key = (
+                        "college_members"
+                        if isinstance(competitor, CollegeCompetitor)
+                        else "pro_members"
+                    )
                     teams = relay.relay_data.get("teams", [])
                     for team in teams:
-                        for list_key in ("pro_members", "college_members"):
-                            team[list_key] = [
-                                m for m in team.get(list_key, [])
-                                if m.get("id") != competitor.id
-                            ]
+                        team[member_key] = [
+                            member
+                            for member in team.get(member_key, [])
+                            if member.get("id") != competitor.id
+                        ]
                     snapshot["relay_teams"].append({
                         "source": "legacy",
                         "relay_event_id": relay_event_id,
                         "team_number": effect.metadata.get("team_number"),
                     })
-                    relay._save_relay_data(commit=False)
+                    # Preserve the store named by the effect and undo snapshot.
+                    # Projecting a complete legacy document here would clear
+                    # event_state and move the remaining roster into normalized
+                    # rows, leaving legacy undo unable to restore this member.
+                    relay_event.event_state = json.dumps(relay.relay_data)
                     effects_applied += 1
 
             elif effect.effect_type == "standings":
@@ -1043,12 +1295,55 @@ def find_undoable_scratch(competitor_id: int, competitor_type: str | None = None
     return scratch_entry
 
 
-def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) -> set:
-    """The subset of competitor_ids whose scratch is still inside the window.
+def _scratch_entry_matches_current_state(
+    audit_entry,
+    competitor=None,
+    prefetched: dict | None = None,
+) -> bool:
+    """Return whether an audit still describes a safely reversible scratch."""
+    from database import db
+    from models.competitor import CollegeCompetitor, ProCompetitor
 
-    Read-only, one query for a whole page.  The rosters need this for every
-    scratched competitor in the table, and calling find_undoable_scratch per
-    row would put a query per competitor on the busiest screen of race day.
+    details = _scratch_audit_details(audit_entry)
+    snapshot = details.get("scratch_snapshot")
+    expected_state = details.get("scratch_post_state_sha256")
+    if not isinstance(snapshot, dict) or not isinstance(expected_state, str):
+        return False
+
+    if competitor is None:
+        comp_type = snapshot.get("competitor_type")
+        model = (
+            CollegeCompetitor
+            if comp_type == "college"
+            else ProCompetitor if comp_type == "pro" else None
+        )
+        if model is None:
+            return False
+        competitor = db.session.get(model, audit_entry.entity_id)
+    if competitor is None:
+        return False
+
+    try:
+        current_state = _scratch_post_state_sha256(
+            competitor,
+            snapshot,
+            prefetched,
+        )
+    except (AttributeError, KeyError, TypeError, ValueError):
+        return False
+    return hmac.compare_digest(expected_state, current_state)
+
+
+def find_undoable_scratch_tokens(
+    competitor_ids,
+    competitor_type: str | None = None,
+) -> dict[int, str]:
+    """Return current undo tokens keyed by competitor id.
+
+    Read-only, with a fixed number of batched queries for a whole page.  The
+    rosters need this for every scratched competitor in the table, and calling
+    find_undoable_scratch per row would put queries per competitor on the
+    busiest screen of race day.
 
     Same cutoff and same snapshot-type filter as find_undoable_scratch, so an
     Undo button on a roster and the one on the confirmation page cannot
@@ -1058,7 +1353,7 @@ def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) 
 
     ids = [int(c) for c in competitor_ids]
     if not ids:
-        return set()
+        return {}
 
     cutoff = utc_now_naive() - timedelta(minutes=SCRATCH_UNDO_WINDOW_MINUTES)
     scratch_entries = (
@@ -1088,11 +1383,60 @@ def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) 
             AuditLog.entity_id.in_(ids),
         ).all()
     )
-    return {
-        competitor_id
-        for competitor_id, entry in latest_by_competitor.items()
-        if entry.id not in consumed and scratch_undo_token(entry) is not None
+
+    from models.competitor import CollegeCompetitor, ProCompetitor
+
+    ids_by_type = {"college": set(), "pro": set()}
+    for competitor_id, entry in latest_by_competitor.items():
+        comp_type = _snapshot_competitor_type(entry)
+        if comp_type in ids_by_type:
+            ids_by_type[comp_type].add(competitor_id)
+    competitors = {
+        ("college", competitor.id): competitor
+        for competitor in CollegeCompetitor.query.filter(
+            CollegeCompetitor.id.in_(ids_by_type["college"])
+        ).all()
     }
+    competitors.update({
+        ("pro", competitor.id): competitor
+        for competitor in ProCompetitor.query.filter(
+            ProCompetitor.id.in_(ids_by_type["pro"])
+        ).all()
+    })
+
+    candidate_snapshots = [
+        details["scratch_snapshot"]
+        for entry in latest_by_competitor.values()
+        if entry.id not in consumed
+        and (details := _scratch_audit_details(entry))
+        and isinstance(details.get("scratch_snapshot"), dict)
+    ]
+    prefetched = _prefetch_scratch_post_state(candidate_snapshots)
+
+    tokens = {}
+    for competitor_id, entry in latest_by_competitor.items():
+        if entry.id in consumed:
+            continue
+        token = scratch_undo_token(entry)
+        competitor = competitors.get((
+            _snapshot_competitor_type(entry),
+            competitor_id,
+        ))
+        if (
+            token is not None
+            and _scratch_entry_matches_current_state(
+                entry,
+                competitor,
+                prefetched,
+            )
+        ):
+            tokens[competitor_id] = token
+    return tokens
+
+
+def find_undoable_scratches(competitor_ids, competitor_type: str | None = None) -> set:
+    """The compatible id-set view of ``find_undoable_scratch_tokens``."""
+    return set(find_undoable_scratch_tokens(competitor_ids, competitor_type))
 
 
 def reverse_cascade(
@@ -1249,9 +1593,9 @@ def reverse_cascade(
 
     expected_post_state = details.get("scratch_post_state_sha256")
     current_post_state = _scratch_post_state_sha256(comp, snapshot)
-    if (
-        not isinstance(expected_post_state, str)
-        or not hmac.compare_digest(expected_post_state, current_post_state)
+    if not (
+        isinstance(expected_post_state, str)
+        and hmac.compare_digest(expected_post_state, current_post_state)
     ):
         return {
             "success": False,

--- a/templates/college/team_detail.html
+++ b/templates/college/team_detail.html
@@ -199,6 +199,7 @@
                                 {% for member in members %}
                                 {% set ev_details = member_event_details.get(member.id, []) %}
                                 {% set already_entered_keys = ev_details | map(attribute='key') | list %}
+                                {% set undo_token = (undo_tokens_by_competitor_id|default({}, true)).get(member.id) %}
 
                                 <!-- Member row -->
                                 <tr class="{{ 'table-secondary' if member.status == 'scratched' else '' }}">
@@ -243,7 +244,7 @@
                                                 <i class="bi bi-slash-circle"></i> Scratch
                                             </button>
                                         </form>
-                                        {% elif member.id in undoable_scratch_ids|default([], true) %}
+                                        {% elif undo_token and current_user.is_authenticated and current_user.can_score %}
                                         {# The scratch is still inside the undo window. See the
                                            matching block in pro/dashboard.html: without it the
                                            window is unreachable, because the confirm redirect
@@ -256,6 +257,7 @@
                                               data-confirm="Undo the scratch for {{ member.name }}?">
                                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                             <input type="hidden" name="competitor_type" value="college">
+                                            <input type="hidden" name="expected_undo_token" value="{{ undo_token }}">
                                             <button type="submit" class="btn btn-sm btn-outline-secondary">
                                                 <i class="bi bi-arrow-counterclockwise"></i> Undo
                                             </button>

--- a/templates/pro/dashboard.html
+++ b/templates/pro/dashboard.html
@@ -153,6 +153,7 @@
                     </thead>
                     <tbody>
                         {% for c in competitors %}
+                        {% set undo_token = (undo_tokens_by_competitor_id|default({}, true)).get(c.id) %}
                         <tr class="{{ 'table-secondary' if c.status == 'scratched' else '' }}">
                             <td><strong>{{ c.name }}</strong></td>
                             <td>{{ c.gender }}</td>
@@ -186,7 +187,7 @@
                                             <i class="bi bi-x-lg"></i>
                                         </button>
                                     </form>
-                                    {% elif c.id in undoable_scratch_ids|default([], true) %}
+                                    {% elif undo_token %}
                                     {# The scratch is still inside the undo window. Before this
                                        the window was unreachable: the confirm redirect lands
                                        here and the only Undo control in the product sat on the
@@ -198,6 +199,7 @@
                                           method="POST" style="display:inline;" data-confirm="Undo the scratch for {{ c.name }}?">
                                         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <input type="hidden" name="competitor_type" value="pro">
+                                        <input type="hidden" name="expected_undo_token" value="{{ undo_token }}">
                                         <button type="submit" class="btn btn-outline-secondary"
                                                 aria-label="Undo scratch for {{ c.name }}" title="Undo scratch">
                                             <i class="bi bi-arrow-counterclockwise"></i>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,22 +56,24 @@ def pytest_configure(config):
     config._prod_db_before = _prod_db_fingerprint()
 
 
-def pytest_unconfigure(config):
-    """Verify production DB was not modified by the test session."""
-    before = getattr(config, '_prod_db_before', None)
+def pytest_sessionfinish(session, exitstatus):
+    """Fail the run if collection or execution touched the default database."""
+    before = getattr(session.config, '_prod_db_before', None)
     if before is None:
         return
     after = _prod_db_fingerprint()
     if before != after:
-        import warnings
-        warnings.warn(
-            f'\n\n*** PRODUCTION DATABASE MODIFIED BY TESTS ***\n'
+        message = (
+            f'*** PRODUCTION DATABASE MODIFIED BY TESTS ***\n'
             f'Before: exists={before[0]}, size={before[1]}, mtime={before[2]}\n'
             f'After:  exists={after[0]}, size={after[1]}, mtime={after[2]}\n'
             f'Path: {_PROD_DB_PATH}\n'
-            f'This should NEVER happen. Investigate immediately.\n',
-            stacklevel=1,
+            f'This should NEVER happen. Investigate immediately.'
         )
+        reporter = session.config.pluginmanager.get_plugin('terminalreporter')
+        if reporter is not None:
+            reporter.write_sep('=', message, red=True)
+        session.exitstatus = pytest.ExitCode.TESTS_FAILED
 
 
 @pytest.fixture(autouse=True, scope='session')

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -218,3 +218,12 @@ class TestHealthEndpoint:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data['status'] == 'ok'
+
+    def test_health_reports_the_railway_git_commit(self, client, monkeypatch):
+        commit = 'a' * 40
+        monkeypatch.setenv('RAILWAY_GIT_COMMIT_SHA', commit)
+
+        resp = client.get('/health')
+
+        assert resp.status_code == 200
+        assert resp.get_json()['git_commit'] == commit

--- a/tests/test_csrf_error_handler.py
+++ b/tests/test_csrf_error_handler.py
@@ -9,23 +9,28 @@ redirect on HTML routes so the user gets a clear, actionable message.
 Found during /investigate on 2026-04-21.
 """
 
-import os
-
 import pytest
+
+from tests.db_test_utils import create_test_app, drop_test_db
 
 
 @pytest.fixture
-def csrf_app():
+def csrf_app(monkeypatch):
     """App with CSRF protection actually enabled (global conftest disables it)."""
-    os.environ.pop("WTF_CSRF_ENABLED", None)
-    from app import create_app
-
-    app = create_app()
+    monkeypatch.delenv("WTF_CSRF_ENABLED", raising=False)
+    app, db_handle = create_test_app()
     app.config["WTF_CSRF_ENABLED"] = True
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = True
     app.config["TESTING"] = True
-    # Re-disable globally so other tests continue to run with CSRF off
-    os.environ["WTF_CSRF_ENABLED"] = "False"
-    yield app
+    try:
+        yield app
+    finally:
+        from database import db
+
+        with app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+        drop_test_db(db_handle)
 
 
 def test_csrf_error_on_html_route_redirects_with_flash(csrf_app):

--- a/tests/test_heat_generator.py
+++ b/tests/test_heat_generator.py
@@ -172,6 +172,102 @@ class TestCompetitorEnteredEvent:
         ev = _event(id=5, name='Underhand', event_type='college')
         assert _competitor_entered_event(ev, ['UNDERHAND']) is True
 
+    def test_legacy_name_selects_same_gender_event_when_names_collide(self, monkeypatch):
+        from services import heat_generator
+
+        men = _event(
+            id=20,
+            name='Underhand Speed',
+            display_name="Men's Underhand Speed",
+            event_type='college',
+            gender='M',
+        )
+        women = _event(
+            id=21,
+            name='Underhand Speed',
+            display_name="Women's Underhand Speed",
+            event_type='college',
+            gender='F',
+        )
+        monkeypatch.setattr(
+            heat_generator,
+            '_get_tournament_events',
+            lambda event: [men, women],
+        )
+
+        assert _competitor_entered_event(
+            men, ['Underhand Speed'], competitor_gender='M'
+        ) is True
+        assert _competitor_entered_event(
+            women, ['Underhand Speed'], competitor_gender='M'
+        ) is False
+        assert _competitor_entered_event(
+            women, ['Underhand Speed'], competitor_gender='F'
+        ) is True
+        assert _competitor_entered_event(
+            men, ['Underhand Speed'], competitor_gender='F'
+        ) is False
+
+    def test_explicit_wrong_gender_id_still_identifies_event(self, monkeypatch):
+        from services import heat_generator
+
+        men = _event(
+            id=20,
+            name='Underhand Speed',
+            display_name="Men's Underhand Speed",
+            event_type='college',
+            gender='M',
+        )
+        women = _event(
+            id=21,
+            name='Underhand Speed',
+            display_name="Women's Underhand Speed",
+            event_type='college',
+            gender='F',
+        )
+        monkeypatch.setattr(
+            heat_generator,
+            '_get_tournament_events',
+            lambda event: [men, women],
+        )
+
+        assert _competitor_entered_event(
+            men, [men.id], competitor_gender='F'
+        ) is True
+        assert _competitor_entered_event(
+            women, [men.id], competitor_gender='F'
+        ) is False
+
+    def test_gender_qualified_wrong_gender_name_still_identifies_event(self, monkeypatch):
+        from services import heat_generator
+
+        men = _event(
+            id=20,
+            name='Underhand Speed',
+            display_name="Men's Underhand Speed",
+            event_type='college',
+            gender='M',
+        )
+        women = _event(
+            id=21,
+            name='Underhand Speed',
+            display_name="Women's Underhand Speed",
+            event_type='college',
+            gender='F',
+        )
+        monkeypatch.setattr(
+            heat_generator,
+            '_get_tournament_events',
+            lambda event: [men, women],
+        )
+
+        assert _competitor_entered_event(
+            men, ["Men's Underhand Speed"], competitor_gender='F'
+        ) is True
+        assert _competitor_entered_event(
+            women, ["Men's Underhand Speed"], competitor_gender='F'
+        ) is False
+
 
 # ---------------------------------------------------------------------------
 # _is_list_only_event

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -280,6 +280,31 @@ class TestReportCache:
             report_cache.set('reports:9:standings', 'stale', ttl_seconds=60)
             assert report_cache.get('reports:9:standings') is None
 
+    def test_postgres_get_or_compute_always_rebuilds(self, app, monkeypatch):
+        from services import report_cache
+
+        monkeypatch.setitem(
+            app.config,
+            'SQLALCHEMY_DATABASE_URI',
+            'postgresql://synthetic/not-connected',
+        )
+        built = []
+
+        def builder():
+            built.append(len(built) + 1)
+            return {'build': built[-1]}
+
+        with app.app_context():
+            assert report_cache.get_or_compute('reports:9:standings', 60, builder) == {
+                'build': 1,
+            }
+            assert report_cache.get_or_compute('reports:9:standings', 60, builder) == {
+                'build': 2,
+            }
+            assert report_cache.get('reports:9:standings') is None
+            with report_cache._lock:
+                assert report_cache._cache == {}
+
     def test_multiple_keys_independent(self):
         from services.report_cache import get, set
         set('key:alpha', 'AAA', ttl_seconds=60)
@@ -306,6 +331,36 @@ class TestReportCache:
             # At 0.5s it should still be alive (ttl = 1)
             mock_time.time.return_value = base_time + 0.5
             assert report_cache.get('test:min_ttl') == 'val'
+
+
+def test_collection_time_default_database_change_fails_the_session(monkeypatch):
+    from types import SimpleNamespace
+
+    from tests import conftest as suite_config
+
+    fingerprints = iter([(False, 0, 0), (True, 0, 1)])
+    monkeypatch.setattr(
+        suite_config,
+        '_prod_db_fingerprint',
+        lambda: next(fingerprints),
+    )
+    messages = []
+    reporter = SimpleNamespace(
+        write_sep=lambda *args, **kwargs: messages.append((args, kwargs)),
+    )
+    config = SimpleNamespace(
+        _prod_db_before=suite_config._prod_db_fingerprint(),
+        pluginmanager=SimpleNamespace(
+            get_plugin=lambda name: reporter if name == 'terminalreporter' else None,
+        ),
+    )
+    session = SimpleNamespace(config=config, exitstatus=pytest.ExitCode.OK)
+
+    suite_config.pytest_sessionfinish(session, pytest.ExitCode.OK)
+
+    assert session.exitstatus == pytest.ExitCode.TESTS_FAILED
+    assert messages
+    assert 'PRODUCTION DATABASE MODIFIED' in messages[0][0][1]
 
 
 # ===================================================================

--- a/tests/test_roster_scratch_undo_tokens.py
+++ b/tests/test_roster_scratch_undo_tokens.py
@@ -1,0 +1,464 @@
+"""Regression coverage for scratch undo tokens on visible roster pages."""
+
+from __future__ import annotations
+
+import json
+from html.parser import HTMLParser
+
+from sqlalchemy import event as sqlalchemy_event
+
+from database import db
+from tests.conftest import (
+    make_college_competitor,
+    make_event,
+    make_event_result,
+    make_heat,
+    make_pro_competitor,
+    make_team,
+    make_tournament,
+)
+
+
+class _FormParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.forms = []
+        self._current = None
+
+    def handle_starttag(self, tag, attrs):
+        attributes = dict(attrs)
+        if tag == "form":
+            self._current = {
+                "action": attributes.get("action", ""),
+                "inputs": {},
+            }
+        elif tag == "input" and self._current is not None:
+            name = attributes.get("name")
+            if name:
+                self._current["inputs"][name] = attributes.get("value", "")
+
+    def handle_endtag(self, tag):
+        if tag == "form" and self._current is not None:
+            self.forms.append(self._current)
+            self._current = None
+
+
+def _undo_forms(response, competitor_id):
+    parser = _FormParser()
+    parser.feed(response.get_data(as_text=True))
+    path_suffix = f"/competitor/{competitor_id}/scratch-undo"
+    return [form for form in parser.forms if form["action"].endswith(path_suffix)]
+
+
+def _undo_form_token(response, competitor_id):
+    form = next(iter(_undo_forms(response, competitor_id)))
+    return form["inputs"].get("expected_undo_token")
+
+
+def _seed_scratch_audit(
+    session,
+    competitor,
+    competitor_type,
+    *,
+    snapshot=None,
+):
+    from models.audit_log import AuditLog
+    from services.scratch_cascade import _scratch_post_state_sha256
+
+    if snapshot is None:
+        snapshot = {
+            "competitor_type": competitor_type,
+            "results": [],
+            "heats": [],
+            "relay_teams": [],
+        }
+
+    entry = AuditLog(
+        action="competitor_scratched",
+        entity_type="competitor",
+        entity_id=competitor.id,
+        details_json=json.dumps({
+            "scratch_snapshot": snapshot,
+            "scratch_post_state_sha256": _scratch_post_state_sha256(
+                competitor,
+                snapshot,
+            ),
+        }),
+    )
+    session.add(entry)
+    session.flush()
+    return entry
+
+
+def test_empty_undo_token_batch_preserves_mapping_contract(db_session):
+    from services.scratch_cascade import (
+        find_undoable_scratch_tokens,
+        find_undoable_scratches,
+    )
+
+    assert find_undoable_scratch_tokens([], "pro") == {}
+    assert find_undoable_scratches([], "pro") == set()
+
+
+def test_malformed_snapshot_lists_hide_the_undo_control(db_session):
+    from models.audit_log import AuditLog
+    from services.scratch_cascade import find_undoable_scratch_tokens
+
+    tournament = make_tournament(db_session, status="active")
+    competitor = make_pro_competitor(
+        db_session,
+        tournament,
+        "Malformed Scratch Audit",
+        status="scratched",
+    )
+    db_session.add(AuditLog(
+        action="competitor_scratched",
+        entity_type="competitor",
+        entity_id=competitor.id,
+        details_json=json.dumps({
+            "scratch_snapshot": {
+                "competitor_type": "pro",
+                "results": None,
+                "heats": "not-a-list",
+                "relay_teams": {},
+            },
+            "scratch_post_state_sha256": "0" * 64,
+        }),
+    ))
+    db_session.flush()
+
+    assert find_undoable_scratch_tokens([competitor.id], "pro") == {}
+
+
+def test_batched_undo_tokens_are_read_only_and_avoid_n_plus_one(db_session):
+    from services.scratch_cascade import (
+        find_undoable_scratch_tokens,
+        find_undoable_scratches,
+        scratch_undo_token,
+    )
+
+    tournament = make_tournament(db_session, status="active")
+    event = make_event(db_session, tournament, "Undo Query Event", event_type="pro")
+    competitors = [
+        make_pro_competitor(
+            db_session,
+            tournament,
+            f"Scratched Pro {index}",
+            status="scratched",
+        )
+        for index in range(5)
+    ]
+    snapshots = []
+    entries = []
+    for index, competitor in enumerate(competitors, start=1):
+        result = make_event_result(db_session, event, competitor)
+        heat = make_heat(
+            db_session,
+            event,
+            heat_number=index,
+            competitors=[competitor.id],
+        )
+        snapshot = {
+            "competitor_type": "pro",
+            "results": [{"id": result.id}],
+            "heats": [{"heat_id": heat.id}],
+            "relay_teams": [],
+        }
+        snapshots.append(snapshot)
+        entries.append(_seed_scratch_audit(
+            db_session,
+            competitor,
+            "pro",
+            snapshot=snapshot,
+        ))
+    entries[0] = _seed_scratch_audit(
+        db_session,
+        competitors[0],
+        "pro",
+        snapshot=snapshots[0],
+    )
+    expected = {
+        competitor.id: scratch_undo_token(entry)
+        for competitor, entry in zip(competitors, entries)
+    }
+    db_session.flush()
+
+    def measure(competitor_ids):
+        db_session.expire_all()
+        statements = []
+
+        def capture_statement(_conn, _cursor, statement, _params, _context, _many):
+            statements.append(" ".join(statement.lower().split()))
+
+        sqlalchemy_event.listen(db.engine, "before_cursor_execute", capture_statement)
+        try:
+            tokens = find_undoable_scratch_tokens(competitor_ids, "pro")
+        finally:
+            sqlalchemy_event.remove(
+                db.engine,
+                "before_cursor_execute",
+                capture_statement,
+            )
+        return tokens, [
+            statement for statement in statements if statement.startswith("select")
+        ], statements
+
+    single_tokens, single_selects, _ = measure([competitors[0].id])
+    tokens, all_selects, statements = measure(
+        [competitor.id for competitor in competitors]
+    )
+
+    audit_selects = [
+        statement
+        for statement in all_selects
+        if " from audit_logs " in f" {statement} "
+    ]
+    assert single_tokens == {competitors[0].id: expected[competitors[0].id]}
+    assert tokens == expected
+    assert len(all_selects) == len(single_selects)
+    assert len(audit_selects) == 2
+    assert not any(
+        statement.startswith(("insert", "update", "delete"))
+        for statement in statements
+    )
+    assert find_undoable_scratches(expected, "pro") == set(expected)
+
+
+def test_undo_rejects_heat_scored_after_scratch(
+    admin_user,
+    db_session,
+):
+    from services.scratch_cascade import (
+        compute_scratch_effects,
+        execute_cascade,
+        reverse_cascade,
+    )
+
+    tournament = make_tournament(db_session, status="active")
+    scratched = make_pro_competitor(
+        db_session,
+        tournament,
+        "Scored Heat Undo",
+    )
+    survivor = make_pro_competitor(
+        db_session,
+        tournament,
+        "Scored Heat Survivor",
+    )
+    event = make_event(db_session, tournament, "Underhand", event_type="pro")
+    heat = make_heat(
+        db_session,
+        event,
+        competitors=[scratched.id, survivor.id],
+        stand_assignments={str(scratched.id): 1, str(survivor.id): 2},
+    )
+    make_event_result(db_session, event, scratched)
+    survivor_result = make_event_result(db_session, event, survivor)
+    db_session.flush()
+
+    scratch_result = execute_cascade(
+        scratched,
+        compute_scratch_effects(scratched, tournament),
+        judge_user_id=admin_user.id,
+        tournament=tournament,
+    )
+    db_session.flush()
+    assert heat.get_competitors() == [survivor.id]
+    assert heat.status == "pending"
+
+    heat.status = "completed"
+    survivor_result.status = "completed"
+    survivor_result.result_value = 30.0
+    db_session.flush()
+
+    undo_result = reverse_cascade(
+        scratched.id,
+        judge_user_id=admin_user.id,
+        tournament=tournament,
+        competitor_type="pro",
+        expected_undo_token=scratch_result["undo_token"],
+    )
+    db_session.flush()
+
+    assert undo_result["success"] is False
+    assert "changed" in undo_result["message"].lower()
+    assert scratched.status == "scratched"
+    assert heat.get_competitors() == [survivor.id]
+    assert heat.status == "completed"
+    assert survivor_result.status == "completed"
+    assert survivor_result.result_value == 30.0
+
+
+def test_undo_still_rejects_a_roster_change_after_scratch(
+    admin_user,
+    db_session,
+):
+    from services.scratch_cascade import (
+        compute_scratch_effects,
+        execute_cascade,
+        reverse_cascade,
+    )
+
+    tournament = make_tournament(db_session, status="active")
+    scratched = make_pro_competitor(db_session, tournament, "Moved Heat Undo")
+    survivor = make_pro_competitor(db_session, tournament, "Moved Heat Survivor")
+    event = make_event(db_session, tournament, "Standing Block", event_type="pro")
+    heat = make_heat(
+        db_session,
+        event,
+        competitors=[scratched.id, survivor.id],
+        stand_assignments={str(scratched.id): 1, str(survivor.id): 2},
+    )
+    make_event_result(db_session, event, scratched)
+    make_event_result(db_session, event, survivor)
+    db_session.flush()
+
+    scratch_result = execute_cascade(
+        scratched,
+        compute_scratch_effects(scratched, tournament),
+        judge_user_id=admin_user.id,
+        tournament=tournament,
+    )
+    db_session.flush()
+
+    heat.set_roster("pro", [survivor.id], {str(survivor.id): 3})
+    db_session.flush()
+
+    undo_result = reverse_cascade(
+        scratched.id,
+        judge_user_id=admin_user.id,
+        tournament=tournament,
+        competitor_type="pro",
+        expected_undo_token=scratch_result["undo_token"],
+    )
+    db_session.flush()
+
+    assert undo_result["success"] is False
+    assert "changed" in undo_result["message"].lower()
+    assert scratched.status == "scratched"
+    assert heat.get_competitors() == [survivor.id]
+    assert heat.get_stand_assignments() == {str(survivor.id): 3}
+
+
+def test_pro_dashboard_undo_form_submits_current_token(
+    auth_client,
+    db_session,
+):
+    from services.scratch_cascade import scratch_undo_token
+
+    tournament = make_tournament(db_session, status="active")
+    competitor = make_pro_competitor(
+        db_session,
+        tournament,
+        "Visible Pro Undo",
+        status="scratched",
+    )
+    entry = _seed_scratch_audit(db_session, competitor, "pro")
+    expected_token = scratch_undo_token(entry)
+
+    response = auth_client.get(f"/tournament/{tournament.id}/pro")
+
+    assert response.status_code == 200
+    assert _undo_form_token(response, competitor.id) == expected_token
+
+
+def test_pro_dashboard_hides_undo_after_post_scratch_state_changes(
+    auth_client,
+    db_session,
+):
+    tournament = make_tournament(db_session, status="active")
+    competitor = make_pro_competitor(
+        db_session,
+        tournament,
+        "Changed Pro Undo",
+        status="scratched",
+    )
+    _seed_scratch_audit(db_session, competitor, "pro")
+    competitor.partners = json.dumps({"changed": "after-scratch"})
+    db_session.flush()
+
+    response = auth_client.get(f"/tournament/{tournament.id}/pro")
+
+    assert response.status_code == 200
+    assert _undo_forms(response, competitor.id) == []
+
+
+def test_college_team_roster_undo_form_submits_current_token(
+    auth_client,
+    db_session,
+):
+    from services.scratch_cascade import scratch_undo_token
+
+    tournament = make_tournament(db_session, status="active")
+    team = make_team(db_session, tournament)
+    competitor = make_college_competitor(
+        db_session,
+        tournament,
+        team,
+        "Visible College Undo",
+        status="scratched",
+    )
+    entry = _seed_scratch_audit(db_session, competitor, "college")
+    expected_token = scratch_undo_token(entry)
+
+    response = auth_client.get(
+        f"/registration/{tournament.id}/college/team/{team.id}"
+    )
+
+    assert response.status_code == 200
+    assert _undo_form_token(response, competitor.id) == expected_token
+
+
+def test_college_team_roster_hides_undo_after_post_scratch_state_changes(
+    auth_client,
+    db_session,
+):
+    tournament = make_tournament(db_session, status="active")
+    team = make_team(db_session, tournament)
+    competitor = make_college_competitor(
+        db_session,
+        tournament,
+        team,
+        "Changed College Undo",
+        status="scratched",
+    )
+    _seed_scratch_audit(db_session, competitor, "college")
+    competitor.partners = json.dumps({"changed": "after-scratch"})
+    db_session.flush()
+
+    response = auth_client.get(
+        f"/registration/{tournament.id}/college/team/{team.id}"
+    )
+
+    assert response.status_code == 200
+    assert _undo_forms(response, competitor.id) == []
+
+
+def test_college_team_roster_hides_undo_from_registrar(app, db_session):
+    from models.user import User
+
+    tournament = make_tournament(db_session, status="active")
+    team = make_team(db_session, tournament)
+    competitor = make_college_competitor(
+        db_session,
+        tournament,
+        team,
+        "Registrar Cannot Undo",
+        status="scratched",
+    )
+    _seed_scratch_audit(db_session, competitor, "college")
+    registrar = User(username="undo_registrar", role="registrar")
+    registrar.set_password("testpass")
+    db_session.add(registrar)
+    db_session.flush()
+
+    registrar_client = app.test_client()
+    with registrar_client.session_transaction() as session:
+        session["_user_id"] = str(registrar.id)
+
+    response = registrar_client.get(
+        f"/registration/{tournament.id}/college/team/{team.id}"
+    )
+
+    assert response.status_code == 200
+    assert _undo_forms(response, competitor.id) == []

--- a/tests/test_route_smoke.py
+++ b/tests/test_route_smoke.py
@@ -4,33 +4,40 @@ from __future__ import annotations
 import os
 import re
 import shutil
-import uuid
 from pathlib import Path
 from urllib.parse import urlencode
 
 import pytest
 
-from app import create_app
+from tests.db_test_utils import create_test_app, drop_test_db
 
 
 def _discover_routes() -> list[dict[str, object]]:
     """Return a normalized route list from the app URL map."""
-    app = create_app()
-    routes: list[dict[str, object]] = []
-    for rule in sorted(app.url_map.iter_rules(), key=lambda r: (r.endpoint, r.rule)):
-        methods = sorted(m for m in rule.methods if m not in {"HEAD", "OPTIONS"})
-        if not methods:
-            continue
-        method = "GET" if "GET" in methods else "POST"
-        routes.append(
-            {
-                "endpoint": rule.endpoint,
-                "rule": rule.rule,
-                "method": method,
-                "methods": methods,
-            }
-        )
-    return routes
+    app, db_handle = create_test_app()
+    try:
+        routes: list[dict[str, object]] = []
+        for rule in sorted(app.url_map.iter_rules(), key=lambda r: (r.endpoint, r.rule)):
+            methods = sorted(m for m in rule.methods if m not in {"HEAD", "OPTIONS"})
+            if not methods:
+                continue
+            method = "GET" if "GET" in methods else "POST"
+            routes.append(
+                {
+                    "endpoint": rule.endpoint,
+                    "rule": rule.rule,
+                    "method": method,
+                    "methods": methods,
+                }
+            )
+        return routes
+    finally:
+        from database import db
+
+        with app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+        drop_test_db(db_handle)
 
 
 ROUTE_SPECS = _discover_routes()
@@ -39,7 +46,6 @@ _SOURCE_DB_ENV = os.environ.get("PROAM_ROUTE_SMOKE_SOURCE_DB", "").strip()
 SOURCE_DB = Path(_SOURCE_DB_ENV) if _SOURCE_DB_ENV else None
 if SOURCE_DB is not None and not SOURCE_DB.is_absolute():
     SOURCE_DB = PROJECT_ROOT / SOURCE_DB
-TMP_ROOT = PROJECT_ROOT / ".qa_tmp"
 
 
 def _seed_minimal_smoke_data(app):
@@ -133,15 +139,14 @@ def _seed_minimal_smoke_data(app):
 
 
 @pytest.fixture()
-def smoke_env(monkeypatch):
+def smoke_env(monkeypatch, tmp_path):
     """Return an app/client backed by an isolated migrated database.
 
     A source database is copied only when PROAM_ROUTE_SMOKE_SOURCE_DB is set
     explicitly (CI supplies its synthetic fixture). Local runs default to the
     same deterministic seed path instead of reading instance/proam.db.
     """
-    TMP_ROOT.mkdir(exist_ok=True)
-    temp_dir = TMP_ROOT / f"route-smoke-{uuid.uuid4().hex}"
+    temp_dir = tmp_path / "route-smoke"
     temp_dir.mkdir()
     db_copy = temp_dir / "proam-copy.db"
 
@@ -174,6 +179,8 @@ def smoke_env(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", "route-smoke-secret")
     monkeypatch.setenv("FLASK_ENV", "testing")
     monkeypatch.setenv("TESTING", "1")
+
+    from app import create_app
 
     app = create_app()
     app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)

--- a/tests/test_scratch_cascade.py
+++ b/tests/test_scratch_cascade.py
@@ -306,6 +306,94 @@ class TestHappyPathRelayTeam:
         )
 
 
+def test_projectable_legacy_relay_stays_undoable_after_scratch(app):
+    from database import db
+    from models.relay import RelayState
+    from services.proam_relay import ProAmRelay
+    from services.scratch_cascade import (
+        compute_scratch_effects,
+        execute_cascade,
+        reverse_cascade,
+    )
+
+    with app.app_context():
+        tournament = _seed_base(db)
+        competitor = _seed_pro(db, tournament, name="Legacy Relay Pro")
+        college_competitor = _seed_college(
+            db, tournament, name="Colliding College Relay",
+        )
+        assert competitor.id == college_competitor.id
+        relay_event = _seed_event(
+            db, tournament, name="Pro-Am Relay", event_type="pro",
+        )
+        relay_event.event_state = _make_relay_state([{
+            "team_number": 1,
+            "name": "Team 1",
+            "pro_members": [{
+                "id": competitor.id,
+                "name": competitor.name,
+                "gender": competitor.gender,
+            }],
+            "college_members": [{
+                "id": college_competitor.id,
+                "name": college_competitor.name,
+                "gender": college_competitor.gender,
+            }],
+            "events": {
+                event_key: {"result": None, "status": "pending"}
+                for event_key in ProAmRelay.RELAY_EVENTS
+            },
+            "total_time": None,
+        }])
+        db.session.commit()
+
+        relay_effect = next(
+            effect for effect in compute_scratch_effects(competitor, tournament)
+            if effect.effect_type == "relay_team"
+        )
+        assert relay_effect.metadata["source"] == "legacy"
+
+        scratched = execute_cascade(
+            competitor,
+            [relay_effect],
+            judge_user_id=1,
+            tournament=tournament,
+        )
+        db.session.commit()
+
+        scratched_state = json.loads(relay_event.event_state)
+        assert scratched_state["teams"][0]["pro_members"] == []
+        assert scratched_state["teams"][0]["college_members"] == [{
+            "id": college_competitor.id,
+            "name": college_competitor.name,
+            "gender": college_competitor.gender,
+        }]
+        assert RelayState.query.filter_by(event_id=relay_event.id).first() is None
+
+        undo = reverse_cascade(
+            competitor.id,
+            judge_user_id=1,
+            tournament=tournament,
+            competitor_type="pro",
+            expected_undo_token=scratched["undo_token"],
+        )
+        db.session.commit()
+
+        assert undo["success"] is True
+        restored_state = json.loads(relay_event.event_state)
+        assert restored_state["teams"][0]["pro_members"] == [{
+            "id": competitor.id,
+            "name": competitor.name,
+            "gender": competitor.gender,
+        }]
+        assert restored_state["teams"][0]["college_members"] == [{
+            "id": college_competitor.id,
+            "name": college_competitor.name,
+            "gender": college_competitor.gender,
+        }]
+        assert competitor.status == "active"
+
+
 def test_normalized_relay_membership_is_scratched_and_undone(app):
     from database import db
     from models.relay import RelayState, RelayTeam, RelayTeamMember
@@ -419,6 +507,79 @@ def test_normalized_relay_undo_preserves_a_later_reassignment(app):
         assert RelayTeamMember.query.filter_by(
             relay_team_id=replacement_team.id, uid=competitor.uid,
         ).first() is not None
+
+
+def test_normalized_relay_undo_rejects_a_redrawn_team(app):
+    from database import db
+    from models.relay import RelayState, RelayTeam, RelayTeamMember
+    from services.scratch_cascade import (
+        compute_scratch_effects,
+        execute_cascade,
+        reverse_cascade,
+    )
+
+    with app.app_context():
+        tournament = _seed_base(db)
+        competitor = _seed_pro(db, tournament, name="Redrawn Relay Pro")
+        relay_event = _seed_event(db, tournament, name="Pro-Am Relay", event_type="pro")
+        relay_state = RelayState(event_id=relay_event.id, status="drawn")
+        db.session.add(relay_state)
+        db.session.flush()
+        original_team = RelayTeam(
+            relay_state_id=relay_state.id,
+            team_number=1,
+            name="Original Team",
+        )
+        db.session.add(original_team)
+        db.session.flush()
+        original_team_id = original_team.id
+        db.session.add(RelayTeamMember(
+            relay_state_id=relay_state.id,
+            relay_team_id=original_team_id,
+            uid=competitor.uid,
+        ))
+        db.session.commit()
+
+        relay_effect = next(
+            effect for effect in compute_scratch_effects(competitor, tournament)
+            if effect.effect_type == "relay_team"
+        )
+        scratched = execute_cascade(
+            competitor,
+            [relay_effect],
+            judge_user_id=1,
+            tournament=tournament,
+        )
+        db.session.commit()
+
+        db.session.delete(original_team)
+        db.session.commit()
+        redrawn_team = RelayTeam(
+            id=original_team_id,
+            relay_state_id=relay_state.id,
+            team_number=1,
+            name="Redrawn Team",
+        )
+        db.session.add(redrawn_team)
+        db.session.commit()
+
+        undo = reverse_cascade(
+            competitor.id,
+            judge_user_id=1,
+            tournament=tournament,
+            competitor_type="pro",
+            expected_undo_token=scratched["undo_token"],
+        )
+        db.session.commit()
+
+        assert undo["success"] is False
+        assert "changed" in undo["message"].lower()
+        assert competitor.status == "scratched"
+        assert RelayTeamMember.query.filter_by(
+            relay_state_id=relay_state.id,
+            uid=competitor.uid,
+        ).first() is None
+        assert db.session.get(RelayTeam, original_team_id).name == "Redrawn Team"
 
 
 class TestHappyPathAllEffectTypes:

--- a/tests/test_smoke_test.py
+++ b/tests/test_smoke_test.py
@@ -1,0 +1,106 @@
+import pytest
+
+from scripts import smoke_test
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ({"status": "ok", "db": True, "migration_current": True,
+          "migration_head": "head", "migration_rev": "head"}, None),
+        ({"status": "degraded", "db": True, "migration_current": True},
+         "status is not ok"),
+        ({"status": "ok", "db": False, "migration_current": True},
+         "database is not healthy"),
+        ({"status": "ok", "db": True, "migration_current": False},
+         "migration is not current"),
+        ({"status": "ok", "db": True, "migration_current": True,
+          "migration_head": "new", "migration_rev": "old"},
+         "migration revision does not match head"),
+        ({"status": "ok", "db": True, "migration_current": True,
+          "migration_head": None, "migration_rev": None},
+         "migration head is missing"),
+        ([], "health response JSON is not an object"),
+    ],
+)
+def test_validate_health_payload(payload, expected_error):
+    assert smoke_test.validate_health_payload(payload) == expected_error
+
+
+def test_validate_health_payload_checks_expected_version_and_migration():
+    payload = {
+        "status": "ok",
+        "db": True,
+        "migration_current": True,
+        "migration_head": "abc123",
+        "migration_rev": "abc123",
+        "version": "2.14.16",
+        "git_commit": "a" * 40,
+    }
+
+    assert smoke_test.validate_health_payload(
+        payload,
+        expected_version="2.14.16",
+        expected_migration="abc123",
+        expected_commit="a" * 40,
+    ) is None
+    assert "version" in smoke_test.validate_health_payload(
+        payload, expected_version="2.14.17"
+    )
+    assert "migration" in smoke_test.validate_health_payload(
+        payload, expected_migration="different"
+    )
+    assert "commit" in smoke_test.validate_health_payload(
+        payload, expected_commit="b" * 40
+    ).lower()
+
+
+def test_same_origin_allows_paths_but_rejects_host_scheme_and_port_changes():
+    base = "https://example.test"
+
+    assert smoke_test.same_origin(base, "https://example.test/portal/")
+    assert smoke_test.same_origin(base, "/portal/spectator/2")
+    assert not smoke_test.same_origin(base, "http://example.test/portal/")
+    assert not smoke_test.same_origin(base, "https://other.test/portal/")
+    assert not smoke_test.same_origin(base, "https://example.test:444/portal/")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://example.test/portal/spectator/2?view=desktop", 2),
+        ("https://example.test/portal/spectator/991", 991),
+        ("https://example.test/portal/", None),
+        ("https://example.test/portal/spectator/nope", None),
+    ],
+)
+def test_extract_spectator_tournament_id(url, expected):
+    assert smoke_test.extract_spectator_tournament_id(url) == expected
+
+
+def test_validate_public_standings_requires_the_endpoint_contract():
+    valid = (
+        '{"tournament":{"id":2},"teams":[],"bull":[],"belle":[],'
+        '"pro_earnings":[]}'
+    )
+    assert smoke_test.validate_public_standings(
+        valid,
+        "application/json",
+        2,
+    ) is None
+    assert smoke_test.validate_public_standings(
+        "<html>login</html>",
+        "text/html",
+        2,
+    ) == "response is not JSON"
+    assert smoke_test.validate_public_standings(
+        '{"error": "database unavailable"}',
+        "application/json",
+        2,
+    ) == "response contains an error"
+    assert "teams" in smoke_test.validate_public_standings(
+        '{"tournament":{"id":2}}', "application/json", 2
+    )
+    assert "tournament" in smoke_test.validate_public_standings(
+        valid, "application/json", 3
+    )


### PR DESCRIPTION
## Summary
- add commit-pinned, read-only production smoke checks and release gates
- make scratch undo tokenized, state-aware, relay-safe, and batch-efficient
- resolve ambiguous college heat-entry matching and PostgreSQL report-cache behavior
- add the unapproved 2027 owner decision packet without overstating certification
- make collection-time default database pollution fail the test session

## Validation
- complete isolated unit suite exited 0 across 4,467 collected tests; documented skip set unchanged
- production-shaped normal mirror lane exited 0 at its standing 205 passed, 6 skipped, 2 expected failures
- 10 scratch roster-token tests passed on disposable PostgreSQL
- focused legacy and normalized relay undo tests passed on SQLite and disposable PostgreSQL
- Ruff, diff check, Python 3.10 grammar, and app compilation passed
- no run-owned PostgreSQL clones or checkout-local test database remained

## Open gates
- owner decision packet is intentionally NOT APPROVED
- authenticated production judge, physical device/radio, and cross-device rehearsals remain required
- hosted encrypted backup and separately held decrypt/restore rehearsal remain blocked on approved key custody and missing backup secrets