### PR TITLE
Gate Railway deploys on /health

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -7,6 +7,8 @@
 # Phase 1 deploy incident notes).  Renaming to preDeployCommand activates the
 # release-phase pipeline so `flask db upgrade` actually runs on every deploy.
 preDeployCommand = "flask db upgrade"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
 
 # ---------------------------------------------------------------------------
 # STRATHMARK environment variables (set in the Railway dashboard, not here)


### PR DESCRIPTION
## Summary
- require Railway to receive HTTP 200 from /health before promoting a deployment
- retain the platform's five-minute startup window

## Verification
- parsed railway.toml and asserted the deploy fields
- 16 focused health and smoke tests passed
- git diff --check passed